### PR TITLE
Add favorites section and enhance FancyMultiSelect component

### DIFF
--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -250,13 +250,13 @@ export default class ServersController {
 
     if (categoryIds) {
       try {
-        const ids = categoryIds
+        const categoryIdList = categoryIds
           .split(',')
           .map((id: string) => Number.parseInt(id.trim(), 10))
           .filter((id: number) => !Number.isNaN(id))
-        if (ids.length > 0) {
+        if (categoryIdList.length > 0) {
           query = query.whereHas('categories', (builder) => {
-            builder.whereIn('categories.id', ids)
+            builder.whereIn('categories.id', categoryIdList)
           })
         }
       } catch (error) {
@@ -266,13 +266,13 @@ export default class ServersController {
 
     if (languageIds) {
       try {
-        const ids = languageIds
+        const languageIdList = languageIds
           .split(',')
           .map((id: string) => Number.parseInt(id.trim(), 10))
           .filter((id: number) => !Number.isNaN(id))
-        if (ids.length > 0) {
+        if (languageIdList.length > 0) {
           query = query.whereHas('languages', (builder) => {
-            builder.whereIn('languages.id', ids)
+            builder.whereIn('languages.id', languageIdList)
           })
         }
       } catch (error) {

--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -147,12 +147,12 @@ export default class ServersController {
     const categoryIds = request.input('categoryIds')
     const languageIds = request.input('languageIds')
     const search = request.input('search', '')
-    const pinnedIdsParam = request.input('pinnedIds')
+    const idsParam = request.input('ids')
 
-    // Pinned IDs appliqués sur toutes les pages pour que le débordement (>= limit)
-    // continue d'apparaître en haut des pages suivantes. La CASE WHEN reste un
-    // no-op pour les rows non pinned, donc pas de coût significatif.
-    const pinnedIds = this.parsePinnedIds(pinnedIdsParam)
+    // `ids` restreint la requête à une liste explicite de serveurs — utilisé par
+    // la section "favoris", qui affiche les favoris de l'utilisateur dans leur
+    // propre bloc, indépendamment de la pagination classique du classement.
+    const ids = this.parseIdList(idsParam)
 
     const cacheKey = CacheService.hashParams('paginate', {
       page,
@@ -160,16 +160,16 @@ export default class ServersController {
       categoryIds,
       languageIds,
       search,
-      pinnedIds: pinnedIds.join(','),
+      ids: ids.join(','),
     })
 
     const nocache = request.input('nocache') === '1'
     const bypass =
       nocache && (process.env.NODE_ENV !== 'production' || ctx.auth?.user?.role === 'admin')
 
-    // TTL réduit quand la requête est personnalisée — la fragmentation cache
-    // coûte moins en stockage, et les stats changent toutes les 10 min de toute façon.
-    const ttl = pinnedIds.length > 0 ? 30 : 60
+    // TTL réduit quand la requête est personnalisée (favoris) — la fragmentation
+    // cache coûte moins en stockage, et les stats changent toutes les 10 min.
+    const ttl = ids.length > 0 ? 30 : 60
 
     return CacheService.cacheOrFetch(
       cacheKey,
@@ -181,7 +181,7 @@ export default class ServersController {
           categoryIds,
           languageIds,
           search,
-          pinnedIds,
+          ids,
         })
         return result
       },
@@ -189,9 +189,9 @@ export default class ServersController {
     )
   }
 
-  private static readonly MAX_PINNED_IDS = 20
+  private static readonly MAX_IDS = 20
 
-  private parsePinnedIds(raw: unknown): number[] {
+  private parseIdList(raw: unknown): number[] {
     if (typeof raw !== 'string' || raw.length === 0) return []
     const ids: number[] = []
     const seen = new Set<number>()
@@ -200,7 +200,7 @@ export default class ServersController {
       if (!Number.isInteger(n) || n <= 0 || seen.has(n)) continue
       seen.add(n)
       ids.push(n)
-      if (ids.length >= ServersController.MAX_PINNED_IDS) break
+      if (ids.length >= ServersController.MAX_IDS) break
     }
     return ids
   }
@@ -211,9 +211,9 @@ export default class ServersController {
     categoryIds?: string
     languageIds?: string
     search: string
-    pinnedIds: number[]
+    ids: number[]
   }) {
-    const { page, limit, categoryIds, languageIds, search, pinnedIds } = opts
+    const { page, limit, categoryIds, languageIds, search, ids } = opts
 
     // Ordering : on ne classe par `last_player_count` que si le dernier ping
     // réussi est récent (< 30 min, soit ~3 cycles de 10 min). Sinon le serveur
@@ -226,11 +226,10 @@ export default class ServersController {
       .preload('growthStat')
       .preload('languages')
 
-    // Priorité aux favoris en page 1 : `IN (?,?,...)` avec bindings explicites,
-    // donc safe même si les IDs venaient d'une source moins fiable.
-    if (pinnedIds.length > 0) {
-      const placeholders = pinnedIds.map(() => '?').join(',')
-      query = query.orderByRaw(`CASE WHEN id IN (${placeholders}) THEN 0 ELSE 1 END`, pinnedIds)
+    // Restriction à une liste explicite d'IDs (section favoris) : `whereIn` avec
+    // bindings, donc safe même si les IDs venaient d'une source moins fiable.
+    if (ids.length > 0) {
+      query = query.whereIn('id', ids)
     }
 
     query = query

--- a/frontend/src/app/(pages)/(index)/page.tsx
+++ b/frontend/src/app/(pages)/(index)/page.tsx
@@ -1,6 +1,7 @@
 import HeroSection from "@/components/home/hero-section";
 import GlobalInsightSection from "@/components/home/global-insight-section";
 import LatestArticlesSection from "@/components/home/latest-articles-section";
+import FavoritesSection from "@/components/home/favorites-section";
 import ServerCardsSection from "@/components/home/server-cards-section";
 import StatsSection from "@/components/home/stats-section";
 import { OrganizationStructuredData, WebsiteStructuredData } from "@/components/seo/structured-data";
@@ -27,6 +28,7 @@ const Home = () => {
         <StatsSection />
         <GlobalInsightSection />
         <LatestArticlesSection />
+        <FavoritesSection />
         <ServerCardsSection />
       </main>
     </>

--- a/frontend/src/components/home/favorites-section.tsx
+++ b/frontend/src/components/home/favorites-section.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import useSWR from "swr";
+import { useMemo } from "react";
+import { Icon } from "@iconify/react/dist/iconify.js";
+import ServerCard from "@/components/serveur/card";
+import { ServerData } from "@/app/(pages)/(index)/page";
+import { fetcher } from "@/app/_cheatcode";
+import { Skeleton } from "@/components/ui/skeleton";
+import { getClientApiUrl } from "@/lib/domain";
+import { MAX_FAVORITES, useFavorite } from "@/contexts/favorite";
+
+interface PaginatedResponse {
+  data: ServerData[];
+  meta: {
+    total: number;
+    perPage: number;
+    currentPage: number;
+    lastPage: number;
+  };
+}
+
+// Bloc dédié aux serveurs favoris, affiché en haut de la liste des serveurs et
+// indépendant de la pagination du classement. Limité à MAX_FAVORITES serveurs.
+// Les favoris peuvent donc aussi apparaître plus bas dans le classement : c'est
+// volontaire, on garde le classement intact.
+const FavoritesSection = () => {
+  const apiUrl = getClientApiUrl();
+  const { favorites, hydrated } = useFavorite();
+
+  // Clé SWR basée sur l'ensemble trié des IDs : tant que l'ensemble des favoris
+  // ne change pas, la clé reste stable (pas de refetch superflu).
+  const idsKey = useMemo(() => [...favorites].sort((a, b) => a - b).join(","), [favorites]);
+
+  const { data, isLoading } = useSWR<PaginatedResponse>(
+    hydrated && idsKey.length > 0
+      ? `${apiUrl}/servers/paginate?page=1&limit=${MAX_FAVORITES}&ids=${idsKey}`
+      : null,
+    fetcher,
+    { keepPreviousData: true }
+  );
+
+  // Filtrage côté client par l'ensemble courant des favoris : retirer une étoile
+  // fait disparaître la carte immédiatement, sans attendre le refetch.
+  const favSet = useMemo(() => new Set(favorites), [favorites]);
+  const servers = useMemo(
+    () => (data?.data ?? []).filter((item) => item?.server && favSet.has(item.server.id)),
+    [data?.data, favSet]
+  );
+
+  // Avant hydratation du localStorage ou sans favori : on n'affiche pas le bloc.
+  if (!hydrated || favorites.length === 0) return null;
+
+  return (
+    <section id="favorites-section" className="w-full scroll-mt-8 space-y-4">
+      <div className="flex items-center gap-2">
+        <div className="flex h-7 w-7 items-center justify-center rounded-md bg-accent/10 text-accent">
+          <Icon icon="material-symbols:star-rounded" className="h-4 w-4" />
+        </div>
+        <h2 className="text-lg font-semibold text-foreground">Your favorites</h2>
+        <span className="text-xs font-medium text-muted-foreground">
+          {favorites.length}/{MAX_FAVORITES}
+        </span>
+      </div>
+
+      {isLoading && servers.length === 0 ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: Math.min(favorites.length, 6) }).map((_, i) => (
+            <Skeleton key={i} className="h-44 w-full rounded-md" />
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {servers.map((item) => (
+            <ServerCard
+              key={item.server.id}
+              server={item.server}
+              stats={item.stats}
+              categories={item.categories}
+              growthStat={item.growthStat}
+              isFull={false}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default FavoritesSection;

--- a/frontend/src/components/home/server-cards-section.tsx
+++ b/frontend/src/components/home/server-cards-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import useSWR from "swr";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Icon } from "@iconify/react/dist/iconify.js";
 import ServerCard from "@/components/serveur/card";
 import { ServerData } from "@/app/(pages)/(index)/page";
@@ -17,7 +17,6 @@ import { Pagination } from "@/components/ui/pagination";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getClientApiUrl } from "@/lib/domain";
-import { useFavorite } from "@/contexts/favorite";
 
 const PAGE_SIZE_OPTIONS = [12, 24, 36, 48] as const;
 const DEFAULT_PAGE_SIZE = 24;
@@ -40,21 +39,6 @@ const ServerCardsSection = () => {
   const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
   const debouncedSearch = useDebounce(search, 300);
   const apiUrl = getClientApiUrl();
-  const { favorites, hydrated: favoritesHydrated } = useFavorite();
-
-  // Snapshot des pinned IDs envoyés au backend. Ne suit pas `favorites` en temps réel —
-  // sinon un simple toggle changerait la clé SWR et déclencherait un full refetch.
-  // Le snapshot ne se rafraîchit que sur:
-  //   1) hydratation initiale des favoris depuis le localStorage
-  //   2) changement de page/pageSize/filtre (= nouvelle requête de toute façon)
-  // Le réordonnancement visuel des favoris se fait côté client via `orderedServers`.
-  const [pinnedSnapshot, setPinnedSnapshot] = useState<number[]>([]);
-
-  useEffect(() => {
-    if (!favoritesHydrated) return;
-    setPinnedSnapshot([...favorites].sort((a, b) => a - b));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [favoritesHydrated, currentPage, pageSize, debouncedSearch, selectedCategories, selectedLanguages]);
 
   const { data: categories } = useSWRImmutable<Category[]>(`${apiUrl}/categories`, fetcher);
   const { data: languages } = useSWRImmutable<Language[]>(`${apiUrl}/languages`, fetcher);
@@ -62,10 +46,9 @@ const ServerCardsSection = () => {
   const searchParam = debouncedSearch ? `&search=${encodeURIComponent(debouncedSearch)}` : "";
   const categoriesParam = selectedCategories.length > 0 ? `&categoryIds=${selectedCategories.join(",")}` : "";
   const languagesParam = selectedLanguages.length > 0 ? `&languageIds=${selectedLanguages.join(",")}` : "";
-  const pinnedParam = pinnedSnapshot.length > 0 ? `&pinnedIds=${pinnedSnapshot.join(",")}` : "";
 
   const { data, isValidating, isLoading } = useSWR<PaginatedResponse>(
-    `${apiUrl}/servers/paginate?page=${currentPage}&limit=${pageSize}${searchParam}${categoriesParam}${languagesParam}${pinnedParam}`,
+    `${apiUrl}/servers/paginate?page=${currentPage}&limit=${pageSize}${searchParam}${categoriesParam}${languagesParam}`,
     fetcher,
     { keepPreviousData: true }
   );
@@ -73,22 +56,6 @@ const ServerCardsSection = () => {
   const servers = useMemo(() => data?.data ?? [], [data?.data]);
   const totalServers = data?.meta?.total ?? 0;
   const totalPages = data?.meta?.lastPage ?? 1;
-
-  // Reorder live: favoris en premier dans la page courante. Préserve l'ordre
-  // relatif renvoyé par le backend dans chaque groupe. Le `[overflow-anchor:none]`
-  // sur le grid empêche le navigateur d'ajuster scrollY pour suivre la carte
-  // déplacée (sinon la page paraît scroller vers le haut au toggle).
-  const orderedServers = useMemo(() => {
-    if (favorites.length === 0 || servers.length === 0) return servers;
-    const favSet = new Set(favorites);
-    const pinned: typeof servers = [];
-    const rest: typeof servers = [];
-    for (const item of servers) {
-      if (item?.server && favSet.has(item.server.id)) pinned.push(item);
-      else rest.push(item);
-    }
-    return [...pinned, ...rest];
-  }, [servers, favorites]);
 
   // Chaque changement de filtre remet la pagination à 1.
   const updateSearch = (value: string) => {
@@ -249,11 +216,10 @@ const ServerCardsSection = () => {
         <div
           className={cn(
             "grid grid-cols-1 gap-4 transition-opacity duration-200 sm:grid-cols-2 lg:grid-cols-3",
-            "[overflow-anchor:none] [&>*]:[overflow-anchor:none]",
             isFetching && "opacity-60"
           )}
         >
-          {orderedServers
+          {servers
             .filter((item) => item?.server)
             .map((item) => (
               <ServerCard

--- a/frontend/src/components/home/server-cards-section.tsx
+++ b/frontend/src/components/home/server-cards-section.tsx
@@ -97,66 +97,65 @@ const ServerCardsSection = () => {
 
   return (
     <section id="server-cards-section" className="w-full scroll-mt-8 space-y-6">
-      <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm">
-        <div className="flex flex-col gap-2 border-b border-border px-6 py-5">
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              <div className="flex h-7 w-7 items-center justify-center rounded-md bg-accent/10 text-accent">
-                <Icon icon="material-symbols:search" className="h-4 w-4" />
-              </div>
-              <h2 className="text-lg font-semibold text-foreground">Browse Servers</h2>
+      <div className="space-y-3">
+        {/* En-tête slim : titre + compteur sur une seule ligne, sans description. */}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <div className="flex h-7 w-7 items-center justify-center rounded-md bg-accent/10 text-accent">
+              <Icon icon="material-symbols:search" className="h-4 w-4" />
             </div>
-            {totalServers > 0 && (
-              <span className="text-xs font-medium text-muted-foreground">
-                {new Intl.NumberFormat("en-US").format(totalServers)} tracked
-              </span>
-            )}
+            <h2 className="text-lg font-semibold text-foreground">Browse Servers</h2>
           </div>
-          <p className="text-sm text-muted-foreground">
-            Find a server by name, IP, category or language.
-          </p>
+          {totalServers > 0 && (
+            <span className="text-xs font-medium text-muted-foreground">
+              {new Intl.NumberFormat("en-US").format(totalServers)} tracked
+            </span>
+          )}
         </div>
 
-        <div className="space-y-4 p-6">
+        {/* Barre d'outils compacte : recherche + filtres + clear sur une ligne. */}
+        <div className="flex flex-col gap-2 rounded-xl border border-border bg-card p-2 sm:flex-row sm:items-center">
           <FancyMultiSelect
             searchOnly
             placeholder="Search by name or IP..."
             onSearch={updateSearch}
             searchValue={search}
-            className="w-full"
+            className="sm:flex-1"
           />
 
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="flex items-center gap-2">
             <FancyMultiSelect
+              compact
               options={categories?.map((cat) => ({ id: cat.id, name: cat.name })) ?? []}
               selectedIds={selectedCategories}
               onChange={updateCategories}
-              placeholder="All categories"
+              placeholder="Categories"
               searchPlaceholder="Search categories..."
               emptyMessage="No categories found."
+              className="flex-1 sm:flex-none"
             />
             <FancyMultiSelect
+              compact
               options={languages?.map((lang) => ({ id: lang.id, name: lang.name, flag: lang.flag })) ?? []}
               selectedIds={selectedLanguages}
               onChange={updateLanguages}
-              placeholder="All languages"
+              placeholder="Languages"
               searchPlaceholder="Search languages..."
               emptyMessage="No languages found."
+              className="flex-1 sm:flex-none"
             />
-          </div>
-
-          <div className="flex justify-end">
             <Button
               variant="ghost"
-              size="sm"
+              size="icon"
               onClick={clearFilters}
+              aria-label="Clear filters"
+              title="Clear filters"
               className={cn(
-                "text-muted-foreground hover:text-foreground transition-opacity",
+                "shrink-0 text-muted-foreground hover:text-foreground transition-opacity",
                 hasActiveFilters ? "opacity-100" : "opacity-0 pointer-events-none"
               )}
             >
-              <X className="h-3.5 w-3.5 mr-1.5" />
-              Clear filters
+              <X className="h-4 w-4" />
             </Button>
           </div>
         </div>

--- a/frontend/src/components/ui/fancy-multi-select.tsx
+++ b/frontend/src/components/ui/fancy-multi-select.tsx
@@ -25,6 +25,7 @@ interface FancyMultiSelectProps {
   searchOnly?: boolean;
   onSearch?: (value: string) => void;
   searchValue?: string;
+  compact?: boolean;
 }
 
 export const FancyMultiSelect = ({
@@ -39,6 +40,7 @@ export const FancyMultiSelect = ({
   searchOnly = false,
   onSearch,
   searchValue,
+  compact = false,
 }: FancyMultiSelectProps) => {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -89,6 +91,68 @@ export const FancyMultiSelect = ({
     );
   }
 
+  const popoverContent = (
+    <PopoverContent className="w-full p-0" align="start">
+      <Command>
+        <CommandInput placeholder={searchPlaceholder} value={search} onValueChange={setSearch} />
+        <CommandEmpty>{emptyMessage}</CommandEmpty>
+        <CommandGroup>
+          <CommandItem
+            onSelect={() => {
+              onChange([]);
+              setOpen(false);
+            }}
+            className="cursor-pointer"
+          >
+            <Check className={cn("mr-2 h-4 w-4", selectedIds.length === 0 ? "opacity-100" : "opacity-0")} />
+            {placeholder}
+          </CommandItem>
+          {displayedOptions.map((option) => (
+            <CommandItem
+              key={option.id}
+              onSelect={() => {
+                handleToggle(option.id);
+                setOpen(false);
+              }}
+              className="cursor-pointer"
+            >
+              <Check
+                className={cn("mr-2 h-4 w-4", selectedIds.includes(option.id) ? "opacity-100" : "opacity-0")}
+              />
+              {option.flag && <span className="mr-1">{option.flag}</span>}
+              {option.name}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </Command>
+    </PopoverContent>
+  );
+
+  // Variante compacte : bouton dimensionné au contenu, sans la zone de badges
+  // en dessous. Le nombre de filtres actifs s'affiche dans le bouton lui-même.
+  if (compact) {
+    return (
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            aria-label={placeholder}
+            className={cn("justify-between gap-2", className)}
+            disabled={disabled}
+          >
+            <span className="truncate">
+              {selectedIds.length === 0 ? placeholder : `${placeholder} (${selectedIds.length})`}
+            </span>
+            <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        {popoverContent}
+      </Popover>
+    );
+  }
+
   return (
     <div className={cn("space-y-2", className)}>
       <Popover open={open} onOpenChange={setOpen}>
@@ -105,40 +169,7 @@ export const FancyMultiSelect = ({
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-full p-0" align="start">
-          <Command>
-            <CommandInput placeholder={searchPlaceholder} value={search} onValueChange={setSearch} />
-            <CommandEmpty>{emptyMessage}</CommandEmpty>
-            <CommandGroup>
-              <CommandItem
-                onSelect={() => {
-                  onChange([]);
-                  setOpen(false);
-                }}
-                className="cursor-pointer"
-              >
-                <Check className={cn("mr-2 h-4 w-4", selectedIds.length === 0 ? "opacity-100" : "opacity-0")} />
-                {placeholder}
-              </CommandItem>
-              {displayedOptions.map((option) => (
-                <CommandItem
-                  key={option.id}
-                  onSelect={() => {
-                    handleToggle(option.id);
-                    setOpen(false);
-                  }}
-                  className="cursor-pointer"
-                >
-                  <Check
-                    className={cn("mr-2 h-4 w-4", selectedIds.includes(option.id) ? "opacity-100" : "opacity-0")}
-                  />
-                  {option.flag && <span className="mr-1">{option.flag}</span>}
-                  {option.name}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </Command>
-        </PopoverContent>
+        {popoverContent}
       </Popover>
 
       <div className="flex flex-wrap gap-2 min-h-[1.75rem]">

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,0 +1,4 @@
+# Memory Index
+
+- [Deployment setup](deployment-setup.md) — déployé via Dokploy ; les NEXT_PUBLIC_* sont des build args et exigent un rebuild
+- [Analytics setup](analytics-setup.md) — GA4 via GTM ; bon ID de mesure = G-MV3LTQ1TF6 (G-V88FF5BD5J est invalide)

--- a/memory/analytics-setup.md
+++ b/memory/analytics-setup.md
@@ -1,0 +1,16 @@
+---
+name: analytics-setup
+description: Comment l'analytics (GA4, GTM, Clarity, Umami) est branché sur Minecraft Stats
+metadata:
+  type: project
+---
+
+Le tracking du site est branché ainsi :
+
+- **GTM** : conteneur `GTM-TK8SWP7K`, chargé sur `minecraft-stats.fr` ET `.com` via `<GoogleTagManager>` dans `frontend/src/app/layout.tsx`. Variable `NEXT_PUBLIC_GOOGLE_TAG_MANAGER` (build arg Dokploy — voir [[deployment-setup]]).
+- **GA4** : piloté depuis GTM (balise « GA4 - Google tag »). ⚠️ Le bon ID de mesure est **`G-MV3LTQ1TF6`**. `G-V88FF5BD5J` est un mauvais ID (renvoie 404 sur `gtag/js`) — ne plus jamais l'utiliser.
+- `NEXT_PUBLIC_GOOGLE_ANALYTICS` dans le `.env` = variable **morte**, aucun code ne l'utilise (le `<GoogleAnalytics>` a été retiré du code il y a des mois).
+- **TarteAuCitron** : était une balise HTML dans GTM (consentement + AdSense `pub-8187816142581559`) ; mise **en pause** dans GTM.
+- **Microsoft Clarity** (`microsoft-clarity.tsx`) et **Umami** (`umami-script.tsx`) sont chargés en direct dans le code, hors GTM.
+
+Objectif en cours : séparer les stats `.fr` vs `.com` dans GA4 via la dimension `Hostname` (1 flux unique, comparaisons enregistrées).

--- a/memory/deployment-setup.md
+++ b/memory/deployment-setup.md
@@ -1,0 +1,13 @@
+---
+name: deployment-setup
+description: How the Minecraft Stats frontend and backend are deployed (Dokploy)
+metadata:
+  type: project
+---
+
+Le projet est déployé via **Dokploy** (instance auto-hébergée sur `dokploy.gablandry.com`).
+
+- **Backend** : workflow `.github/workflows/deploy-backend.yml` → build l'image `sportek/minecraft-stats-back`, push sur Docker Hub, puis déclenche un déploiement Dokploy via `compose.deploy` API.
+- **Frontend** : pas de workflow GitHub dédié — déployé directement par Dokploy à partir du repo + `frontend/Dockerfile`.
+
+⚠️ Les variables `NEXT_PUBLIC_*` sont injectées **au moment du build** (ARG → ENV dans le Dockerfile). Elles doivent être configurées dans l'onglet **Environment** de l'application frontend dans Dokploy, et un **rebuild/redéploiement** est requis pour qu'un changement prenne effet — un simple restart ne suffit pas. `.env.local` est gitignored et ne sert qu'au dev local.


### PR DESCRIPTION
This pull request introduces a dedicated "Favorites" section to the homepage, allowing users to view their favorite servers in a separate block above the main server list. It also simplifies the backend and frontend logic by removing the old "pinned" server handling, and updates the filtering UI for a more compact and user-friendly experience.

**Favorites feature and backend API changes:**
* Added a new `FavoritesSection` component that displays the user's favorite servers independently of the main paginated server list. It fetches only the selected favorites and updates instantly when favorites change. [[1]](diffhunk://#diff-8de2668cecbea61f2c9c05dd1adfafb0bb85a833f86845352334175fa8ed5fffR1-R90) [[2]](diffhunk://#diff-16bdd53f69077dd9b37765a5e0235bfa600aff6f4e473ef1a28028a704af6be6R4) [[3]](diffhunk://#diff-16bdd53f69077dd9b37765a5e0235bfa600aff6f4e473ef1a28028a704af6be6R31)
* Updated the backend API in `ServersController` to support an explicit `ids` parameter (replacing `pinnedIds`), which restricts queries to a provided list of server IDs—used for the new favorites section. The query logic and cache handling are updated accordingly. [[1]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L150-R172) [[2]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L184-R194) [[3]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L203-R203) [[4]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L214-R216) [[5]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L229-R232)

**Server list and filtering UI improvements:**
* Removed all "pinned" logic from the main server cards section, as favorites are now handled in their own block. The main list no longer reorders or highlights favorites. [[1]](diffhunk://#diff-688de21caeba7c06613936305e1fa58c868b9359c70dc517a91736a1de4285cbL4-R4) [[2]](diffhunk://#diff-688de21caeba7c06613936305e1fa58c868b9359c70dc517a91736a1de4285cbL20) [[3]](diffhunk://#diff-688de21caeba7c06613936305e1fa58c868b9359c70dc517a91736a1de4285cbL43-R51) [[4]](diffhunk://#diff-688de21caeba7c06613936305e1fa58c868b9359c70dc517a91736a1de4285cbL77-L92) [[5]](diffhunk://#diff-688de21caeba7c06613936305e1fa58c868b9359c70dc517a91736a1de4285cbL252-R221)
* Refactored and compacted the server filtering UI: filters and search are now displayed in a single, streamlined row with improved button styles and accessibility. [[1]](diffhunk://#diff-688de21caeba7c06613936305e1fa58c868b9359c70dc517a91736a1de4285cbL133-R101) [[2]](diffhunk://#diff-688de21caeba7c06613936305e1fa58c868b9359c70dc517a91736a1de4285cbL148-R158)
* Added a `compact` prop to `FancyMultiSelect` to support the new compact filter layout. [[1]](diffhunk://#diff-7367af4134951fc74a37cdc51e635adad775fd4c95fbe382a4cfe5c43f469ca5R28) [[2]](diffhunk://#diff-7367af4134951fc74a37cdc51e635adad775fd4c95fbe382a4cfe5c43f469ca5R43) [[3]](diffhunk://#diff-7367af4134951fc74a37cdc51e635adad775fd4c95fbe382a4cfe5c43f469ca5L92-R94)

**Other minor fixes:**
* Improved variable naming for clarity in category and language ID handling in the backend. [[1]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L254-R259) [[2]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L270-R275)

These changes collectively improve the user experience by making favorites more visible and simplifying the codebase.