### PR TITLE
Add dynamic placeholders to blog articles

### DIFF
--- a/backend/app/services/placeholder_service.ts
+++ b/backend/app/services/placeholder_service.ts
@@ -217,9 +217,9 @@ export default class PlaceholderService {
         example: '%DATA_SINCE_DATE_125%',
       },
       {
-        name: 'OFFICIAL_WEBSITE',
-        description: 'Server official website (domain only)',
-        example: '%OFFICIAL_WEBSITE_125%',
+        name: 'ADDRESS',
+        description: 'Server address',
+        example: '%ADDRESS_125%',
       },
     ]
   }

--- a/backend/app/services/placeholder_service.ts
+++ b/backend/app/services/placeholder_service.ts
@@ -1,0 +1,262 @@
+import Server from '#models/server'
+import ServerStat from '#models/server_stat'
+import Database from '@adonisjs/lucid/services/db'
+import { DateTime } from 'luxon'
+
+/**
+ * Service to handle placeholder replacement in blog posts
+ * Format: %PLACEHOLDER_NAME_SERVER_ID%
+ *
+ * Available placeholders:
+ * - PLAYER_COUNT_REALTIME: Current player count
+ * - PLAYER_COUNT_PEAK_HIGH: Highest player count recorded
+ * - PLAYER_COUNT_PEAK_LOW: Lowest player count recorded
+ * - PLAYER_COUNT_AVERAGE: Average player count
+ * - PLAYER_COUNT_MEDIAN: Median player count
+ * - SERVER_VERSION: Server version
+ * - DATA_SINCE_DATE: Date since data collection started
+ * - OFFICIAL_WEBSITE: Server official website (domain only)
+ */
+export default class PlaceholderService {
+  /**
+   * Regular expression to match placeholders
+   * Example: %PLAYER_COUNT_REALTIME_125%
+   */
+  private static readonly PLACEHOLDER_REGEX = /%([A-Z_]+)_(\d+)%/g
+
+  /**
+   * Replace all placeholders in content with actual values
+   */
+  static async replacePlaceholders(content: string): Promise<string> {
+    const matches = Array.from(content.matchAll(this.PLACEHOLDER_REGEX))
+
+    if (matches.length === 0) {
+      return content
+    }
+
+    // Group placeholders by server ID to minimize database queries
+    const serverIds = [...new Set(matches.map((match) => Number.parseInt(match[2])))]
+
+    // Preload all server data
+    const serversData = await this.preloadServerData(serverIds)
+
+    // Replace each placeholder
+    let result = content
+    for (const match of matches) {
+      const [fullMatch, placeholderName, serverId] = match
+      const serverIdNum = Number.parseInt(serverId)
+
+      const value = await this.getPlaceholderValue(
+        placeholderName,
+        serverIdNum,
+        serversData.get(serverIdNum)
+      )
+
+      result = result.replace(fullMatch, value)
+    }
+
+    return result
+  }
+
+  /**
+   * Preload server data for multiple servers at once
+   */
+  private static async preloadServerData(
+    serverIds: number[]
+  ): Promise<Map<number, ServerData>> {
+    const serversData = new Map<number, ServerData>()
+
+    for (const serverId of serverIds) {
+      try {
+        const server = await Server.find(serverId)
+        if (!server) {
+          serversData.set(serverId, { exists: false })
+          continue
+        }
+
+        // Get latest stat
+        const latestStat = await ServerStat.query()
+          .where('serverId', serverId)
+          .orderBy('createdAt', 'desc')
+          .first()
+
+        // Get first stat (for data since date)
+        const firstStat = await ServerStat.query()
+          .where('serverId', serverId)
+          .orderBy('createdAt', 'asc')
+          .first()
+
+        // Get peak high
+        const peakHigh = await ServerStat.query()
+          .where('serverId', serverId)
+          .orderBy('playerCount', 'desc')
+          .first()
+
+        // Get peak low (excluding 0 values)
+        const peakLow = await ServerStat.query()
+          .where('serverId', serverId)
+          .where('playerCount', '>', 0)
+          .orderBy('playerCount', 'asc')
+          .first()
+
+        // Get average and median
+        const statsQuery = await Database.rawQuery(
+          `
+          SELECT
+            AVG(player_count)::int as avg_players,
+            PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY player_count)::int as median_players
+          FROM server_stats
+          WHERE server_id = ?
+        `,
+          [serverId]
+        )
+
+        const stats = statsQuery.rows[0]
+
+        serversData.set(serverId, {
+          exists: true,
+          server,
+          latestStat,
+          firstStat,
+          peakHigh,
+          peakLow,
+          average: stats?.avg_players || 0,
+          median: stats?.median_players || 0,
+        })
+      } catch (error) {
+        serversData.set(serverId, { exists: false })
+      }
+    }
+
+    return serversData
+  }
+
+  /**
+   * Get the value for a specific placeholder
+   */
+  private static async getPlaceholderValue(
+    placeholderName: string,
+    serverId: number,
+    data?: ServerData
+  ): Promise<string> {
+    if (!data || !data.exists) {
+      return `[Server ${serverId} not found]`
+    }
+
+    switch (placeholderName) {
+      case 'PLAYER_COUNT_REALTIME':
+        return String(data.latestStat?.playerCount ?? 0)
+
+      case 'PLAYER_COUNT_PEAK_HIGH':
+        return String(data.peakHigh?.playerCount ?? 0)
+
+      case 'PLAYER_COUNT_PEAK_LOW':
+        return String(data.peakLow?.playerCount ?? 0)
+
+      case 'PLAYER_COUNT_AVERAGE':
+        return String(data.average)
+
+      case 'PLAYER_COUNT_MEDIAN':
+        return String(data.median)
+
+      case 'SERVER_VERSION':
+        return data.server.version || 'Unknown'
+
+      case 'DATA_SINCE_DATE':
+        if (data.firstStat) {
+          return data.firstStat.createdAt.toFormat('dd/MM/yyyy')
+        }
+        return 'N/A'
+
+      case 'OFFICIAL_WEBSITE':
+        if (!data.server.websiteUrl) {
+          return 'N/A'
+        }
+        try {
+          const url = new URL(data.server.websiteUrl)
+          // Extract main domain (e.g., "example.com" from "subdomain.example.com")
+          const parts = url.hostname.split('.')
+          if (parts.length >= 2) {
+            return `${parts[parts.length - 2]}.${parts[parts.length - 1]}`
+          }
+          return url.hostname
+        } catch {
+          return data.server.websiteUrl
+        }
+
+      default:
+        return `[Unknown placeholder: ${placeholderName}]`
+    }
+  }
+
+  /**
+   * Get available placeholder types with descriptions
+   */
+  static getAvailablePlaceholders(): PlaceholderInfo[] {
+    return [
+      {
+        name: 'PLAYER_COUNT_REALTIME',
+        description: 'Current number of online players',
+        example: '%PLAYER_COUNT_REALTIME_125%',
+      },
+      {
+        name: 'PLAYER_COUNT_PEAK_HIGH',
+        description: 'Highest number of players ever recorded',
+        example: '%PLAYER_COUNT_PEAK_HIGH_125%',
+      },
+      {
+        name: 'PLAYER_COUNT_PEAK_LOW',
+        description: 'Lowest number of players recorded (excluding 0)',
+        example: '%PLAYER_COUNT_PEAK_LOW_125%',
+      },
+      {
+        name: 'PLAYER_COUNT_AVERAGE',
+        description: 'Average number of players',
+        example: '%PLAYER_COUNT_AVERAGE_125%',
+      },
+      {
+        name: 'PLAYER_COUNT_MEDIAN',
+        description: 'Median number of players',
+        example: '%PLAYER_COUNT_MEDIAN_125%',
+      },
+      {
+        name: 'SERVER_VERSION',
+        description: 'Minecraft server version',
+        example: '%SERVER_VERSION_125%',
+      },
+      {
+        name: 'DATA_SINCE_DATE',
+        description: 'Date when data collection started',
+        example: '%DATA_SINCE_DATE_125%',
+      },
+      {
+        name: 'OFFICIAL_WEBSITE',
+        description: 'Server official website (domain only)',
+        example: '%OFFICIAL_WEBSITE_125%',
+      },
+    ]
+  }
+}
+
+/**
+ * Server data structure for placeholder replacement
+ */
+interface ServerData {
+  exists: boolean
+  server?: Server
+  latestStat?: ServerStat
+  firstStat?: ServerStat
+  peakHigh?: ServerStat
+  peakLow?: ServerStat
+  average?: number
+  median?: number
+}
+
+/**
+ * Placeholder information structure
+ */
+interface PlaceholderInfo {
+  name: string
+  description: string
+  example: string
+}

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -103,6 +103,11 @@ router
       .get('posts/:slug', '#controllers/posts_controller.show')
       .use(throttleLight('posts.show', 50))
 
+    // Blog - Placeholders (public)
+    router
+      .get('posts/placeholders/list', '#controllers/posts_controller.getPlaceholders')
+      .use(throttleLight('posts.placeholders.list', 20))
+
     // Blog - Posts management (writers and admins via policy)
     router
       .group(() => {
@@ -124,6 +129,11 @@ router
         router
           .post('posts/:id/unpublish', '#controllers/posts_controller.unpublish')
           .use(throttleLight('admin.posts.unpublish', 20))
+
+        // Placeholders preview (writers and admins)
+        router
+          .post('posts/placeholders/preview', '#controllers/posts_controller.previewPlaceholder')
+          .use(throttleLight('admin.posts.placeholders.preview', 20))
 
         // User management (admin only via policy)
         router

--- a/frontend/src/components/blog/placeholder-picker.tsx
+++ b/frontend/src/components/blog/placeholder-picker.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { getPlaceholders, PlaceholderInfo } from "@/http/post";
+import { BookText, Copy, Info, X } from "lucide-react";
+import { useEffect, useState } from "react";
+
+interface PlaceholderPickerProps {
+  onInsert: (placeholder: string) => void;
+}
+
+export function PlaceholderPicker({ onInsert }: PlaceholderPickerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [placeholders, setPlaceholders] = useState<PlaceholderInfo[]>([]);
+  const [serverId, setServerId] = useState("");
+  const [selectedPlaceholder, setSelectedPlaceholder] = useState<string | null>(null);
+  const [copiedPlaceholder, setCopiedPlaceholder] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadPlaceholders = async () => {
+      try {
+        const data = await getPlaceholders();
+        setPlaceholders(data);
+      } catch (error) {
+        console.error("Failed to load placeholders:", error);
+      }
+    };
+
+    if (isOpen) {
+      loadPlaceholders();
+    }
+  }, [isOpen]);
+
+  const handleInsert = (placeholderName: string) => {
+    if (!serverId || isNaN(Number(serverId))) {
+      alert("Please enter a valid server ID");
+      return;
+    }
+
+    const placeholder = `%${placeholderName}_${serverId}%`;
+    onInsert(placeholder);
+    setIsOpen(false);
+    setServerId("");
+    setSelectedPlaceholder(null);
+  };
+
+  const handleCopy = (placeholderName: string) => {
+    if (!serverId || isNaN(Number(serverId))) {
+      alert("Please enter a valid server ID");
+      return;
+    }
+
+    const placeholder = `%${placeholderName}_${serverId}%`;
+    navigator.clipboard.writeText(placeholder);
+    setCopiedPlaceholder(placeholderName);
+    setTimeout(() => setCopiedPlaceholder(null), 2000);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="p-2 rounded hover:bg-gray-200 dark:hover:bg-stats-blue-800"
+        title="Insert Placeholder"
+      >
+        <BookText className="w-4 h-4" />
+      </button>
+
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="bg-white dark:bg-stats-blue-950 rounded-lg border border-gray-300 dark:border-stats-blue-700 max-w-3xl w-full max-h-[80vh] overflow-hidden flex flex-col">
+            {/* Header */}
+            <div className="flex items-center justify-between p-4 border-b border-gray-300 dark:border-stats-blue-700">
+              <h2 className="text-xl font-bold text-gray-900 dark:text-white">Insert Placeholder</h2>
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="p-2 rounded hover:bg-gray-200 dark:hover:bg-stats-blue-800 text-gray-600 dark:text-slate-400"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            {/* Server ID Input */}
+            <div className="p-4 border-b border-gray-300 dark:border-stats-blue-700 bg-gray-50 dark:bg-stats-blue-900/30">
+              <label className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
+                Server ID
+              </label>
+              <input
+                type="number"
+                value={serverId}
+                onChange={(e) => setServerId(e.target.value)}
+                placeholder="Enter server ID (e.g., 125)"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-stats-blue-700 rounded-lg bg-white dark:bg-stats-blue-950 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-stats-blue-500"
+              />
+              <p className="mt-2 text-xs text-gray-600 dark:text-slate-400 flex items-start gap-1">
+                <Info className="w-3 h-3 mt-0.5 flex-shrink-0" />
+                <span>
+                  Enter the ID of the server you want to reference. You can find server IDs in the URL when
+                  viewing a server page (e.g., /server/125).
+                </span>
+              </p>
+            </div>
+
+            {/* Placeholders List */}
+            <div className="flex-1 overflow-y-auto p-4">
+              <div className="space-y-3">
+                {placeholders.map((placeholder) => {
+                  const isSelected = selectedPlaceholder === placeholder.name;
+                  const isCopied = copiedPlaceholder === placeholder.name;
+
+                  return (
+                    <div
+                      key={placeholder.name}
+                      className={`p-4 rounded-lg border transition-all ${
+                        isSelected
+                          ? "border-stats-blue-500 bg-stats-blue-50 dark:bg-stats-blue-900/30"
+                          : "border-gray-200 dark:border-stats-blue-800 bg-gray-50 dark:bg-stats-blue-900/20"
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-1">
+                            <h3 className="font-mono text-sm font-bold text-stats-blue-600 dark:text-stats-blue-400">
+                              {placeholder.name}
+                            </h3>
+                          </div>
+                          <p className="text-sm text-gray-600 dark:text-slate-400 mb-2">
+                            {placeholder.description}
+                          </p>
+                          <code className="text-xs bg-gray-200 dark:bg-stats-blue-800 px-2 py-1 rounded text-gray-800 dark:text-slate-200">
+                            {serverId
+                              ? `%${placeholder.name}_${serverId}%`
+                              : placeholder.example}
+                          </code>
+                        </div>
+                        <div className="flex gap-2">
+                          <button
+                            type="button"
+                            onClick={() => handleCopy(placeholder.name)}
+                            disabled={!serverId}
+                            className={`px-3 py-2 rounded text-sm font-medium transition-colors ${
+                              !serverId
+                                ? "bg-gray-200 dark:bg-stats-blue-800 text-gray-400 dark:text-slate-600 cursor-not-allowed"
+                                : isCopied
+                                  ? "bg-green-600 text-white"
+                                  : "bg-gray-300 dark:bg-stats-blue-700 text-gray-800 dark:text-white hover:bg-gray-400 dark:hover:bg-stats-blue-600"
+                            }`}
+                            title={!serverId ? "Enter a server ID first" : "Copy to clipboard"}
+                          >
+                            <Copy className="w-4 h-4" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleInsert(placeholder.name)}
+                            disabled={!serverId}
+                            className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
+                              !serverId
+                                ? "bg-gray-300 dark:bg-stats-blue-800 text-gray-400 dark:text-slate-600 cursor-not-allowed"
+                                : "bg-stats-blue-600 text-white hover:bg-stats-blue-700"
+                            }`}
+                            title={!serverId ? "Enter a server ID first" : "Insert into editor"}
+                          >
+                            Insert
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Footer */}
+            <div className="p-4 border-t border-gray-300 dark:border-stats-blue-700 bg-gray-50 dark:bg-stats-blue-900/30">
+              <p className="text-xs text-gray-600 dark:text-slate-400">
+                <strong>How it works:</strong> Placeholders are replaced with real-time server data when the
+                article is displayed. The format is{" "}
+                <code className="bg-gray-200 dark:bg-stats-blue-800 px-1 py-0.5 rounded">
+                  %PLACEHOLDER_NAME_SERVER_ID%
+                </code>
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/blog/tiptap-editor.tsx
+++ b/frontend/src/components/blog/tiptap-editor.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect } from "react";
 import { Markdown } from "tiptap-markdown";
+import { PlaceholderPicker } from "./placeholder-picker";
 
 interface TiptapEditorProps {
   content: string;
@@ -144,6 +145,14 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
 
     editor.chain().focus().extendMarkRange("link").setLink({ href: url }).run();
   }, [editor]);
+
+  const insertPlaceholder = useCallback(
+    (placeholder: string) => {
+      if (!editor) return;
+      editor.chain().focus().insertContent(placeholder).run();
+    },
+    [editor]
+  );
 
   if (!editor) {
     return null;
@@ -278,6 +287,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
         >
           <ImageIcon className="w-4 h-4" />
         </button>
+        <PlaceholderPicker onInsert={insertPlaceholder} />
         <div className="w-px bg-gray-300 dark:bg-stats-blue-700 mx-1" />
         <button
           type="button"

--- a/frontend/src/http/post.ts
+++ b/frontend/src/http/post.ts
@@ -168,3 +168,54 @@ export const uploadImage = async (file: File, token: string) => {
 
   return response.json() as Promise<{ url: string }>
 }
+
+// Placeholders
+
+export const getPlaceholders = async () => {
+  const response = await fetch(`${getBaseUrl()}/posts/placeholders/list`, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    cache: 'no-store',
+  })
+
+  if (!response.ok) {
+    const errorMessage = await getErrorMessage(response)
+    throw new Error(errorMessage)
+  }
+
+  return response.json() as Promise<PlaceholderInfo[]>
+}
+
+export const previewPlaceholder = async (
+  placeholderName: string,
+  serverId: number,
+  token: string
+) => {
+  const response = await fetch(`${getBaseUrl()}/admin/posts/placeholders/preview`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ placeholderName, serverId }),
+  })
+
+  if (!response.ok) {
+    const errorMessage = await getErrorMessage(response)
+    throw new Error(errorMessage)
+  }
+
+  return response.json() as Promise<{
+    placeholder: string
+    value: string
+    serverId: number
+    placeholderName: string
+  }>
+}
+
+export interface PlaceholderInfo {
+  name: string
+  description: string
+  example: string
+}


### PR DESCRIPTION
Implemented a comprehensive placeholder system that allows blog authors to insert dynamic server statistics into their articles. The placeholders are automatically replaced with real-time server data when the article is displayed.

Backend changes:
- Created PlaceholderService to handle placeholder parsing and replacement
- Added support for 8 placeholder types: PLAYER_COUNT_REALTIME, PLAYER_COUNT_PEAK_HIGH, PLAYER_COUNT_PEAK_LOW, PLAYER_COUNT_AVERAGE, PLAYER_COUNT_MEDIAN, SERVER_VERSION, DATA_SINCE_DATE, OFFICIAL_WEBSITE
- Added POST /api/v1/posts/placeholders/list endpoint to get available placeholders
- Added POST /api/v1/admin/posts/placeholders/preview endpoint to preview placeholder values
- Modified PostsController.show() to replace placeholders before returning post content
- Optimized database queries by preloading server data for multiple placeholders at once

Frontend changes:
- Created PlaceholderPicker component with modal UI for selecting and inserting placeholders
- Integrated PlaceholderPicker into TipTap editor toolbar
- Added HTTP client functions for fetching placeholders and previewing values
- Added visual feedback (copy button, server ID validation) in the picker UI

Placeholder format: %PLACEHOLDER_NAME_SERVER_ID%
Example: %PLAYER_COUNT_REALTIME_125%