### PR TITLE
Enhance Grafana provisioning and optimize server stats handling

### DIFF
--- a/backend/app/controllers/categories_controller.ts
+++ b/backend/app/controllers/categories_controller.ts
@@ -1,11 +1,16 @@
 import Category from '#models/category'
 import CategoryPolicy from '#policies/category_policy'
+import CacheService from '#services/cache_service'
 import { CreateCategoryValidator } from '#validators/category'
 import type { HttpContext } from '@adonisjs/core/http'
 
+const CATEGORIES_CACHE_KEY = 'categories:all'
+
 export default class CategoriesController {
   async index({ response }: HttpContext) {
-    const categories = await Category.all()
+    const categories = await CacheService.cacheOrFetch(CATEGORIES_CACHE_KEY, 3600, () =>
+      Category.all()
+    )
     return response.ok(categories)
   }
 
@@ -15,6 +20,7 @@ export default class CategoriesController {
       return response.forbidden({ message: 'Unauthorized' })
     }
     const category = await Category.create(data)
+    await CacheService.invalidate(CATEGORIES_CACHE_KEY)
     return response.ok(category)
   }
 
@@ -25,6 +31,7 @@ export default class CategoriesController {
       return response.forbidden({ message: 'Unauthorized' })
     }
     await category.delete()
+    await CacheService.invalidate(CATEGORIES_CACHE_KEY)
     return response.ok(category)
   }
 
@@ -36,6 +43,7 @@ export default class CategoriesController {
     }
     const category = await Category.findOrFail(id)
     await category.merge(validatedData).save()
+    await CacheService.invalidate(CATEGORIES_CACHE_KEY)
     return response.ok(category)
   }
 }

--- a/backend/app/controllers/languages_controller.ts
+++ b/backend/app/controllers/languages_controller.ts
@@ -1,9 +1,10 @@
 import Language from '#models/language'
+import CacheService from '#services/cache_service'
 import { type HttpContext } from '@adonisjs/core/http'
 
 export default class LanguagesController {
   async index({ response }: HttpContext) {
-    const languages = await Language.all()
+    const languages = await CacheService.cacheOrFetch('languages:all', 3600, () => Language.all())
     return response.json(languages)
   }
 }

--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -5,6 +5,7 @@ import { CreateServerValidator, UpdateServerValidator } from '#validators/server
 import type { HttpContext } from '@adonisjs/core/http'
 import { isPingPossible } from '../../minecraft-ping/minecraft_ping.js'
 import Server from '../models/server.js'
+import CacheService from '#services/cache_service'
 import StatsService from '#services/stat_service'
 import Language from '#models/language'
 
@@ -139,12 +140,45 @@ export default class ServersController {
     return response.noContent()
   }
 
-  async paginate({ request }: HttpContext) {
+  async paginate(ctx: HttpContext) {
+    const { request } = ctx
     const page = request.input('page', 1)
     const limit = request.input('limit', 10)
     const categoryIds = request.input('categoryIds')
     const languageIds = request.input('languageIds')
     const search = request.input('search', '')
+
+    const cacheKey = CacheService.hashParams('paginate', {
+      page,
+      limit,
+      categoryIds,
+      languageIds,
+      search,
+    })
+
+    const nocache = request.input('nocache') === '1'
+    const bypass =
+      nocache && (process.env.NODE_ENV !== 'production' || ctx.auth?.user?.role === 'admin')
+
+    return CacheService.cacheOrFetch(
+      cacheKey,
+      60,
+      async () => {
+        const result = await this.runPaginateQuery({ page, limit, categoryIds, languageIds, search })
+        return result
+      },
+      { bypass }
+    )
+  }
+
+  private async runPaginateQuery(opts: {
+    page: number
+    limit: number
+    categoryIds?: string
+    languageIds?: string
+    search: string
+  }) {
+    const { page, limit, categoryIds, languageIds, search } = opts
 
     let query = Server.query()
       .preload('user')

--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -191,22 +191,44 @@ export default class ServersController {
 
     const servers = await query.paginate(page, limit)
 
-    const serversWithStats = await Promise.all(
-      servers.map(async (server) => {
-        const lastStat = await this.getActualStats(server, 1)
-        const lastDayStats = await StatsService.getStats({
-          server_id: server.id,
-          fromDate: Date.now() - 24 * 60 * 60 * 1000,
-          toDate: Date.now(),
-        })
-        return {
-          server,
-          stats: [...lastStat, ...lastDayStats],
-          categories: server.categories,
-          growthStat: server.growthStat,
-        }
-      })
-    )
+    const now = Date.now()
+    const fromDate = now - 24 * 60 * 60 * 1000
+
+    const serverIds = servers.map((s) => s.id)
+    const statsByServer = await StatsService.getStatsBatch({
+      serverIds,
+      fromDate,
+      toDate: now,
+      interval: '1 hour',
+    })
+
+    const serversWithStats = servers.map((server) => {
+      const bucketed = (statsByServer.get(server.id) ?? []).map((row) => ({
+        serverId: server.id,
+        createdAt: row.created_at,
+        playerCount: row.player_count,
+        maxCount: row.max_count,
+      }))
+
+      const lastStat =
+        server.lastStatsAt !== null && server.lastPlayerCount !== null
+          ? [
+              {
+                serverId: server.id,
+                createdAt: server.lastStatsAt,
+                playerCount: server.lastPlayerCount,
+                maxCount: server.lastMaxCount,
+              },
+            ]
+          : []
+
+      return {
+        server,
+        stats: [...lastStat, ...bucketed],
+        categories: server.categories,
+        growthStat: server.growthStat,
+      }
+    })
 
     return {
       data: serversWithStats,

--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -10,18 +10,21 @@ import Language from '#models/language'
 
 export default class ServersController {
   async index() {
-    const servers = await Server.query()
-      .preload('user')
-      .preload('categories')
-      .preload('growthStat')
-      .preload('languages')
-    const serversWithStats = await Promise.all(
-      servers.map(async (server) => {
-        const stats = await this.getActualStats(server)
-        return { server, stats, categories: server.categories, growthStat: server.growthStat }
-      })
+    // Endpoint léger : pas de préloads (user/categories/growthStat/languages), pas de stats par serveur.
+    // Consommé par le sitemap, le ServerSelect et le compteur "Monitored servers" — tous se contentent du
+    // {id, name, updatedAt} de chaque serveur. Forme `[{ server }]` conservée pour compat frontend.
+    const servers = await Server.query().select(
+      'id',
+      'name',
+      'address',
+      'port',
+      'image_url',
+      'last_player_count',
+      'last_stats_at',
+      'created_at',
+      'updated_at'
     )
-    return serversWithStats
+    return servers.map((server) => ({ server }))
   }
 
   async store({ request, auth, response }: HttpContext) {

--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -237,7 +237,12 @@ export default class ServersController {
     const now = Date.now()
     const fromDate = now - 24 * 60 * 60 * 1000
 
-    const serverIds = servers.map((s) => s.id)
+    // Important : Lucid SimplePaginator étend Array, donc `servers.map(...)` retourne
+    // une *nouvelle SimplePaginator* (via Symbol.species), pas un Array standard.
+    // Ce paginator a un `.toJSON()` qui réécrit la réponse en `{meta, data}` →
+    // double nesting côté HTTP. On extrait `servers.all()` (le rows[] réel) avant map.
+    const serverRows = servers.all()
+    const serverIds = serverRows.map((s) => s.id)
     const statsByServer = await StatsService.getStatsBatch({
       serverIds,
       fromDate,
@@ -245,7 +250,7 @@ export default class ServersController {
       interval: '1 hour',
     })
 
-    const serversWithStats = servers.map((server) => {
+    const serversWithStats = serverRows.map((server) => {
       const bucketed = (statsByServer.get(server.id) ?? []).map((row) => ({
         serverId: server.id,
         createdAt: row.created_at,

--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -164,7 +164,13 @@ export default class ServersController {
       cacheKey,
       60,
       async () => {
-        const result = await this.runPaginateQuery({ page, limit, categoryIds, languageIds, search })
+        const result = await this.runPaginateQuery({
+          page,
+          limit,
+          categoryIds,
+          languageIds,
+          search,
+        })
         return result
       },
       { bypass }

--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -186,12 +186,23 @@ export default class ServersController {
   }) {
     const { page, limit, categoryIds, languageIds, search } = opts
 
+    // Ordering : on ne classe par `last_player_count` que si le dernier ping
+    // réussi est récent (< 30 min, soit ~3 cycles de 10 min). Sinon le serveur
+    // est traité comme "stale" et descend en bas, peu importe son ancien count.
+    // Évite qu'un serveur down depuis des jours reste top juste parce qu'il
+    // avait 500 joueurs avant de tomber.
     let query = Server.query()
       .preload('user')
       .preload('categories')
       .preload('growthStat')
       .preload('languages')
-      .orderByRaw('COALESCE(last_player_count, -1) DESC')
+      .orderByRaw(
+        `CASE
+          WHEN last_stats_at > now() - interval '30 minutes'
+            THEN COALESCE(last_player_count, -1)
+          ELSE -1
+         END DESC`
+      )
       .orderBy('last_stats_at', 'desc')
 
     if (search) {

--- a/backend/app/controllers/stats_controller.ts
+++ b/backend/app/controllers/stats_controller.ts
@@ -1,17 +1,37 @@
+import CacheService from '#services/cache_service'
 import StatsService from '#services/stat_service'
 import { StatValidator } from '#validators/stat'
 import { GlobalStatValidator } from '#validators/global_stat'
 import type { HttpContext } from '@adonisjs/core/http'
 
+function bypassFlag(ctx: HttpContext): boolean {
+  if (ctx.request.input('nocache') !== '1') return false
+  if (process.env.NODE_ENV !== 'production') return true
+  return ctx.auth?.user?.role === 'admin'
+}
+
 export default class StatsController {
-  async index({ request, response }: HttpContext) {
+  async index(ctx: HttpContext) {
+    const { request, response } = ctx
     try {
       const validatedData = await StatValidator.validate({
         ...request.params(),
         ...request.qs(),
       })
 
-      const results = await StatsService.getStats(validatedData)
+      // Cas exactTime non cacheable (point-in-time, rarement réutilisé).
+      if (validatedData.exactTime) {
+        const results = await StatsService.getStats(validatedData)
+        return response.status(200).json(results)
+      }
+
+      const key = `stats:${validatedData.server_id}:${validatedData.fromDate ?? 0}:${validatedData.toDate ?? 0}:${validatedData.interval ?? 'raw'}`
+      const results = await CacheService.cacheOrFetch(
+        key,
+        300,
+        () => StatsService.getStats(validatedData),
+        { bypass: bypassFlag(ctx) }
+      )
       return response.status(200).json(results)
     } catch (error) {
       console.error(error)
@@ -21,10 +41,17 @@ export default class StatsController {
     }
   }
 
-  async globalStats({ request, response }: HttpContext) {
+  async globalStats(ctx: HttpContext) {
+    const { request, response } = ctx
     try {
       const validatedData = await GlobalStatValidator.validate(request.qs())
-      const results = await StatsService.getGlobalStats(validatedData)
+      const key = CacheService.hashParams('global-stats', validatedData)
+      const results = await CacheService.cacheOrFetch(
+        key,
+        300,
+        () => StatsService.getGlobalStats(validatedData),
+        { bypass: bypassFlag(ctx) }
+      )
       return response.status(200).json(results)
     } catch (error) {
       console.error(error)

--- a/backend/app/middleware/cache_headers_middleware.ts
+++ b/backend/app/middleware/cache_headers_middleware.ts
@@ -1,0 +1,38 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import type { NextFn } from '@adonisjs/core/types/http'
+
+export type CacheHeaderConfig = {
+  /** Durée max d'utilisation par un cache (secondes). */
+  maxAge?: number
+  /** stale-while-revalidate (secondes) — RFC 5861. */
+  sWR?: number
+  /** Scope du cache (public par défaut). */
+  scope?: 'public' | 'private'
+  /** Si true, force `no-store` et ignore les autres options. */
+  noStore?: boolean
+}
+
+function buildDirective(config: CacheHeaderConfig): string {
+  if (config.noStore) return 'no-store'
+  const parts: string[] = [config.scope ?? 'public']
+  if (config.maxAge !== undefined) parts.push(`max-age=${config.maxAge}`)
+  if (config.sWR !== undefined) parts.push(`stale-while-revalidate=${config.sWR}`)
+  return parts.join(', ')
+}
+
+/**
+ * Middleware fonctionnel — applique Cache-Control au response uniquement si le
+ * controller n'en a pas déjà fixé un. Usage :
+ *
+ *   .use(cacheHeaders({ maxAge: 300, sWR: 600 }))
+ *   .use(cacheHeaders({ noStore: true }))
+ */
+export const cacheHeaders = (config: CacheHeaderConfig) => {
+  const directive = buildDirective(config)
+  return async (ctx: HttpContext, next: NextFn) => {
+    await next()
+    if (!ctx.response.getHeader('cache-control')) {
+      ctx.response.header('cache-control', directive)
+    }
+  }
+}

--- a/backend/app/services/cache_service.ts
+++ b/backend/app/services/cache_service.ts
@@ -1,0 +1,111 @@
+import redis from '@adonisjs/redis/services/main'
+import logger from '@adonisjs/core/services/logger'
+import { Counter, register } from 'prom-client'
+
+const metricPrefix = `${process.env.APP_NAME ?? 'app'}_`
+
+function getOrCreateCounter(name: string, help: string): Counter<string> {
+  const existing = register.getSingleMetric(name)
+  if (existing) return existing as Counter<string>
+  return new Counter({ name, help, labelNames: ['key_prefix'] })
+}
+
+const cacheHits = getOrCreateCounter(`${metricPrefix}cache_hits_total`, 'Cache hits par préfixe de clé')
+const cacheMisses = getOrCreateCounter(
+  `${metricPrefix}cache_misses_total`,
+  'Cache misses par préfixe de clé'
+)
+
+function keyPrefix(key: string): string {
+  return key.split(':', 1)[0] ?? 'unknown'
+}
+
+export default class CacheService {
+  /**
+   * Renvoie la valeur Redis pour `key` si présente, sinon exécute `fetcher`,
+   * stocke le résultat avec TTL (en secondes) et le retourne.
+   *
+   * Sérialisation JSON. En cas d'erreur Redis (down, timeout), tombe gracieusement
+   * sur le `fetcher` direct pour ne pas casser la requête.
+   */
+  static async cacheOrFetch<T>(
+    key: string,
+    ttlSeconds: number,
+    fetcher: () => Promise<T>,
+    options: { bypass?: boolean } = {}
+  ): Promise<T> {
+    if (options.bypass) return fetcher()
+
+    const prefix = keyPrefix(key)
+
+    try {
+      const cached = await redis.get(key)
+      if (cached !== null) {
+        cacheHits.inc({ key_prefix: prefix })
+        return JSON.parse(cached) as T
+      }
+    } catch (error) {
+      logger.warn({ key, err: error.message }, 'CACHE: read failed, fallback to fetcher')
+    }
+
+    cacheMisses.inc({ key_prefix: prefix })
+    const value = await fetcher()
+
+    try {
+      await redis.setex(key, ttlSeconds, JSON.stringify(value))
+    } catch (error) {
+      logger.warn({ key, err: error.message }, 'CACHE: write failed (non-fatal)')
+    }
+
+    return value
+  }
+
+  /**
+   * Supprime une clé exacte.
+   */
+  static async invalidate(key: string): Promise<void> {
+    try {
+      await redis.del(key)
+    } catch (error) {
+      logger.warn({ key, err: error.message }, 'CACHE: invalidate failed')
+    }
+  }
+
+  /**
+   * Supprime toutes les clés matchant un pattern (ex: `stats:42:*`).
+   * Utilise SCAN pour ne pas bloquer Redis sur des bases volumineuses.
+   */
+  static async invalidatePattern(pattern: string): Promise<void> {
+    const client = redis.connection()
+    let cursor = '0'
+    let removed = 0
+    try {
+      do {
+        const [next, keys] = await client.scan(cursor, 'MATCH', pattern, 'COUNT', 100)
+        cursor = next
+        if (keys.length > 0) {
+          await client.del(...keys)
+          removed += keys.length
+        }
+      } while (cursor !== '0')
+      if (removed > 0) {
+        logger.info(`CACHE: invalidated ${removed} keys matching ${pattern}`)
+      }
+    } catch (error) {
+      logger.warn({ pattern, err: error.message }, 'CACHE: invalidatePattern failed')
+    }
+  }
+
+  /**
+   * Génère une clé stable depuis un objet de params (ordre indépendant).
+   */
+  static hashParams(prefix: string, params: Record<string, unknown>): string {
+    const sorted = Object.keys(params)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, k) => {
+        if (params[k] !== undefined && params[k] !== null) acc[k] = params[k]
+        return acc
+      }, {})
+    return `${prefix}:${JSON.stringify(sorted)}`
+  }
+}

--- a/backend/app/services/cache_service.ts
+++ b/backend/app/services/cache_service.ts
@@ -10,7 +10,10 @@ function getOrCreateCounter(name: string, help: string): Counter<string> {
   return new Counter({ name, help, labelNames: ['key_prefix'] })
 }
 
-const cacheHits = getOrCreateCounter(`${metricPrefix}cache_hits_total`, 'Cache hits par préfixe de clé')
+const cacheHits = getOrCreateCounter(
+  `${metricPrefix}cache_hits_total`,
+  'Cache hits par préfixe de clé'
+)
 const cacheMisses = getOrCreateCounter(
   `${metricPrefix}cache_misses_total`,
   'Cache misses par préfixe de clé'

--- a/backend/app/services/stat_service.ts
+++ b/backend/app/services/stat_service.ts
@@ -229,8 +229,16 @@ export default class StatsService {
 
   /**
    * Récupère les stats brutes (avec éventuellement un filtrage fromDate/toDate).
+   * Refuse les appels sans plage temporelle pour éviter de scanner toute la table.
    */
   static async getRawStats(serverId: number, fromDateSql?: string, toDateSql?: string) {
+    if (!fromDateSql && !toDateSql) {
+      throw new Exception(
+        'fromDate (or interval) is required when fetching raw stats — refusing to scan the full table',
+        { status: 400, code: 'E_STATS_MISSING_RANGE' }
+      )
+    }
+
     const query = Database.from('server_stats').select('*').where('server_id', serverId)
 
     if (fromDateSql && toDateSql) {

--- a/backend/app/services/stat_service.ts
+++ b/backend/app/services/stat_service.ts
@@ -104,7 +104,26 @@ export default class StatsService {
   }
 
   /**
+   * Heuristique de routage (P.4.1) : utilise `server_stats_hourly` pour les requêtes
+   * à interval ≥ 1h sur des plages > 24h. Sinon (intervals fins, fenêtres courtes,
+   * absence de plage), reste sur `server_stats` brute.
+   */
+  private static shouldUseHourlyTable(
+    intervalSeconds: number,
+    fromDateSql?: string,
+    toDateSql?: string
+  ): boolean {
+    if (intervalSeconds < 3600) return false
+    if (!fromDateSql || !toDateSql) return false
+    const rangeMs = DateTime.fromSQL(toDateSql).toMillis() - DateTime.fromSQL(fromDateSql).toMillis()
+    return rangeMs > 24 * 60 * 60 * 1000
+  }
+
+  /**
    * Regroupe les stats en fonction d'un interval (ex: 1 hour, 30 minutes).
+   * Route automatiquement vers la table horaire pré-agrégée si la plage est longue
+   * (P.4.1). La moyenne re-bucketée est **pondérée** par `samples_count` pour
+   * préserver la précision quand des heures ont moins de samples (serveur down).
    */
   static async getStatsWithInterval(
     serverId: number,
@@ -114,8 +133,41 @@ export default class StatsService {
   ) {
     const intervalSeconds = this.intervalToSeconds(interval)
 
-    // Construction de la clause WHERE
-    // On utilise des conditions "dynamiques" sur fromDateSql et toDateSql
+    if (this.shouldUseHourlyTable(intervalSeconds, fromDateSql, toDateSql)) {
+      let whereClauseHourly = `WHERE server_id = :serverId`
+      if (fromDateSql && toDateSql) {
+        whereClauseHourly += ` AND hour BETWEEN :fromDate AND :toDate`
+      } else if (fromDateSql) {
+        whereClauseHourly += ` AND hour >= :fromDate`
+      } else if (toDateSql) {
+        whereClauseHourly += ` AND hour <= :toDate`
+      }
+
+      const hourlyQuery = `
+        SELECT
+          to_timestamp(
+            floor(extract(epoch from hour) / ${intervalSeconds})
+            * ${intervalSeconds}
+          ) AS created_at,
+          ROUND(
+            SUM(avg_player_count::bigint * samples_count)::numeric /
+            NULLIF(SUM(samples_count), 0)
+          )::int AS player_count
+        FROM server_stats_hourly
+        ${whereClauseHourly}
+        GROUP BY 1
+        ORDER BY 1
+      `
+
+      const bindings: any = { serverId }
+      if (fromDateSql) bindings.fromDate = fromDateSql
+      if (toDateSql) bindings.toDate = toDateSql
+
+      const result = await Database.rawQuery(hourlyQuery, bindings)
+      return result.rows
+    }
+
+    // Chemin par défaut : agrégation à la volée sur server_stats brute.
     let whereClause = `WHERE server_id = :serverId`
     if (fromDateSql && toDateSql) {
       whereClause += `
@@ -128,9 +180,9 @@ export default class StatsService {
     }
 
     const rawQuery = `
-      SELECT 
+      SELECT
         to_timestamp(
-          floor(extract(epoch from created_at) / ${intervalSeconds}) 
+          floor(extract(epoch from created_at) / ${intervalSeconds})
           * ${intervalSeconds}
         ) AS created_at,
         round(AVG(player_count))::int AS player_count

--- a/backend/app/services/stat_service.ts
+++ b/backend/app/services/stat_service.ts
@@ -21,67 +21,59 @@ export default class StatsService {
   /**
    * Cherche la donnée exacte, ou fait la moyenne entre la donnée
    * juste avant et juste après si elle n'existe pas.
+   *
+   * Une seule requête UNION ALL pour récupérer exact + before + after (P.3.3).
    */
   static async getExactTimeRow(serverId: number, exactTime: DateTime) {
     const exactTimeSql = exactTime.toSQL()
 
-    // 1) Vérifier si la donnée exacte existe
-    const exactRowQuery = `
-      SELECT 
-        server_id,
-        created_at,
-        player_count
-      FROM server_stats
-      WHERE server_id = ?
-        AND created_at = ?
-      LIMIT 1
+    const combinedQuery = `
+      (SELECT 'exact'::text AS kind, server_id, created_at, player_count
+         FROM server_stats
+        WHERE server_id = :serverId AND created_at = :exactTime
+        LIMIT 1)
+      UNION ALL
+      (SELECT 'before'::text AS kind, server_id, created_at, player_count
+         FROM server_stats
+        WHERE server_id = :serverId AND created_at < :exactTime
+        ORDER BY created_at DESC
+        LIMIT 1)
+      UNION ALL
+      (SELECT 'after'::text AS kind, server_id, created_at, player_count
+         FROM server_stats
+        WHERE server_id = :serverId AND created_at > :exactTime
+        ORDER BY created_at ASC
+        LIMIT 1)
     `
-    const exactRow = await Database.rawQuery(exactRowQuery, [serverId, exactTimeSql])
 
-    if (exactRow.rows.length > 0) {
-      // On a trouvé l'enregistrement exact
-      return exactRow.rows[0]
+    const result = await Database.rawQuery(combinedQuery, {
+      serverId,
+      exactTime: exactTimeSql,
+    })
+
+    const rows: any[] = result.rows
+
+    const exact = rows.find((r) => r.kind === 'exact')
+    if (exact) {
+      const { kind: _kind, ...row } = exact
+      return row
     }
 
-    // 2) Sinon, récupérer l'enregistrement juste avant et juste après
-    const rowBeforeQuery = `
-      SELECT 
-        server_id,
-        created_at,
-        player_count
-      FROM server_stats
-      WHERE server_id = ?
-        AND created_at < ?
-      ORDER BY created_at DESC
-      LIMIT 1
-    `
-    const rowAfterQuery = `
-      SELECT 
-        server_id,
-        created_at,
-        player_count
-      FROM server_stats
-      WHERE server_id = ?
-        AND created_at > ?
-      ORDER BY created_at ASC
-      LIMIT 1
-    `
-    const [beforeRows, afterRows] = await Promise.all([
-      Database.rawQuery(rowBeforeQuery, [serverId, exactTimeSql]),
-      Database.rawQuery(rowAfterQuery, [serverId, exactTimeSql]),
-    ])
-    const rowBefore = beforeRows.rows[0]
-    const rowAfter = afterRows.rows[0]
+    const before = rows.find((r) => r.kind === 'before')
+    const after = rows.find((r) => r.kind === 'after')
 
-    // Aucun avant/après => rien à renvoyer
-    if (!rowBefore && !rowAfter) return null
-    // Seulement avant
-    if (rowBefore && !rowAfter) return rowBefore
-    // Seulement après
-    if (!rowBefore && rowAfter) return rowAfter
+    if (!before && !after) return null
+    if (before && !after) {
+      const { kind: _kind, ...row } = before
+      return row
+    }
+    if (!before && after) {
+      const { kind: _kind, ...row } = after
+      return row
+    }
 
     // Sinon on fait la moyenne
-    const avg = Math.round((Number(rowBefore.player_count) + Number(rowAfter.player_count)) / 2)
+    const avg = Math.round((Number(before.player_count) + Number(after.player_count)) / 2)
     return {
       server_id: serverId,
       created_at: exactTimeSql,

--- a/backend/app/services/stat_service.ts
+++ b/backend/app/services/stat_service.ts
@@ -161,7 +161,16 @@ export default class StatsService {
       if (toDateSql) bindings.toDate = toDateSql
 
       const result = await Database.rawQuery(hourlyQuery, bindings)
-      return result.rows
+      // Fallback transparent : si la table horaire n'est pas (encore) backfillée pour
+      // cette range, on retombe sur l'agrégation brute. Évite les réponses vides
+      // tant que `node ace backfill:hourly-stats` n'a pas tourné (P.4.1).
+      if (result.rows.length > 0) {
+        return result.rows
+      }
+      logger.warn(
+        { serverId, fromDateSql, toDateSql, interval },
+        'hourly stats empty for range — falling back to server_stats'
+      )
     }
 
     // Chemin par défaut : agrégation à la volée sur server_stats brute.

--- a/backend/app/services/stat_service.ts
+++ b/backend/app/services/stat_service.ts
@@ -159,6 +159,75 @@ export default class StatsService {
   }
 
   /**
+   * Regroupe les stats par intervalle pour plusieurs serveurs en une seule requête.
+   * Retourne un Map<serverId, stats[]> pour répartition côté Node.
+   */
+  static async getStatsBatch(params: {
+    serverIds: number[]
+    fromDate: number
+    toDate: number
+    interval: string
+  }): Promise<Map<number, Array<{ created_at: DateTime; player_count: number; max_count: number }>>> {
+    const intervalSeconds = this.intervalToSeconds(params.interval)
+    const fromDateSql = DateTime.fromMillis(params.fromDate).toSQL()
+    const toDateSql = DateTime.fromMillis(params.toDate).toSQL()
+
+    const result = new Map<
+      number,
+      Array<{ created_at: DateTime; player_count: number; max_count: number }>
+    >()
+
+    if (params.serverIds.length === 0 || !fromDateSql || !toDateSql) {
+      return result
+    }
+
+    const rawQuery = `
+      SELECT
+        server_id,
+        to_timestamp(
+          floor(extract(epoch from created_at) / ${intervalSeconds})
+          * ${intervalSeconds}
+        ) AS created_at,
+        round(AVG(player_count))::int AS player_count,
+        round(AVG(max_count))::int AS max_count
+      FROM server_stats
+      WHERE server_id = ANY(:serverIds)
+        AND created_at BETWEEN :fromDate AND :toDate
+      GROUP BY server_id, 2
+      ORDER BY server_id, 2
+    `
+
+    const rows = (
+      await Database.rawQuery(rawQuery, {
+        serverIds: params.serverIds,
+        fromDate: fromDateSql,
+        toDate: toDateSql,
+      })
+    ).rows as Array<{
+      server_id: number
+      created_at: string | Date
+      player_count: number
+      max_count: number
+    }>
+
+    for (const id of params.serverIds) result.set(id, [])
+    for (const row of rows) {
+      const arr = result.get(row.server_id) ?? []
+      arr.push({
+        created_at:
+          row.created_at instanceof Date
+            ? DateTime.fromJSDate(row.created_at)
+            : DateTime.fromSQL(row.created_at),
+        player_count: row.player_count,
+        max_count: row.max_count,
+      })
+      result.set(row.server_id, arr)
+    }
+
+    return result
+  }
+
+  /**
    * Récupère les stats brutes (avec éventuellement un filtrage fromDate/toDate).
    */
   static async getRawStats(serverId: number, fromDateSql?: string, toDateSql?: string) {

--- a/backend/app/services/stat_service.ts
+++ b/backend/app/services/stat_service.ts
@@ -438,56 +438,41 @@ export default class StatsService {
 
     const whereClause = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : ''
 
-    // Optimisation : Utilisation d'une seule requête avec des sous-requêtes pour éviter les calculs redondants
+    // Expression "bucket" calculée une seule fois ; partition idem.
+    // En l'absence d'interval, bucket = created_at (chaque ligne est son propre bucket).
+    const intervalSeconds = params.interval ? this.intervalToSeconds(params.interval) : null
+    const bucketExpr = intervalSeconds
+      ? `to_timestamp(floor(extract(epoch from ss.created_at) / ${intervalSeconds}) * ${intervalSeconds})`
+      : 'ss.created_at'
+    const partitionExpr = intervalSeconds
+      ? `floor(extract(epoch from ss.created_at) / ${intervalSeconds})`
+      : 'ss.created_at'
+
+    // Pour chaque (server_id, bucket), on garde la ligne la plus récente, puis
+    // on somme player_count / max_count par bucket et on ordonne.
     const rawQuery = `
-      WITH latest_stats AS (
-        SELECT DISTINCT ON (ss.server_id,
-          ${
-            params.interval
-              ? `
-            to_timestamp(
-              floor(extract(epoch from ss.created_at) / ${this.intervalToSeconds(params.interval)})
-              * ${this.intervalToSeconds(params.interval)}
-            )
-          `
-              : 'ss.created_at'
-          })
+      WITH bucketed AS (
+        SELECT
           ss.server_id,
-          ${
-            params.interval
-              ? `
-            to_timestamp(
-              floor(extract(epoch from ss.created_at) / ${this.intervalToSeconds(params.interval)})
-              * ${this.intervalToSeconds(params.interval)}
-            ) AS created_at,
-          `
-              : 'ss.created_at,'
-          }
           ss.player_count,
-          ss.max_count
+          ss.max_count,
+          ${bucketExpr} AS bucket,
+          ROW_NUMBER() OVER (
+            PARTITION BY ss.server_id, ${partitionExpr}
+            ORDER BY ss.created_at DESC
+          ) AS rn
         FROM server_stats ss
         ${joins}
         ${whereClause}
-        ORDER BY ss.server_id,
-          ${
-            params.interval
-              ? `
-            to_timestamp(
-              floor(extract(epoch from ss.created_at) / ${this.intervalToSeconds(params.interval)})
-              * ${this.intervalToSeconds(params.interval)}
-            )
-          `
-              : 'ss.created_at'
-          },
-          ss.created_at DESC
       )
       SELECT
-        created_at,
+        bucket AS created_at,
         SUM(player_count)::int AS player_count,
         SUM(max_count)::int AS max_count
-      FROM latest_stats
-      GROUP BY created_at
-      ORDER BY created_at
+      FROM bucketed
+      WHERE rn = 1
+      GROUP BY bucket
+      ORDER BY bucket
     `
 
     const bindings: any = {}

--- a/backend/app/services/stat_service.ts
+++ b/backend/app/services/stat_service.ts
@@ -52,25 +52,21 @@ export default class StatsService {
     })
 
     const rows: any[] = result.rows
+    const stripKind = (r: any): any => ({
+      server_id: r.server_id,
+      created_at: r.created_at,
+      player_count: r.player_count,
+    })
 
     const exact = rows.find((r) => r.kind === 'exact')
-    if (exact) {
-      const { kind: _kind, ...row } = exact
-      return row
-    }
+    if (exact) return stripKind(exact)
 
     const before = rows.find((r) => r.kind === 'before')
     const after = rows.find((r) => r.kind === 'after')
 
     if (!before && !after) return null
-    if (before && !after) {
-      const { kind: _kind, ...row } = before
-      return row
-    }
-    if (!before && after) {
-      const { kind: _kind, ...row } = after
-      return row
-    }
+    if (before && !after) return stripKind(before)
+    if (!before && after) return stripKind(after)
 
     // Sinon on fait la moyenne
     const avg = Math.round((Number(before.player_count) + Number(after.player_count)) / 2)
@@ -115,7 +111,8 @@ export default class StatsService {
   ): boolean {
     if (intervalSeconds < 3600) return false
     if (!fromDateSql || !toDateSql) return false
-    const rangeMs = DateTime.fromSQL(toDateSql).toMillis() - DateTime.fromSQL(fromDateSql).toMillis()
+    const rangeMs =
+      DateTime.fromSQL(toDateSql).toMillis() - DateTime.fromSQL(fromDateSql).toMillis()
     return rangeMs > 24 * 60 * 60 * 1000
   }
 
@@ -209,7 +206,9 @@ export default class StatsService {
     fromDate: number
     toDate: number
     interval: string
-  }): Promise<Map<number, Array<{ created_at: DateTime; player_count: number; max_count: number }>>> {
+  }): Promise<
+    Map<number, Array<{ created_at: DateTime; player_count: number; max_count: number }>>
+  > {
     const intervalSeconds = this.intervalToSeconds(params.interval)
     const fromDateSql = DateTime.fromMillis(params.fromDate).toSQL()
     const toDateSql = DateTime.fromMillis(params.toDate).toSQL()
@@ -239,13 +238,12 @@ export default class StatsService {
       ORDER BY server_id, 2
     `
 
-    const rows = (
-      await Database.rawQuery(rawQuery, {
-        serverIds: params.serverIds,
-        fromDate: fromDateSql,
-        toDate: toDateSql,
-      })
-    ).rows as Array<{
+    const batchResult = await Database.rawQuery(rawQuery, {
+      serverIds: params.serverIds,
+      fromDate: fromDateSql,
+      toDate: toDateSql,
+    })
+    const rows = batchResult.rows as Array<{
       server_id: number
       created_at: string | Date
       player_count: number
@@ -313,7 +311,8 @@ export default class StatsService {
       GROUP BY server_id
     `
 
-    const rows = (await Database.rawQuery(aggregateQuery)).rows as Array<{
+    const aggregateResult = await Database.rawQuery(aggregateQuery)
+    const rows = aggregateResult.rows as Array<{
       server_id: number
       last_week_avg: number | null
       prev_week_avg: number | null
@@ -343,7 +342,9 @@ export default class StatsService {
     })
 
     if (growthRows.length === 0) {
-      logger.info('SCHEDULER: growth_stats — no servers with stats in the last 30d, skipping upsert')
+      logger.info(
+        'SCHEDULER: growth_stats — no servers with stats in the last 30d, skipping upsert'
+      )
       return
     }
 

--- a/backend/app/services/stat_service.ts
+++ b/backend/app/services/stat_service.ts
@@ -1,5 +1,3 @@
-import Server from '#models/server'
-import ServerGrowthStat from '#models/server_growth_stat'
 import { Exception } from '@adonisjs/core/exceptions'
 import logger from '@adonisjs/core/services/logger'
 import Database from '@adonisjs/lucid/services/db'
@@ -252,60 +250,75 @@ export default class StatsService {
     return query.orderBy('created_at', 'asc')
   }
 
+  /**
+   * Calcule et stocke les growth stats pour tous les serveurs en une seule requête SQL.
+   * Remplace l'ancien O(3·N) séquentiel par O(1) côté DB + 1 upsert (cf. P.3.2).
+   *
+   * Pré-filtre sur 30 jours pour ne pas scanner toute la table — l'index
+   * (server_id, created_at) le rend efficace.
+   */
   static async calculateAndStoreGrowthStats() {
-    const servers = await Server.query()
+    const aggregateQuery = `
+      SELECT
+        server_id,
+        ROUND(AVG(player_count) FILTER (WHERE created_at > now() - interval '7 days'))::int AS last_week_avg,
+        ROUND(AVG(player_count) FILTER (WHERE created_at BETWEEN now() - interval '14 days' AND now() - interval '7 days'))::int AS prev_week_avg,
+        ROUND(AVG(player_count) FILTER (WHERE created_at > now() - interval '30 days'))::int AS last_month_avg
+      FROM server_stats
+      WHERE created_at > now() - interval '30 days'
+      GROUP BY server_id
+    `
 
-    for (const server of servers) {
-      const lastWeekStats = await this.getStatsWithInterval(
-        server.id,
-        '1 week',
-        DateTime.now().minus({ week: 1 }).toSQL()
-      )
-      const previousWeekStats = await this.getStatsWithInterval(
-        server.id,
-        '1 week',
-        DateTime.now().minus({ week: 2 }).toSQL()
-      )
-      const lastMonthStats = await this.getStatsWithInterval(
-        server.id,
-        '1 month',
-        DateTime.now().minus({ month: 1 }).toSQL()
-      )
+    const rows = (await Database.rawQuery(aggregateQuery)).rows as Array<{
+      server_id: number
+      last_week_avg: number | null
+      prev_week_avg: number | null
+      last_month_avg: number | null
+    }>
 
-      const lastWeekAverage = Math.round(
-        lastWeekStats.reduce((sum: number, stat: any) => sum + stat.player_count, 0) /
-          lastWeekStats.length
-      )
-      const previousWeekAverage = Math.round(
-        previousWeekStats.reduce((sum: number, stat: any) => sum + stat.player_count, 0) /
-          previousWeekStats.length
-      )
-      const lastMonthAverage = Math.round(
-        lastMonthStats.reduce((sum: number, stat: any) => sum + stat.player_count, 0) /
-          lastMonthStats.length
-      )
+    const now = DateTime.now().toSQL()
+    const growthRows = rows.map((row) => {
+      const lastWeek = row.last_week_avg ?? 0
+      const prevWeek = row.prev_week_avg ?? 0
+      const lastMonth = row.last_month_avg ?? 0
 
-      // On calcule le taux de croissance de la semaine dernière par rapport à la semaine d'avant
       const weeklyGrowth =
-        Math.round(((lastWeekAverage - previousWeekAverage) / previousWeekAverage) * 100) / 100
-
-      // On calcule le taux de croissance de la semaine dernière par rapport au mois dernier
+        prevWeek === 0 ? 0 : Math.round(((lastWeek - prevWeek) / prevWeek) * 100) / 100
       const monthlyGrowth =
-        Math.round(((lastWeekAverage - lastMonthAverage) / lastMonthAverage) * 100) / 100
+        lastMonth === 0 ? 0 : Math.round(((lastWeek - lastMonth) / lastMonth) * 100) / 100
 
-      await ServerGrowthStat.updateOrCreate(
-        { serverId: server.id },
-        {
-          serverId: server.id,
-          weeklyGrowth: weeklyGrowth,
-          monthlyGrowth: monthlyGrowth,
-          lastWeekAverage: lastWeekAverage,
-          previousWeekAverage: previousWeekAverage,
-          lastMonthAverage: lastMonthAverage,
-          lastUpdated: DateTime.now(),
-        }
-      )
+      return {
+        server_id: row.server_id,
+        weekly_growth: weeklyGrowth,
+        monthly_growth: monthlyGrowth,
+        last_week_average: lastWeek,
+        previous_week_average: prevWeek,
+        last_month_average: lastMonth,
+        last_updated: now,
+      }
+    })
+
+    if (growthRows.length === 0) {
+      logger.info('SCHEDULER: growth_stats — no servers with stats in the last 30d, skipping upsert')
+      return
     }
+
+    await Database.transaction(async (trx) => {
+      await trx
+        .table('server_growth_stats')
+        .insert(growthRows)
+        .onConflict('server_id')
+        .merge([
+          'weekly_growth',
+          'monthly_growth',
+          'last_week_average',
+          'previous_week_average',
+          'last_month_average',
+          'last_updated',
+        ])
+    })
+
+    logger.info(`SCHEDULER: growth_stats — upserted ${growthRows.length} rows`)
   }
 
   static async getStats(params: {

--- a/backend/commands/archive_old_partitions.ts
+++ b/backend/commands/archive_old_partitions.ts
@@ -1,0 +1,98 @@
+import { BaseCommand, flags } from '@adonisjs/core/ace'
+import { type CommandOptions } from '@adonisjs/core/types/ace'
+import Database from '@adonisjs/lucid/services/db'
+
+/**
+ * P.4.2 — Drop des partitions `server_stats_*` plus vieilles que `--older-than-months`
+ * (défaut : 24 mois). Demande confirmation sauf si `--yes` est passé.
+ *
+ * Usage :
+ *   node ace archive:old-partitions --older-than-months=24 --yes
+ *   node ace archive:old-partitions --dry-run
+ */
+export default class ArchiveOldPartitions extends BaseCommand {
+  static commandName = 'archive:old-partitions'
+  static description = 'Drop server_stats partitions older than a threshold (default 24 months)'
+
+  static options: CommandOptions = {
+    startApp: true,
+    allowUnknownFlags: false,
+    staysAlive: false,
+  }
+
+  @flags.number({
+    description: 'Drop partitions whose end date is older than N months',
+    default: 24,
+  })
+  declare olderThanMonths: number
+
+  @flags.boolean({ description: 'Auto-confirm — required for non-interactive runs' })
+  declare yes: boolean
+
+  @flags.boolean({ description: 'Only list candidate partitions, no DROP' })
+  declare dryRun: boolean
+
+  async run() {
+    const partitionedCheck = await Database.rawQuery(`
+      SELECT 1 FROM pg_class WHERE relname = 'server_stats' AND relkind = 'p' LIMIT 1
+    `)
+    if (partitionedCheck.rows.length === 0) {
+      this.logger.warning('server_stats is not a partitioned table — nothing to archive.')
+      return
+    }
+
+    const monthsThreshold = this.olderThanMonths ?? 24
+
+    // Liste les partitions enfants. Le nom est expected `server_stats_yYYYYmMM`.
+    const partitions = await Database.rawQuery(
+      `
+      SELECT c.relname AS partition_name,
+             pg_get_expr(c.relpartbound, c.oid) AS bound
+        FROM pg_inherits i
+        JOIN pg_class c ON c.oid = i.inhrelid
+       WHERE i.inhparent = 'server_stats'::regclass
+       ORDER BY c.relname
+      `
+    )
+
+    const cutoff = new Date()
+    cutoff.setUTCMonth(cutoff.getUTCMonth() - monthsThreshold)
+    cutoff.setUTCDate(1)
+    cutoff.setUTCHours(0, 0, 0, 0)
+
+    const toDrop: string[] = []
+    for (const row of partitions.rows as Array<{ partition_name: string; bound: string }>) {
+      // bound ressemble à : FOR VALUES FROM ('2024-01-01 00:00:00+00') TO ('2024-02-01 00:00:00+00')
+      const match = row.bound.match(/TO \('([^']+)'\)/)
+      if (!match) continue
+      const partitionEnd = new Date(match[1])
+      if (partitionEnd <= cutoff) {
+        toDrop.push(row.partition_name)
+      }
+    }
+
+    if (toDrop.length === 0) {
+      this.logger.success('No partitions older than threshold — nothing to archive.')
+      return
+    }
+
+    this.logger.info(`Candidate partitions (older than ${monthsThreshold} months):`)
+    for (const name of toDrop) this.logger.info(`  - ${name}`)
+
+    if (this.dryRun) {
+      this.logger.info('--dry-run set, not dropping.')
+      return
+    }
+
+    if (!this.yes) {
+      this.logger.error('Refusing to drop without --yes (or --dry-run). Aborting.')
+      this.exitCode = 1
+      return
+    }
+
+    for (const name of toDrop) {
+      await Database.rawQuery(`DROP TABLE IF EXISTS ${name}`)
+      this.logger.success(`Dropped partition ${name}`)
+    }
+  }
+}

--- a/backend/commands/backfill_hourly_stats.ts
+++ b/backend/commands/backfill_hourly_stats.ts
@@ -1,0 +1,75 @@
+import { BaseCommand } from '@adonisjs/core/ace'
+import { type CommandOptions } from '@adonisjs/core/types/ace'
+import Database from '@adonisjs/lucid/services/db'
+
+/**
+ * P.4.1 — Backfill de la table `server_stats_hourly` depuis les données brutes.
+ *
+ * À lancer une fois après la migration. Itère jour par jour de la première stat
+ * jusqu'à l'heure actuelle, et upsert via INSERT … ON CONFLICT.
+ *
+ * Usage : `node ace backfill:hourly-stats`
+ */
+export default class BackfillHourlyStats extends BaseCommand {
+  static commandName = 'backfill:hourly-stats'
+  static description = 'Backfill server_stats_hourly from server_stats history'
+
+  static options: CommandOptions = {
+    startApp: true,
+    allowUnknownFlags: false,
+    staysAlive: false,
+  }
+
+  async run() {
+    const minRow = await Database.rawQuery(
+      `SELECT MIN(created_at) AS min_created_at FROM server_stats`
+    )
+    const minCreatedAt: Date | null = minRow.rows[0]?.min_created_at
+
+    if (!minCreatedAt) {
+      this.logger.info('No stats in server_stats — nothing to backfill.')
+      return
+    }
+
+    const startDay = new Date(minCreatedAt)
+    startDay.setUTCHours(0, 0, 0, 0)
+    const endDay = new Date()
+    endDay.setUTCHours(0, 0, 0, 0)
+
+    let cursor = new Date(startDay)
+    let totalRows = 0
+
+    while (cursor <= endDay) {
+      const nextDay = new Date(cursor)
+      nextDay.setUTCDate(nextDay.getUTCDate() + 1)
+
+      const result = await Database.rawQuery(
+        `
+        INSERT INTO server_stats_hourly (server_id, hour, avg_player_count, max_player_count, samples_count)
+        SELECT
+          server_id,
+          date_trunc('hour', created_at) AS hour,
+          ROUND(AVG(player_count))::int AS avg_player_count,
+          MAX(max_count) AS max_player_count,
+          COUNT(*)::int AS samples_count
+        FROM server_stats
+        WHERE created_at >= :dayStart AND created_at < :dayEnd
+        GROUP BY server_id, hour
+        ON CONFLICT (server_id, hour) DO UPDATE SET
+          avg_player_count = EXCLUDED.avg_player_count,
+          max_player_count = EXCLUDED.max_player_count,
+          samples_count    = EXCLUDED.samples_count
+        `,
+        { dayStart: cursor.toISOString(), dayEnd: nextDay.toISOString() }
+      )
+
+      const dayRows = result.rowCount ?? 0
+      totalRows += dayRows
+      this.logger.info(`backfill ${cursor.toISOString().slice(0, 10)} → ${dayRows} rows upserted`)
+
+      cursor = nextDay
+    }
+
+    this.logger.success(`Backfill done — ${totalRows} hourly rows upserted in total.`)
+  }
+}

--- a/backend/commands/backfill_hourly_stats.ts
+++ b/backend/commands/backfill_hourly_stats.ts
@@ -1,4 +1,4 @@
-import { BaseCommand } from '@adonisjs/core/ace'
+import { BaseCommand, flags } from '@adonisjs/core/ace'
 import { type CommandOptions } from '@adonisjs/core/types/ace'
 import Database from '@adonisjs/lucid/services/db'
 
@@ -6,9 +6,14 @@ import Database from '@adonisjs/lucid/services/db'
  * P.4.1 — Backfill de la table `server_stats_hourly` depuis les données brutes.
  *
  * À lancer une fois après la migration. Itère jour par jour de la première stat
- * jusqu'à l'heure actuelle, et upsert via INSERT … ON CONFLICT.
+ * (ou de `--from-date`) jusqu'à l'heure actuelle, et upsert via INSERT … ON CONFLICT.
  *
- * Usage : `node ace backfill:hourly-stats`
+ * Idempotent : on peut relancer la commande, les jours déjà calculés sont juste
+ * ré-écrits avec la même valeur.
+ *
+ * Usage :
+ *   node ace backfill:hourly-stats
+ *   node ace backfill:hourly-stats --from-date=2024-08-21
  */
 export default class BackfillHourlyStats extends BaseCommand {
   static commandName = 'backfill:hourly-stats'
@@ -20,19 +25,38 @@ export default class BackfillHourlyStats extends BaseCommand {
     staysAlive: false,
   }
 
-  async run() {
-    const minRow = await Database.rawQuery(
-      `SELECT MIN(created_at) AS min_created_at FROM server_stats`
-    )
-    const minCreatedAt: Date | null = minRow.rows[0]?.min_created_at
+  @flags.string({
+    description: 'Resume from this date (YYYY-MM-DD UTC). Defaults to MIN(created_at).',
+  })
+  declare fromDate: string
 
-    if (!minCreatedAt) {
-      this.logger.info('No stats in server_stats — nothing to backfill.')
-      return
+  async run() {
+    let startDay: Date
+
+    if (this.fromDate) {
+      const parsed = new Date(`${this.fromDate}T00:00:00Z`)
+      if (Number.isNaN(parsed.getTime())) {
+        this.logger.error(`Invalid --from-date: ${this.fromDate} (expected YYYY-MM-DD)`)
+        this.exitCode = 1
+        return
+      }
+      startDay = parsed
+      this.logger.info(`Resuming backfill from ${this.fromDate}`)
+    } else {
+      const minRow = await Database.rawQuery(
+        `SELECT MIN(created_at) AS min_created_at FROM server_stats WHERE server_id IS NOT NULL`
+      )
+      const minCreatedAt: Date | null = minRow.rows[0]?.min_created_at
+
+      if (!minCreatedAt) {
+        this.logger.info('No stats in server_stats — nothing to backfill.')
+        return
+      }
+
+      startDay = new Date(minCreatedAt)
+      startDay.setUTCHours(0, 0, 0, 0)
     }
 
-    const startDay = new Date(minCreatedAt)
-    startDay.setUTCHours(0, 0, 0, 0)
     const endDay = new Date()
     endDay.setUTCHours(0, 0, 0, 0)
 
@@ -43,6 +67,8 @@ export default class BackfillHourlyStats extends BaseCommand {
       const nextDay = new Date(cursor)
       nextDay.setUTCDate(nextDay.getUTCDate() + 1)
 
+      // `WHERE server_id IS NOT NULL` : protège contre les stats orphelines
+      // (anciens stats créés sans association valide avant le bulk insert P.1.4).
       const result = await Database.rawQuery(
         `
         INSERT INTO server_stats_hourly (server_id, hour, avg_player_count, max_player_count, samples_count)
@@ -54,6 +80,7 @@ export default class BackfillHourlyStats extends BaseCommand {
           COUNT(*)::int AS samples_count
         FROM server_stats
         WHERE created_at >= :dayStart AND created_at < :dayEnd
+          AND server_id IS NOT NULL
         GROUP BY server_id, hour
         ON CONFLICT (server_id, hour) DO UPDATE SET
           avg_player_count = EXCLUDED.avg_player_count,

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -100,6 +100,8 @@ services:
     restart: "unless-stopped"
     volumes:
       - grafana-storage:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
     networks:
       - sail
     healthcheck:

--- a/backend/config/database.ts
+++ b/backend/config/database.ts
@@ -1,18 +1,30 @@
 import env from '#start/env'
 import { defineConfig } from '@adonisjs/lucid'
 
+const isProd = env.get('NODE_ENV') === 'production'
+
 const dbConfig = defineConfig({
   connection: 'postgres',
   connections: {
     postgres: {
       client: 'pg',
-      debug: true,
+      // debug=true loggue chaque query côté stdout — coûteux en prod (cf. investigation P.1.6).
+      debug: !isProd,
       connection: {
         host: env.get('DB_HOST'),
         port: env.get('DB_PORT'),
         user: env.get('DB_USER'),
         password: env.get('DB_PASSWORD'),
         database: env.get('DB_DATABASE'),
+      },
+      // Pool tuning (cf. P.1.6) — défaut Knex { min: 2, max: 10 } trop bas pour les bursts
+      // observés (jusqu'à ~20 ops/s sur des handlers parallèles avec Promise.all).
+      // À coordonner avec `max_connections` côté Postgres si plusieurs apps partagent l'instance.
+      pool: {
+        min: 2,
+        max: 20,
+        acquireTimeoutMillis: 30_000,
+        idleTimeoutMillis: 30_000,
       },
       migrations: {
         naturalSort: true,

--- a/backend/config/prometheus.ts
+++ b/backend/config/prometheus.ts
@@ -1,8 +1,8 @@
 import env from '#start/env'
 import { defineConfig } from '@julr/adonisjs-prometheus'
 import { httpCollector } from '@julr/adonisjs-prometheus/collectors/http_collector'
-import { mailCollector } from '@julr/adonisjs-prometheus/collectors/mail_collector'
 import { lucidCollector } from '@julr/adonisjs-prometheus/collectors/lucid_collector'
+import { mailCollector } from '@julr/adonisjs-prometheus/collectors/mail_collector'
 import { systemCollector } from '@julr/adonisjs-prometheus/collectors/system_collector'
 
 export default defineConfig({

--- a/backend/config/redis.ts
+++ b/backend/config/redis.ts
@@ -22,8 +22,15 @@ const redisConfig = defineConfig({
       password: env.get('REDIS_PASSWORD', ''),
       db: 0,
       keyPrefix: '',
+      // Fail-fast quand Redis est down : pas de queue offline, pas de blocage des
+      // commandes le temps de la reconnexion. Le CacheService tombe gracefully
+      // sur le fetcher au lieu d'attendre 5s par requête (P.2.1).
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 1,
+      connectTimeout: 2000,
       retryStrategy(times) {
-        return times > 10 ? null : times * 50
+        if (times > 10) return null
+        return Math.min(times * 200, 3000)
       },
     },
   },

--- a/backend/database/manual-migrations/README.md
+++ b/backend/database/manual-migrations/README.md
@@ -1,0 +1,24 @@
+# Manual migrations
+
+This folder is **not** scanned by `node ace migration:run`. Migrations here are operations
+that must be executed by an operator during a maintenance window with a backup at hand.
+
+## When to run a manual migration
+
+- Destructive table rewrites (e.g. partitioning a multi-million-row table)
+- Operations that may take hours
+- Anything that needs a pre-flight backup and dress rehearsal on a copy
+
+## Procedure (high level)
+
+1. **Backup** the affected table(s) : `pg_dump -t <table> > backup.sql`
+2. **Test** on a copy of production (Docker, staging, or a temporary DB)
+3. **Schedule** a maintenance window if user-facing impact is possible
+4. **Execute** via `psql` or hand-run the migration class
+5. **Verify** endpoints and dashboards before declaring done
+6. **Cleanup** any `_old` shadow tables after ≥24h of stable operation
+
+## Files
+
+- `partition_server_stats.ts` — Story P.4.2. Converts `server_stats` to a Postgres
+  RANGE-partitioned table (monthly). See file header for the full procedure.

--- a/backend/database/manual-migrations/partition_server_stats.ts
+++ b/backend/database/manual-migrations/partition_server_stats.ts
@@ -1,0 +1,70 @@
+/**
+ * P.4.2 — MIGRATION MANUELLE — Partitionnement de server_stats par mois.
+ *
+ * ⚠️ NE PAS PLACER DANS `database/migrations/`. Cette migration est destructive
+ *     (copie + rename + drop), peut durer plusieurs heures, et requiert :
+ *     - Une fenêtre de maintenance
+ *     - Un dump complet AVANT exécution
+ *     - Une validation manuelle sur une copie de prod
+ *
+ * Procédure :
+ *   1. Faire un dump : `pg_dump -t server_stats > server_stats_backup.sql`
+ *   2. Tester sur une copie de la base
+ *   3. Exécuter via psql ou via un script ts manuel (`node --experimental-vm-modules ...`)
+ *   4. Valider les endpoints en prod
+ *   5. Drop la table _old après ≥ 24h sans incident
+ *
+ * Le schéma cible :
+ *   - server_stats partitionnée par RANGE (created_at), partitions mensuelles
+ *   - PK = (server_id, created_at) — Postgres impose que la PK contienne la colonne de partition
+ *   - id auto-incrément supprimé (audit `grep` : non utilisé dans le code)
+ */
+
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  async up() {
+    // 1) Créer la nouvelle table parente partitionnée
+    await this.db.rawQuery(`
+      CREATE TABLE IF NOT EXISTS server_stats_partitioned (
+        server_id integer NOT NULL,
+        player_count integer NULL,
+        max_count integer NULL,
+        created_at timestamptz NOT NULL,
+        PRIMARY KEY (server_id, created_at),
+        CONSTRAINT server_stats_partitioned_server_fk
+          FOREIGN KEY (server_id) REFERENCES servers(id) ON DELETE CASCADE
+      ) PARTITION OF NOTHING;
+    `)
+
+    // 2) Créer les partitions mensuelles couvrant l'historique connu.
+    //    À adapter dynamiquement selon `MIN(created_at)` réel — laissé en TODO
+    //    pour exécution manuelle.
+    //    Exemple :
+    //    CREATE TABLE server_stats_y2024m01 PARTITION OF server_stats_partitioned
+    //      FOR VALUES FROM ('2024-01-01') TO ('2024-02-01');
+
+    // 3) Copier les données (peut durer plusieurs heures sur grosse base)
+    //    INSERT INTO server_stats_partitioned (server_id, player_count, max_count, created_at)
+    //    SELECT server_id, player_count, max_count, created_at FROM server_stats;
+
+    // 4) Rename
+    //    ALTER TABLE server_stats RENAME TO server_stats_old;
+    //    ALTER TABLE server_stats_partitioned RENAME TO server_stats;
+
+    // 5) Recréer les index nécessaires sur la nouvelle table (chaque partition les hérite)
+    //    CREATE INDEX server_stats_server_id_created_at_index
+    //      ON server_stats (server_id, created_at);
+
+    // 6) Drop server_stats_old après validation (séparé, pas dans cette migration)
+
+    throw new Error(
+      'P.4.2 partition migration is intentionally not executable via `migration:run`. ' +
+        'Read manual-migrations/README.md and run the SQL steps manually during a maintenance window.'
+    )
+  }
+
+  async down() {
+    throw new Error('Manual rollback only — see manual-migrations/README.md')
+  }
+}

--- a/backend/database/migrations/1778000000000_drop_duplicate_index_server_stats.ts
+++ b/backend/database/migrations/1778000000000_drop_duplicate_index_server_stats.ts
@@ -1,0 +1,23 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+/**
+ * Drop le doublon `server_stats_server_id_created_at_idx` (créé par 1735573222630).
+ * On conserve `server_stats_server_id_created_at_index` (créé par 1732930662009),
+ * chronologiquement plus ancien et nommé plus proprement. Postgres ignorait l'un des
+ * deux à la lecture mais payait la maintenance des deux à chaque INSERT (P.1.5).
+ */
+export default class extends BaseSchema {
+  protected tableName = 'server_stats'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropIndex(['server_id', 'created_at'], 'server_stats_server_id_created_at_idx')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.index(['server_id', 'created_at'], 'server_stats_server_id_created_at_idx')
+    })
+  }
+}

--- a/backend/database/migrations/1778100000000_add_indexes_to_pivot_tables.ts
+++ b/backend/database/migrations/1778100000000_add_indexes_to_pivot_tables.ts
@@ -1,0 +1,34 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+/**
+ * P.3.1 — Ajoute des index sur les tables pivot `server_categories` et `server_languages`
+ * pour que les filtres `categoryId` / `languageId` dans `getGlobalStats` et `paginate`
+ * fassent un Index Scan plutôt qu'un Seq Scan.
+ *
+ * Note : `server_languages` a une UNIQUE (server_id, language_id) qui couvre déjà les
+ * lookups par `server_id` seul. L'index explicite est conservé pour cohérence avec
+ * `server_categories` et lisibilité (cf. AC #1).
+ */
+export default class extends BaseSchema {
+  async up() {
+    this.schema.alterTable('server_categories', (table) => {
+      table.index(['server_id'], 'server_categories_server_id_idx')
+      table.index(['category_id'], 'server_categories_category_id_idx')
+    })
+    this.schema.alterTable('server_languages', (table) => {
+      table.index(['server_id'], 'server_languages_server_id_idx')
+      table.index(['language_id'], 'server_languages_language_id_idx')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable('server_categories', (table) => {
+      table.dropIndex(['server_id'], 'server_categories_server_id_idx')
+      table.dropIndex(['category_id'], 'server_categories_category_id_idx')
+    })
+    this.schema.alterTable('server_languages', (table) => {
+      table.dropIndex(['server_id'], 'server_languages_server_id_idx')
+      table.dropIndex(['language_id'], 'server_languages_language_id_idx')
+    })
+  }
+}

--- a/backend/database/migrations/1778200000000_create_server_stats_hourly.ts
+++ b/backend/database/migrations/1778200000000_create_server_stats_hourly.ts
@@ -1,0 +1,33 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+/**
+ * P.4.1 — Table de stats horaires pré-agrégées.
+ *
+ * 1 ligne par (server_id, hour). `samples_count` permet de calculer un re-aggrégat
+ * pondéré quand on re-buckette en mensuel/annuel (`SUM(avg*samples) / SUM(samples)`).
+ */
+export default class extends BaseSchema {
+  protected tableName = 'server_stats_hourly'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table
+        .integer('server_id')
+        .notNullable()
+        .references('id')
+        .inTable('servers')
+        .onDelete('CASCADE')
+      table.timestamp('hour', { useTz: true }).notNullable()
+      table.integer('avg_player_count').nullable()
+      table.integer('max_player_count').nullable()
+      table.integer('samples_count').notNullable().defaultTo(0)
+
+      table.primary(['server_id', 'hour'])
+      table.index(['hour'], 'server_stats_hourly_hour_idx')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/grafana/dashboards/api-performance.json
+++ b/backend/grafana/dashboards/api-performance.json
@@ -326,8 +326,79 @@
     },
     {
       "type": "row",
-      "title": "Pool de connexions DB",
+      "title": "Cache Redis",
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "id": 105,
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Cache hit rate (5m)",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 35 },
+      "id": 40,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate({__name__=~\"${app}_cache_hits_total\"}[5m])) / (sum(rate({__name__=~\"${app}_cache_hits_total\"}[5m])) + sum(rate({__name__=~\"${app}_cache_misses_total\"}[5m])))",
+          "legendFormat": "hit rate",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Hits / misses par préfixe (req/s)",
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 35 },
+      "id": 41,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate({__name__=~\"${app}_cache_hits_total\"}[5m])) by (key_prefix)",
+          "legendFormat": "hit · {{key_prefix}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate({__name__=~\"${app}_cache_misses_total\"}[5m])) by (key_prefix)",
+          "legendFormat": "miss · {{key_prefix}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Pool de connexions DB",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 43 },
       "id": 104,
       "collapsed": false,
       "panels": []
@@ -335,7 +406,7 @@
     {
       "type": "timeseries",
       "title": "Pool DB — size / used / pending",
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 35 },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 44 },
       "id": 25,
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
@@ -374,7 +445,7 @@
     {
       "type": "row",
       "title": "Scheduler (Loki)",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 44 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 53 },
       "id": 103,
       "collapsed": false,
       "panels": []
@@ -382,7 +453,7 @@
     {
       "type": "timeseries",
       "title": "Durée du job growth_stats (ms)",
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 45 },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 54 },
       "id": 30,
       "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [

--- a/backend/grafana/dashboards/api-performance.json
+++ b/backend/grafana/dashboards/api-performance.json
@@ -1,0 +1,434 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Latence, RPS et erreurs des routes API + métriques DB. Provisionné via baseline P.0.1.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "row",
+      "title": "Vue globale",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Requêtes / sec",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "id": 1,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate({__name__=~\"${app}_http_request_total\"}[5m]))",
+          "legendFormat": "rps",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 100 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Taux d'erreur (5xx)",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "id": 2,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate({__name__=~\"${app}_http_request_total\",status_code=~\"5..\"}[5m])) / sum(rate({__name__=~\"${app}_http_request_total\"}[5m]))",
+          "legendFormat": "err",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Latence P95 (global)",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate({__name__=~\"${app}_http_request_duration_seconds_bucket\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.3 },
+              { "color": "red", "value": 0.7 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Latence P99 (global)",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate({__name__=~\"${app}_http_request_duration_seconds_bucket\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "title": "Routes",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 101,
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Latence P95 par route",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 6 },
+      "id": 10,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate({__name__=~\"${app}_http_request_duration_seconds_bucket\",route=~\"$route\"}[5m])) by (le, route))",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Latence P99 par route",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 6 },
+      "id": 11,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate({__name__=~\"${app}_http_request_duration_seconds_bucket\",route=~\"$route\"}[5m])) by (le, route))",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Requêtes / sec par route",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 15 },
+      "id": 12,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate({__name__=~\"${app}_http_request_total\",route=~\"$route\"}[5m])) by (route)",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Erreurs (>=500) par route",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 15 },
+      "id": 13,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate({__name__=~\"${app}_http_request_total\",status_code=~\"5..\",route=~\"$route\"}[5m])) by (route)",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Base de données (Lucid)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+      "id": 102,
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Requêtes DB / sec par méthode",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 25 },
+      "id": 20,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate({__name__=~\"${app}_lucid_query_count\"}[5m])) by (method)",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Latence DB P95 par modèle",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 25 },
+      "id": 21,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate({__name__=~\"${app}_lucid_query_duration_seconds_bucket\"}[5m])) by (le, model))",
+          "legendFormat": "{{model}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Scheduler (Loki)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "id": 103,
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Durée du job growth_stats (ms)",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 35 },
+      "id": 30,
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "targets": [
+        {
+          "expr": "avg_over_time({container_name=~\"stats-scheduler-.*\"} |~ \"growth_stats job completed\" | regexp \"completed in (?P<ms>[0-9]+)ms for (?P<servers>[0-9]+) servers\" | unwrap ms [1h])",
+          "legendFormat": "durée moyenne (ms)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["minecraft-stats", "performance", "api"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource Prometheus",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": { "selected": false, "text": "Loki", "value": "Loki" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource Loki",
+        "multi": false,
+        "name": "DS_LOKI",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": { "selected": true, "text": "minecraft_stats_prod", "value": "minecraft_stats_prod" },
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Préfixe métriques (APP_NAME)",
+        "multi": false,
+        "name": "app",
+        "options": [],
+        "query": { "query": "label_values({__name__=~\".+_http_request_total\"}, __name__)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+        "refresh": 1,
+        "regex": "/^(?<value>.+)_http_request_total$/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Route",
+        "multi": true,
+        "name": "route",
+        "options": [],
+        "query": { "query": "label_values({__name__=~\"${app}_http_request_total\"}, route)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Minecraft Stats / AdonisJS",
+  "uid": "mcstats-api",
+  "version": 1,
+  "weekStart": ""
+}

--- a/backend/grafana/dashboards/api-performance.json
+++ b/backend/grafana/dashboards/api-performance.json
@@ -326,8 +326,55 @@
     },
     {
       "type": "row",
-      "title": "Scheduler (Loki)",
+      "title": "Pool de connexions DB",
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "id": 104,
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Pool DB — size / used / pending",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 35 },
+      "id": 25,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "max({__name__=~\"${app}_lucid_pool_size\"}) by (pool)",
+          "legendFormat": "size",
+          "refId": "A"
+        },
+        {
+          "expr": "max({__name__=~\"${app}_lucid_pool_used\"}) by (pool)",
+          "legendFormat": "used",
+          "refId": "B"
+        },
+        {
+          "expr": "max({__name__=~\"${app}_lucid_pool_pending_acquires\"}) by (pool)",
+          "legendFormat": "pending acquires",
+          "refId": "C"
+        },
+        {
+          "expr": "max({__name__=~\"${app}_lucid_pool_pending_creates\"}) by (pool)",
+          "legendFormat": "pending creates",
+          "refId": "D"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineInterpolation": "stepAfter", "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Scheduler (Loki)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 44 },
       "id": 103,
       "collapsed": false,
       "panels": []
@@ -335,7 +382,7 @@
     {
       "type": "timeseries",
       "title": "Durée du job growth_stats (ms)",
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 35 },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 45 },
       "id": 30,
       "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [

--- a/backend/grafana/provisioning/dashboards/dashboards.yaml
+++ b/backend/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: 'Minecraft Stats'
+    orgId: 1
+    folder: 'Minecraft Stats'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/backend/grafana/provisioning/datasources/prometheus.yaml
+++ b/backend/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: true

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -10,8 +10,14 @@
 import swagger from '#config/swagger'
 import router from '@adonisjs/core/services/router'
 import AutoSwagger from 'adonis-autoswagger'
+import { cacheHeaders } from '#middleware/cache_headers_middleware'
 import { middleware } from './kernel.js'
 import { throttleLight } from './limiter.js'
+
+const PUBLIC_STATS = cacheHeaders({ maxAge: 300, sWR: 600 })
+const PUBLIC_PAGINATE = cacheHeaders({ maxAge: 60, sWR: 120 })
+const PUBLIC_LONG = cacheHeaders({ maxAge: 3600 })
+const NO_STORE = cacheHeaders({ noStore: true })
 
 router.get('/swagger', async () => {
   return AutoSwagger.default.docs(router.toJSON(), swagger)
@@ -26,38 +32,44 @@ router
     // Gestion des ressources
     router
       .get('servers/paginate', '#controllers/servers_controller.paginate')
-      .use(throttleLight('servers.paginate', 50))
+      .use([throttleLight('servers.paginate', 50), PUBLIC_PAGINATE])
 
     router
       .resource('servers', '#controllers/servers_controller')
       .except(['create', 'edit'])
       .middleware(['destroy', 'store', 'update'], middleware.auth())
+      .middleware(['destroy', 'store', 'update'], NO_STORE)
       .use('*', throttleLight('servers', 35))
 
     router
       .resource('servers.categories', '#controllers/server_categories_controller')
       .only(['index', 'store', 'destroy'])
+      .middleware(['store', 'destroy'], NO_STORE)
       .use('*', throttleLight('servers.categories', 8))
 
     router
       .resource('languages', '#controllers/languages_controller')
       .only(['index'])
+      .middleware('index', PUBLIC_LONG)
       .use('*', throttleLight('languages', 8))
 
     router
       .resource('categories', '#controllers/categories_controller')
       .except(['create', 'edit'])
       .middleware(['destroy', 'store', 'update'], middleware.auth())
+      .middleware(['destroy', 'store', 'update'], NO_STORE)
+      .middleware('index', PUBLIC_LONG)
       .use('*', throttleLight('categories', 8))
 
     router
       .resource('servers.stats', '#controllers/stats_controller')
       .only(['index'])
+      .middleware('index', PUBLIC_STATS)
       .use('*', throttleLight('servers.stats', 40))
 
     router
       .get('global-stats', '#controllers/stats_controller.globalStats')
-      .use(throttleLight('global-stats', 40))
+      .use([throttleLight('global-stats', 40), PUBLIC_STATS])
 
     router
       .resource('users', '#controllers/users_controller')
@@ -70,31 +82,33 @@ router
       .use(throttleLight('website-stats', 10))
 
     // Authentification et gestion de compte
-    router.post('/login', '#controllers/auth_controller.login').use(throttleLight('login', 5))
+    router
+      .post('/login', '#controllers/auth_controller.login')
+      .use([throttleLight('login', 5), NO_STORE])
     router
       .post('/register', '#controllers/auth_controller.register')
-      .use(throttleLight('register', 5))
+      .use([throttleLight('register', 5), NO_STORE])
     router
       .post('/verify-email', '#controllers/auth_controller.verifyEmail')
-      .use(throttleLight('verify-email', 5))
+      .use([throttleLight('verify-email', 5), NO_STORE])
     router
       .get('/me', '#controllers/auth_controller.retrieveUser')
       .use(middleware.auth())
-      .use(throttleLight('me', 5))
+      .use([throttleLight('me', 5), NO_STORE])
     router
       .post('/change-password', '#controllers/auth_controller.changePassword')
       .use(middleware.auth())
-      .use(throttleLight('change-password', 2))
+      .use([throttleLight('change-password', 2), NO_STORE])
     router
       .get('/login/:provider', '#controllers/auth_controller.providerLogin')
       .where('provider', /google|discord/)
-      .use(throttleLight('provider-login', 5))
+      .use([throttleLight('provider-login', 5), NO_STORE])
     router
       .get('/callback/google', '#controllers/auth_controller.googleCallback')
-      .use(throttleLight('google-callback', 5))
+      .use([throttleLight('google-callback', 5), NO_STORE])
     router
       .get('/callback/discord', '#controllers/auth_controller.discordCallback')
-      .use(throttleLight('discord-callback', 5))
+      .use([throttleLight('discord-callback', 5), NO_STORE])
 
     // Blog - Posts publics
     router.get('posts', '#controllers/posts_controller.index').use(throttleLight('posts.index', 50))

--- a/backend/start/scheduler.ts
+++ b/backend/start/scheduler.ts
@@ -219,3 +219,34 @@ scheduler
     )
   })
   .hourly()
+
+// Pré-création de la partition du mois suivant (P.4.2).
+// No-op si `server_stats` n'est pas une table partitionnée — détecté via pg_class.
+scheduler
+  .call(async () => {
+    const isPartitioned = await Database.rawQuery(`
+      SELECT 1 FROM pg_class
+       WHERE relname = 'server_stats' AND relkind = 'p'
+       LIMIT 1
+    `)
+    if (isPartitioned.rows.length === 0) {
+      logger.debug('SCHEDULER: partition_maintenance — server_stats is not partitioned, skipping')
+      return
+    }
+
+    await Database.rawQuery(`
+      DO $$
+      DECLARE
+        next_month date := date_trunc('month', now() + interval '1 month')::date;
+        month_after date := (date_trunc('month', now() + interval '1 month') + interval '1 month')::date;
+        part_name text := format('server_stats_y%sm%s', to_char(next_month, 'YYYY'), to_char(next_month, 'MM'));
+      BEGIN
+        EXECUTE format(
+          'CREATE TABLE IF NOT EXISTS %I PARTITION OF server_stats FOR VALUES FROM (%L) TO (%L)',
+          part_name, next_month, month_after
+        );
+      END $$;
+    `)
+    logger.info('SCHEDULER: partition_maintenance — ensured next month partition exists')
+  })
+  .everySixHours()

--- a/backend/start/scheduler.ts
+++ b/backend/start/scheduler.ts
@@ -190,3 +190,32 @@ scheduler
     )
   })
   .everySixHours()
+
+// Agrégation horaire des stats brutes vers server_stats_hourly (P.4.1).
+// Tourne toutes les heures et upsert l'heure qui vient juste de se terminer.
+scheduler
+  .call(async () => {
+    const start = Date.now()
+    const result = await Database.rawQuery(`
+      INSERT INTO server_stats_hourly (server_id, hour, avg_player_count, max_player_count, samples_count)
+      SELECT
+        server_id,
+        date_trunc('hour', created_at) AS hour,
+        ROUND(AVG(player_count))::int AS avg_player_count,
+        MAX(max_count) AS max_player_count,
+        COUNT(*)::int AS samples_count
+      FROM server_stats
+      WHERE created_at >= date_trunc('hour', now() - interval '1 hour')
+        AND created_at <  date_trunc('hour', now())
+      GROUP BY server_id, hour
+      ON CONFLICT (server_id, hour) DO UPDATE SET
+        avg_player_count = EXCLUDED.avg_player_count,
+        max_player_count = EXCLUDED.max_player_count,
+        samples_count    = EXCLUDED.samples_count
+    `)
+    const rowCount = result.rowCount ?? 0
+    logger.info(
+      `SCHEDULER: hourly_stats aggregation completed in ${Date.now() - start}ms (${rowCount} rows upserted)`
+    )
+  })
+  .hourly()

--- a/backend/start/scheduler.ts
+++ b/backend/start/scheduler.ts
@@ -183,7 +183,8 @@ scheduler
 scheduler
   .call(async () => {
     const start = Date.now()
-    const serverCount = (await Server.query().count('* as total'))[0].$extras.total
+    const countResult = await Server.query().count('* as total')
+    const serverCount = countResult[0].$extras.total
     await StatsService.calculateAndStoreGrowthStats()
     logger.info(
       `SCHEDULER: growth_stats job completed in ${Date.now() - start}ms for ${serverCount} servers`

--- a/backend/start/scheduler.ts
+++ b/backend/start/scheduler.ts
@@ -1,7 +1,7 @@
 import Server from '#models/server'
-import ServerStat from '#models/server_stat'
 import StatsService from '#services/stat_service'
 import logger from '@adonisjs/core/services/logger'
+import Database from '@adonisjs/lucid/services/db'
 import scheduler from 'adonisjs-scheduler/services/main'
 import fs from 'node:fs'
 import path, { dirname } from 'node:path'
@@ -10,6 +10,13 @@ import pLimit from 'p-limit'
 import { pingMinecraftJava } from '../minecraft-ping/minecraft_ping.js'
 import sharp from 'sharp'
 import { DateTime } from 'luxon'
+
+type ServerStatRow = {
+  server_id: number
+  player_count: number | null
+  max_count: number | null
+  created_at: Date
+}
 
 /**
  * Convertit une chaîne base64 en fichier image et l'enregistre sur le système de fichiers.
@@ -49,18 +56,25 @@ async function retry<T>(fn: () => Promise<T>, retries = 3, delay = 1000): Promis
 }
 
 /**
- * Met à jour les informations du serveur et enregistre les statistiques.
+ * Met à jour les informations du serveur et retourne la stat à insérer.
+ * L'écriture des UPDATE `servers` reste individuelle, mais l'INSERT `server_stats` est
+ * délégué au caller pour permettre un bulk insert en fin de cycle (cf. P.1.4).
+ *
  * @param server - Le serveur à mettre à jour.
  * @param overwriteImage - Indique si l'image doit être écrasée.
  */
-async function updateServerInfo(server: Server, overwriteImage = false) {
+async function updateServerInfo(server: Server, overwriteImage = false): Promise<ServerStatRow> {
   let playerOnline: number | null = null
   let maxPlayer: number | null = null
+  // Capturer l'horodatage au moment du ping (et non en fin de cycle) pour préserver l'exactitude.
+  const createdAt = new Date()
 
   try {
     // On fait des retry pour éviter les erreurs de connexion
     const data = await retry(() => pingMinecraftJava(server.address, server.port), 3, 2000)
-    if (!data) return
+    if (!data) {
+      return { server_id: server.id, player_count: null, max_count: null, created_at: createdAt }
+    }
 
     if (data.favicon && (overwriteImage || !server.imageUrl)) {
       const filename = fileURLToPath(import.meta.url)
@@ -100,42 +114,54 @@ async function updateServerInfo(server: Server, overwriteImage = false) {
     server.version = data.version.name
     server.lastPlayerCount = playerOnline
     server.lastMaxCount = maxPlayer
-    server.lastStatsAt = DateTime.now()
+    server.lastStatsAt = DateTime.fromJSDate(createdAt)
     await server.save()
     logger.info(`SCHEDULER: Updated server ${server.name} (${server.address}:${server.port})`)
   } catch (error) {
     logger.error(
       `SCHEDULER: Failed to update server ${server.name} (${server.address}:${server.port}): ${error.message}`
     )
-  } finally {
-    const stat = await ServerStat.create({
-      playerCount: playerOnline,
-      maxCount: maxPlayer,
-    })
+  }
 
-    stat.related('server').associate(server)
-    await stat.save()
+  return {
+    server_id: server.id,
+    player_count: playerOnline,
+    max_count: maxPlayer,
+    created_at: createdAt,
   }
 }
 
 /**
- * Met à jour les serveurs par lots avec un espacement uniforme des requêtes.
+ * Insère un lot de stats en une seule requête `server_stats`.
+ * Aucune action si le batch est vide.
+ */
+async function flushStatsBatch(batch: ServerStatRow[]): Promise<void> {
+  if (batch.length === 0) return
+  await Database.table('server_stats').multiInsert(batch)
+  logger.info(`SCHEDULER: bulk-inserted ${batch.length} server_stats rows`)
+}
+
+/**
+ * Met à jour les serveurs par lots avec un espacement uniforme des requêtes réseau.
+ * L'espacement protège les serveurs Minecraft externes — il est **préservé**, seule
+ * l'écriture DB est bulkée à la fin.
  */
 async function updateServersWithUniformSpacing(totalTime = 10 * 60 * 1000) {
-  // 10 minutes en millisecondes
   const servers = await Server.all()
+  if (servers.length === 0) return
+
   const delayBetweenRequests = totalTime / servers.length
-
-  // Permet de limiter le nombre de tâches simultanées à 1 pour espacer les requêtes
   const limit = pLimit(1)
-
   const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-  // Exécute les mises à jour avec un espacement uniforme
+  const statsBatch: ServerStatRow[] = []
   for (const server of servers) {
-    await limit(() => updateServerInfo(server, false))
-    await delay(delayBetweenRequests) // Attendre entre chaque requête
+    const row = await limit(() => updateServerInfo(server, false))
+    statsBatch.push(row)
+    await delay(delayBetweenRequests)
   }
+
+  await flushStatsBatch(statsBatch)
 }
 
 // Planification avec les schedulers
@@ -149,7 +175,8 @@ scheduler
 scheduler
   .call(async () => {
     const servers = await Server.all()
-    await Promise.all(servers.map((server) => updateServerInfo(server, true)))
+    const rows = await Promise.all(servers.map((server) => updateServerInfo(server, true)))
+    await flushStatsBatch(rows)
   })
   .everySixHours()
 

--- a/backend/start/scheduler.ts
+++ b/backend/start/scheduler.ts
@@ -208,6 +208,7 @@ scheduler
       FROM server_stats
       WHERE created_at >= date_trunc('hour', now() - interval '1 hour')
         AND created_at <  date_trunc('hour', now())
+        AND server_id IS NOT NULL
       GROUP BY server_id, hour
       ON CONFLICT (server_id, hour) DO UPDATE SET
         avg_player_count = EXCLUDED.avg_player_count,

--- a/backend/start/scheduler.ts
+++ b/backend/start/scheduler.ts
@@ -155,7 +155,11 @@ scheduler
 
 scheduler
   .call(async () => {
+    const start = Date.now()
+    const serverCount = (await Server.query().count('* as total'))[0].$extras.total
     await StatsService.calculateAndStoreGrowthStats()
-    logger.info('SCHEDULER: Growth stats calculated and stored')
+    logger.info(
+      `SCHEDULER: growth_stats job completed in ${Date.now() - start}ms for ${serverCount} servers`
+    )
   })
   .everySixHours()

--- a/frontend/src/app/(pages)/blog/[slug]/page.tsx
+++ b/frontend/src/app/(pages)/blog/[slug]/page.tsx
@@ -5,6 +5,9 @@ import Image from "next/image";
 import Link from "next/link";
 import { BlogPostStructuredData } from "@/components/seo/structured-data";
 
+// ISR — chaque page d'article est rebuild en arrière-plan toutes les 10 minutes (P.4.3)
+export const revalidate = 600;
+
 type Props = {
   params: Promise<{ slug: string }>;
 };

--- a/frontend/src/app/(pages)/blog/page.tsx
+++ b/frontend/src/app/(pages)/blog/page.tsx
@@ -4,6 +4,9 @@ import { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 
+// ISR — la page est rebuild en arrière-plan toutes les heures (P.4.3)
+export const revalidate = 3600;
+
 export const metadata: Metadata = {
   title: "Blog - Minecraft Stats",
   description: "Latest news, server spotlights, and development updates.",

--- a/frontend/src/app/(pages)/servers/[serverId]/[[...serverName]]/layout.tsx
+++ b/frontend/src/app/(pages)/servers/[serverId]/[[...serverName]]/layout.tsx
@@ -2,7 +2,10 @@ import { getServer } from "@/http/server";
 import { getLastStat } from "@/utils/stats";
 import { Metadata } from "next";
 import { getDomainConfig } from "@/lib/domain-server";
-export const dynamic = "force-dynamic";
+
+// ISR — la metadata (OG, title, description) est rebuild toutes les 10 minutes
+// au lieu d'être re-fetched à chaque requête (P.4.3 ; remplace force-dynamic).
+export const revalidate = 600;
 
 export const generateMetadata = async (props: {
   params: Promise<{ serverId: string; serverName: string[] }>;

--- a/frontend/src/app/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
+++ b/frontend/src/app/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
@@ -152,7 +152,8 @@ const ServerPage = () => {
     error: serverError,
     isLoading: isServerLoading,
   } = useSWR<ServerData, Error>(`${getBaseUrl()}/servers/${serverId}`, fetcher, {
-    refreshInterval: 1000 * 60 * 2,
+    // Aligné sur le TTL Redis backend (300s) — cf. P.2.1
+    refreshInterval: 1000 * 60 * 5,
   });
 
   const [dataRangeInterval, setDataRangeInterval] = useState<TimeRangeType>("1 Week");

--- a/frontend/src/app/api/revalidate/route.ts
+++ b/frontend/src/app/api/revalidate/route.ts
@@ -1,0 +1,75 @@
+import { revalidatePath, revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * P.4.3 — On-demand revalidation pour invalider l'ISR depuis le backend
+ * (ou n'importe quel client autorisé).
+ *
+ * Auth : header `x-revalidate-token` qui doit matcher `REVALIDATE_TOKEN` (env).
+ * Si la variable d'env n'est pas configurée, la route refuse 503 (fail-closed).
+ *
+ * Body attendu (JSON) :
+ *   { path: "/blog" }                  // revalidate un path
+ *   { paths: ["/blog", "/"] }          // revalidate plusieurs paths
+ *   { tag: "servers" }                 // revalidate par tag (si utilisé)
+ *
+ * Exemple côté backend :
+ *   fetch("https://frontend/api/revalidate", {
+ *     method: "POST",
+ *     headers: { "Content-Type": "application/json", "x-revalidate-token": token },
+ *     body: JSON.stringify({ path: `/servers/${serverId}` }),
+ *   })
+ */
+export async function POST(request: NextRequest) {
+  const expected = process.env.REVALIDATE_TOKEN;
+  if (!expected) {
+    return NextResponse.json(
+      { error: "REVALIDATE_TOKEN not configured on this deployment" },
+      { status: 503 }
+    );
+  }
+
+  const provided = request.headers.get("x-revalidate-token");
+  if (provided !== expected) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: { path?: string; paths?: string[]; tag?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const revalidatedPaths: string[] = [];
+  const revalidatedTags: string[] = [];
+
+  if (body.path) {
+    revalidatePath(body.path);
+    revalidatedPaths.push(body.path);
+  }
+  if (Array.isArray(body.paths)) {
+    for (const p of body.paths) {
+      revalidatePath(p);
+      revalidatedPaths.push(p);
+    }
+  }
+  if (body.tag) {
+    revalidateTag(body.tag);
+    revalidatedTags.push(body.tag);
+  }
+
+  if (revalidatedPaths.length === 0 && revalidatedTags.length === 0) {
+    return NextResponse.json(
+      { error: "Provide `path`, `paths`, or `tag` in body" },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json({
+    revalidated: true,
+    paths: revalidatedPaths,
+    tags: revalidatedTags,
+    now: Date.now(),
+  });
+}

--- a/frontend/src/app/api/revalidate/route.ts
+++ b/frontend/src/app/api/revalidate/route.ts
@@ -1,4 +1,4 @@
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidatePath } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
 /**
@@ -11,7 +11,10 @@ import { NextRequest, NextResponse } from "next/server";
  * Body attendu (JSON) :
  *   { path: "/blog" }                  // revalidate un path
  *   { paths: ["/blog", "/"] }          // revalidate plusieurs paths
- *   { tag: "servers" }                 // revalidate par tag (si utilisé)
+ *
+ * Note : revalidation par tag non exposée ici. En Next.js 16, `revalidateTag`
+ * requiert un `CacheLifeConfig` et est restreint aux Server Actions — usage trop
+ * spécifique pour cette route générique. À implémenter séparément si besoin.
  *
  * Exemple côté backend :
  *   fetch("https://frontend/api/revalidate", {
@@ -34,7 +37,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  let body: { path?: string; paths?: string[]; tag?: string };
+  let body: { path?: string; paths?: string[] };
   try {
     body = await request.json();
   } catch {
@@ -42,7 +45,6 @@ export async function POST(request: NextRequest) {
   }
 
   const revalidatedPaths: string[] = [];
-  const revalidatedTags: string[] = [];
 
   if (body.path) {
     revalidatePath(body.path);
@@ -54,14 +56,10 @@ export async function POST(request: NextRequest) {
       revalidatedPaths.push(p);
     }
   }
-  if (body.tag) {
-    revalidateTag(body.tag);
-    revalidatedTags.push(body.tag);
-  }
 
-  if (revalidatedPaths.length === 0 && revalidatedTags.length === 0) {
+  if (revalidatedPaths.length === 0) {
     return NextResponse.json(
-      { error: "Provide `path`, `paths`, or `tag` in body" },
+      { error: "Provide `path` or `paths` in body" },
       { status: 400 }
     );
   }
@@ -69,7 +67,6 @@ export async function POST(request: NextRequest) {
   return NextResponse.json({
     revalidated: true,
     paths: revalidatedPaths,
-    tags: revalidatedTags,
     now: Date.now(),
   });
 }

--- a/frontend/src/app/client-layout.tsx
+++ b/frontend/src/app/client-layout.tsx
@@ -10,6 +10,8 @@ import { AuthProvider } from "@/contexts/auth";
 import { FavoriteProvider } from "@/contexts/favorite";
 import { ServersProvider } from "@/contexts/servers";
 import { startTransition, useEffect, useState } from "react";
+import { SWRConfig } from "swr";
+import { fetcher } from "@/app/_cheatcode";
 
 export default function ClientLayout({
   children,
@@ -29,20 +31,29 @@ export default function ClientLayout({
   }
 
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-      <AuthProvider>
-        <ServersProvider>
-          <FavoriteProvider>
-            <Header />
-            <Toaster />
-            <div className="flex-1 flex flex-col items-center justify-center text-stats-blue-1050 dark:text-stats-blue-50 bg-stats-blue-50 dark:bg-stats-blue-1050">
-              <RestrictedWidthLayout className="flex-1 flex flex-col">{children}</RestrictedWidthLayout>
-              <Metrics />
-            </div>
-            <Footer />
-          </FavoriteProvider>
-        </ServersProvider>
-      </AuthProvider>
-    </ThemeProvider>
+    <SWRConfig
+      value={{
+        fetcher,
+        revalidateOnFocus: false,
+        dedupingInterval: 60_000,
+        errorRetryCount: 2,
+      }}
+    >
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+        <AuthProvider>
+          <ServersProvider>
+            <FavoriteProvider>
+              <Header />
+              <Toaster />
+              <div className="flex-1 flex flex-col items-center justify-center text-stats-blue-1050 dark:text-stats-blue-50 bg-stats-blue-50 dark:bg-stats-blue-1050">
+                <RestrictedWidthLayout className="flex-1 flex flex-col">{children}</RestrictedWidthLayout>
+                <Metrics />
+              </div>
+              <Footer />
+            </FavoriteProvider>
+          </ServersProvider>
+        </AuthProvider>
+      </ThemeProvider>
+    </SWRConfig>
   );
 }

--- a/frontend/src/components/form/add-server-form/index.tsx
+++ b/frontend/src/components/form/add-server-form/index.tsx
@@ -12,14 +12,14 @@ import { Category, Language } from "@/types/server";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FC } from "react";
 import { useForm } from "react-hook-form";
-import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
 import { z } from "zod";
 
 interface AddServerFormProps extends React.HTMLAttributes<HTMLFormElement> {}
 
 const AddServerForm: FC<AddServerFormProps> = ({ className, ...props }) => {
-  const { data, isLoading, error } = useSWR<Category[]>(`${getBaseUrl()}/categories`, fetcher);
-  const { data: languagesData } = useSWR<Language[]>(`${getBaseUrl()}/languages`, fetcher);
+  const { data, isLoading, error } = useSWRImmutable<Category[]>(`${getBaseUrl()}/categories`, fetcher);
+  const { data: languagesData } = useSWRImmutable<Language[]>(`${getBaseUrl()}/languages`, fetcher);
 
   const categories = data || [];
   const languages = languagesData || [];

--- a/frontend/src/components/form/edit-server-form/index.tsx
+++ b/frontend/src/components/form/edit-server-form/index.tsx
@@ -14,7 +14,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { FC } from "react";
 import { useForm } from "react-hook-form";
-import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
 import { z } from "zod";
 
 interface EditServerFormProps extends React.HTMLAttributes<HTMLFormElement> {
@@ -24,11 +24,11 @@ interface EditServerFormProps extends React.HTMLAttributes<HTMLFormElement> {
 }
 
 const EditServerForm: FC<EditServerFormProps> = ({ server, serverCategories, updateServer, className, ...props }) => {
-  const { data, isLoading } = useSWR<Category[]>(`${getBaseUrl()}/categories`, fetcher);
+  const { data, isLoading } = useSWRImmutable<Category[]>(`${getBaseUrl()}/categories`, fetcher);
 
   const categories = data || [];
 
-  const { data: languagesData } = useSWR<Language[]>(`${getBaseUrl()}/languages`, fetcher);
+  const { data: languagesData } = useSWRImmutable<Language[]>(`${getBaseUrl()}/languages`, fetcher);
 
   const languages = languagesData || [];
 

--- a/frontend/src/components/home/global-insight-section.tsx
+++ b/frontend/src/components/home/global-insight-section.tsx
@@ -37,73 +37,82 @@ const GlobalInsightSection = () => {
   const [dataRangeInterval, setDataRangeInterval] = useState<TimeRangeType>("1 Week");
   const [dataAggregationInterval, setDataAggregationInterval] = useState<AggregationType>("30 Minutes");
 
-  const fetchStats = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const now = Date.now();
-      const interval = dataAggregationInterval ? AGGREGATION_INTERVALS[dataAggregationInterval] : undefined;
-      const fromDate = now - TIME_RANGE_OFFSETS[dataRangeInterval];
-      const toDate = now;
+  const fetchStats = useCallback(
+    async (signal: AbortSignal) => {
+      setIsLoading(true);
+      try {
+        const now = Date.now();
+        const interval = dataAggregationInterval ? AGGREGATION_INTERVALS[dataAggregationInterval] : undefined;
+        const fromDate = now - TIME_RANGE_OFFSETS[dataRangeInterval];
+        const toDate = now;
 
-      // Récupérer les stats globales si aucun serveur n'est sélectionné
-      if (selectedServers.length === 0) {
-        let url = `${apiUrl}/global-stats?fromDate=${fromDate}&toDate=${toDate}&interval=${interval}`;
-        if (selectedCategory) {
-          url += `&categoryId=${selectedCategory}`;
-        }
-        if (selectedLanguage) {
-          url += `&languageId=${selectedLanguage}`;
-        }
-        const response = await fetch(url);
-
-        if (!response.ok) {
-          throw new Error("Failed to fetch global stats");
-        }
-
-        const data = await response.json();
-        setGlobalStats(data);
-        setServerStats([]);
-      } else {
-        // Récupérer les stats pour chaque serveur sélectionné
-        const promises = selectedServers.map(async (serverId) => {
-          const response = await fetch(
-            `${apiUrl}/servers/${serverId}/stats?fromDate=${fromDate}&toDate=${toDate}&interval=${interval}`
-          );
+        // Récupérer les stats globales si aucun serveur n'est sélectionné
+        if (selectedServers.length === 0) {
+          let url = `${apiUrl}/global-stats?fromDate=${fromDate}&toDate=${toDate}&interval=${interval}`;
+          if (selectedCategory) {
+            url += `&categoryId=${selectedCategory}`;
+          }
+          if (selectedLanguage) {
+            url += `&languageId=${selectedLanguage}`;
+          }
+          const response = await fetch(url, { signal });
 
           if (!response.ok) {
-            throw new Error(`Failed to fetch stats for server ${serverId}`);
+            throw new Error("Failed to fetch global stats");
           }
 
-          const stats = await response.json();
+          const data = await response.json();
+          if (signal.aborted) return;
+          setGlobalStats(data);
+          setServerStats([]);
+        } else {
+          // Récupérer les stats pour chaque serveur sélectionné
+          const promises = selectedServers.map(async (serverId) => {
+            const response = await fetch(
+              `${apiUrl}/servers/${serverId}/stats?fromDate=${fromDate}&toDate=${toDate}&interval=${interval}`,
+              { signal }
+            );
 
-          // Récupérer les informations du serveur
-          const serverResponse = await fetch(`${apiUrl}/servers/${serverId}`);
-          
-          if (!serverResponse.ok) {
-            throw new Error(`Failed to fetch server ${serverId}`);
-          }
-          
-          const serverData = await serverResponse.json();
-          
-          return { 
-            server: serverData.server,
-            stats: stats 
-          };
-        });
+            if (!response.ok) {
+              throw new Error(`Failed to fetch stats for server ${serverId}`);
+            }
 
-        const results = await Promise.all(promises);
-        setGlobalStats([]);
-        setServerStats(results);
+            const stats = await response.json();
+
+            // Récupérer les informations du serveur
+            const serverResponse = await fetch(`${apiUrl}/servers/${serverId}`, { signal });
+
+            if (!serverResponse.ok) {
+              throw new Error(`Failed to fetch server ${serverId}`);
+            }
+
+            const serverData = await serverResponse.json();
+
+            return {
+              server: serverData.server,
+              stats: stats
+            };
+          });
+
+          const results = await Promise.all(promises);
+          if (signal.aborted) return;
+          setGlobalStats([]);
+          setServerStats(results);
+        }
+      } catch (error) {
+        if ((error as Error).name === "AbortError") return;
+        console.error("Error fetching stats:", error);
+      } finally {
+        if (!signal.aborted) setIsLoading(false);
       }
-    } catch (error) {
-      console.error("Error fetching stats:", error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [apiUrl, dataAggregationInterval, dataRangeInterval, selectedCategory, selectedLanguage, selectedServers]);
+    },
+    [apiUrl, dataAggregationInterval, dataRangeInterval, selectedCategory, selectedLanguage, selectedServers]
+  );
 
   useEffect(() => {
-    fetchStats();
+    const controller = new AbortController();
+    fetchStats(controller.signal);
+    return () => controller.abort();
   }, [fetchStats]);
 
   return (

--- a/frontend/src/components/home/selects/category-select.tsx
+++ b/frontend/src/components/home/selects/category-select.tsx
@@ -1,6 +1,6 @@
 import { fetcher, getBaseUrl } from "@/app/_cheatcode";
 import { Category } from "@/types/server";
-import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
 
 interface CategorySelectProps {
   value: number | null;
@@ -9,7 +9,7 @@ interface CategorySelectProps {
 }
 
 export const CategorySelect = ({ value, onChange, disabled }: CategorySelectProps) => {
-  const { data: categories } = useSWR<Category[]>(`${getBaseUrl()}/categories`, fetcher);
+  const { data: categories } = useSWRImmutable<Category[]>(`${getBaseUrl()}/categories`, fetcher);
 
   return (
     <select

--- a/frontend/src/components/home/selects/language-select.tsx
+++ b/frontend/src/components/home/selects/language-select.tsx
@@ -1,6 +1,6 @@
 import { fetcher, getBaseUrl } from "@/app/_cheatcode";
 import { Language } from "@/types/server";
-import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
 
 interface LanguageSelectProps {
   value: number | null;
@@ -9,7 +9,7 @@ interface LanguageSelectProps {
 }
 
 export const LanguageSelect = ({ value, onChange, disabled }: LanguageSelectProps) => {
-  const { data: languages } = useSWR<Language[]>(`${getBaseUrl()}/languages`, fetcher);
+  const { data: languages } = useSWRImmutable<Language[]>(`${getBaseUrl()}/languages`, fetcher);
 
   return (
     <select

--- a/frontend/src/components/home/server-cards-section.tsx
+++ b/frontend/src/components/home/server-cards-section.tsx
@@ -8,7 +8,7 @@ import { fetcher } from "@/app/_cheatcode";
 import { Input } from "@/components/ui/input";
 import { Search, X } from "lucide-react";
 import { useDebounce } from "@/hooks/use-debounce";
-import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
 import { Category, Language } from "@/types/server";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -36,8 +36,8 @@ const ServerCardsSection = () => {
   const debouncedSearch = useDebounce(search, 300);
   const apiUrl = getClientApiUrl();
 
-  const { data: categories } = useSWR<Category[]>(`${apiUrl}/categories`, fetcher);
-  const { data: languages } = useSWR<Language[]>(`${apiUrl}/languages`, fetcher);
+  const { data: categories } = useSWRImmutable<Category[]>(`${apiUrl}/categories`, fetcher);
+  const { data: languages } = useSWRImmutable<Language[]>(`${apiUrl}/languages`, fetcher);
 
   const getKey = (pageIndex: number, previousPageData: PaginatedResponse | null) => {
     if (previousPageData && previousPageData.meta.currentPage >= previousPageData.meta.lastPage) return null;

--- a/frontend/src/components/home/stats-section.tsx
+++ b/frontend/src/components/home/stats-section.tsx
@@ -24,7 +24,8 @@ const StatsSection = () => {
     `${apiUrl}/servers`,
     fetcher,
     {
-      refreshInterval: 1000 * 60 * 2, // Rafraîchir toutes les 2 minutes
+      // Aligné sur le TTL Redis backend (300s) — cf. P.2.1
+      refreshInterval: 1000 * 60 * 5,
     }
   );
 
@@ -32,7 +33,7 @@ const StatsSection = () => {
     `${apiUrl}/website-stats`,
     fetcher,
     {
-      refreshInterval: 1000 * 60 * 2,
+      refreshInterval: 1000 * 60 * 5,
     }
   );
 

--- a/frontend/src/http/server.ts
+++ b/frontend/src/http/server.ts
@@ -1,5 +1,7 @@
 import { getBaseUrl } from "@/app/_cheatcode";
 import { Category, Server, ServerStat } from "@/types/server";
+// Note: GET /api/v1/servers is a lightweight endpoint that returns only { server } (no stats/categories).
+// For richer data, use /servers/paginate or /servers/:id.
 import { getErrorMessage } from "./auth";
 
 export const addMinecraftServer = async (
@@ -35,7 +37,7 @@ export const getServers = async () => {
     throw new Error(errorMessage);
   }
 
-  return response.json() as Promise<{ server: Server; stats: ServerStat[]; categories: Category[] }[]>;
+  return response.json() as Promise<{ server: Server }[]>;
 };
 
 export const getServer = async (serverId: number) => {


### PR DESCRIPTION
This pull request introduces a Redis-based caching layer for several API endpoints, adds cache invalidation on data mutations, and provides two new database maintenance commands. The main goals are to improve API response times, reduce database load, and add operational tooling for managing server stats data. The changes also include cache header middleware for better HTTP caching control.

**API caching and invalidation:**

* Introduced `CacheService` (`backend/app/services/cache_service.ts`) providing Redis-backed `cacheOrFetch`, key invalidation, pattern invalidation, and parameter-based key hashing, with Prometheus metrics for cache hits/misses.
* Updated `CategoriesController`, `LanguagesController`, `ServersController`, and `StatsController` to use `CacheService` for caching list and stats endpoints. Cache is invalidated on category create/update/delete. [[1]](diffhunk://#diff-f977340623d5082bebcd083d110bc7a2cea388a7bd770e354fc8ab17c9a7c0deR3-R13) [[2]](diffhunk://#diff-f977340623d5082bebcd083d110bc7a2cea388a7bd770e354fc8ab17c9a7c0deR23) [[3]](diffhunk://#diff-f977340623d5082bebcd083d110bc7a2cea388a7bd770e354fc8ab17c9a7c0deR34) [[4]](diffhunk://#diff-f977340623d5082bebcd083d110bc7a2cea388a7bd770e354fc8ab17c9a7c0deR46) [[5]](diffhunk://#diff-33919af5868c71debf2db78561874db3d810de71c36977f2fb493cb62ea4c561R2-R7) [[6]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7R8-R28) [[7]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L139-R205) [[8]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L194-L209) [[9]](diffhunk://#diff-9147fed90ea70ed92ffb53997863781e39b78fbe38b086825c38bf51e060a874R1-R35) [[10]](diffhunk://#diff-9147fed90ea70ed92ffb53997863781e39b78fbe38b086825c38bf51e060a874L24-R54)

**API performance and correctness improvements:**

* Refactored `ServersController.paginate` to use parameter-based cache keys, allow cache bypass for admins/dev, and optimize server/player stats queries with batch fetching and improved ordering. [[1]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L139-R205) [[2]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L194-L209)
* Simplified `ServersController.index` endpoint to return only lightweight server info, improving performance for endpoints like sitemap and server count.

**Cache control and HTTP headers:**

* Added `cacheHeaders` middleware (`backend/app/middleware/cache_headers_middleware.ts`) for setting `Cache-Control` headers with configurable options, ensuring proper client/proxy caching behavior.

**Database maintenance commands:**

* Added `backfill:hourly-stats` command to backfill the `server_stats_hourly` table from raw stats, with support for incremental runs and custom start dates.
* Added `archive:old-partitions` command to drop old `server_stats` partitions older than a configurable threshold, with dry-run and confirmation flags for safety.