### PR TITLE
Improve ad preview by removing injected CSS and clarifying documentation

### DIFF
--- a/frontend/src/components/ads/ad-preview.tsx
+++ b/frontend/src/components/ads/ad-preview.tsx
@@ -10,19 +10,15 @@ interface AdPreviewProps {
  * Utilisé pour la prévisualisation dans le panel admin.
  */
 const AdPreview = ({ htmlContent, className }: AdPreviewProps) => {
-  const reset =
-    "*{box-sizing:border-box}html,body{margin:0;padding:0;width:100%;height:100%;overflow:hidden}";
-  const srcDoc = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${reset}</style></head><body>${htmlContent}</body></html>`;
+  // Aucun CSS injecté : rendu identique à l'affichage réel sur le site.
+  const srcDoc = `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>${htmlContent}</body></html>`;
 
   return (
     <iframe
       title="Prévisualisation de la publicité"
       srcDoc={srcDoc}
       sandbox=""
-      className={
-        className ??
-        "block h-[130px] w-full rounded-lg border border-gray-300 bg-white dark:border-stats-blue-700 dark:bg-stats-blue-900"
-      }
+      className={className ?? "block h-[130px] w-full"}
     />
   );
 };

--- a/frontend/src/components/ads/ad-slot.tsx
+++ b/frontend/src/components/ads/ad-slot.tsx
@@ -70,11 +70,8 @@ function buildSrcDoc(
     anchor.setAttribute("rel", "noopener noreferrer nofollow sponsored");
   });
 
-  const reset =
-    "*{box-sizing:border-box}html,body{margin:0;padding:0;width:100%;height:100%;overflow:hidden}";
-
-  return `<!DOCTYPE html><html><head><meta charset="utf-8">
-<style>${reset}</style>${doc.head.innerHTML}</head><body>${doc.body.innerHTML}</body></html>`;
+  // Aucun CSS injecté : la publicité contrôle entièrement son propre rendu.
+  return `<!DOCTYPE html><html><head><meta charset="utf-8">${doc.head.innerHTML}</head><body>${doc.body.innerHTML}</body></html>`;
 }
 
 /**
@@ -127,7 +124,7 @@ const AdSlot = ({ placement, serverId, serverCategoryIds, className }: AdSlotPro
         srcDoc={srcDoc}
         sandbox="allow-popups allow-popups-to-escape-sandbox"
         loading="lazy"
-        className="block h-[110px] w-full rounded-lg border border-border bg-card sm:h-[130px]"
+        className="block h-[110px] w-full sm:h-[130px]"
       />
     </div>
   );

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -2,3 +2,5 @@
 
 - [Deployment setup](deployment-setup.md) — déployé via Dokploy ; les NEXT_PUBLIC_* sont des build args et exigent un rebuild
 - [Analytics setup](analytics-setup.md) — GA4 via GTM ; bon ID de mesure = G-MV3LTQ1TF6 (G-V88FF5BD5J est invalide)
+- [Plan système de publicités](advertising-feature-plan.md) — feature pubs maison + panel admin + stats, phasée
+- [Créer une publicité](advertising-ad-creation-steps.md) — étapes + conventions HTML/CSS pour ajouter une pub dans le panel admin

--- a/memory/advertising-ad-creation-steps.md
+++ b/memory/advertising-ad-creation-steps.md
@@ -1,0 +1,31 @@
+---
+name: advertising-ad-creation-steps
+description: Étapes et conventions pour créer une publicité dans le panel admin (HTML/CSS, emplacements, tracking)
+metadata:
+  type: reference
+---
+
+Guide pour créer une publicité dans Minecraft Stats. Voir [[advertising-feature-plan]] pour l'architecture.
+
+**Étapes**
+1. Menu utilisateur → « Manage advertisements » (visible pour le rôle `admin` uniquement) → page `/admin/advertisements`.
+2. « Nouvelle publicité ».
+3. **Nom** : libellé interne (non affiché aux visiteurs).
+4. **Code HTML / CSS** : voir conventions ci-dessous.
+5. **Emplacements** : cocher Page d'accueil et/ou Pages des serveurs (au moins un).
+6. **Ciblage par catégorie** (si pages serveur) : aucune catégorie = toutes les pages serveur ; sinon la pub ne s'affiche que pour les catégories cochées.
+7. **Poids** : entier 1–1000, rotation pondérée (poids élevé = affichée plus souvent face aux autres pubs).
+8. **Début / Fin** : planification optionnelle (datetime-local). Vide = pas de borne.
+9. Vérifier la **prévisualisation** (affichée à la largeur réelle du site).
+10. Cocher **Activer** puis créer. Suivi des vues/clics/CTR via l'icône stats dans la liste.
+
+**Conventions HTML/CSS impératives**
+- La pub est rendue dans une **iframe sandboxée SANS `allow-scripts`** : aucun JavaScript ne s'exécute (`<script>`, `onclick`… sont inertes). HTML + CSS uniquement.
+- Le CSS va dans une balise `<style>` ; il est totalement isolé (ne peut pas casser le site).
+- **Aucun CSS n'est injecté** par le système : la pub contrôle tout. Elle doit donc inclure son propre reset (`* { margin: 0 }` / `html, body { margin: 0; height: 100% }`) et, si on veut des coins arrondis ou une bordure, les définir elle-même. L'iframe et son conteneur n'ajoutent ni bordure ni `border-radius`.
+- **Toute la bannière doit être un seul `<a href="https://...">`** englobant le contenu → 1 lien = 1 clic tracké. Plusieurs `<a>` = plusieurs liens trackés séparément.
+- Le `href` doit être en **http(s)**, sur **une seule ligne, sans retour ni espace au milieu** de l'URL (un saut de ligne casse le lien de parrainage ; le backend ne plante plus mais le lien serait erroné).
+- Les liens `<a href>` sont réécrits automatiquement vers l'endpoint de redirection traquée — ne pas le faire soi-même.
+- Dimensions du slot : pleine largeur du contenu (~1120px desktop) × 130px desktop / 110px mobile. Concevoir responsive (media queries dans le `<style>`), élément racine en `height:100%` pour remplir le slot.
+- Privilégier du CSS pur (dégradés, texte) plutôt que des images externes pour la robustesse ; les images hotlinkées restent possibles.
+- Champ `type` = 'custom' (pubs maison). Le type 'network' (AdSense/régies, rendu inline) est réservé à la Phase 2.

--- a/memory/advertising-feature-plan.md
+++ b/memory/advertising-feature-plan.md
@@ -1,0 +1,32 @@
+---
+name: advertising-feature-plan
+description: Plan validé du système de publicités (pubs maison + panel admin + stats)
+metadata:
+  type: project
+---
+
+Système de publicités à construire. Plan validé par le user le 2026-05-16.
+
+**Phasage**
+- Phase 1 : IMPLÉMENTÉE le 2026-05-16 (pubs maison HTML/CSS de bout en bout). Migrations à exécuter : `node ace migration:run`.
+- Phase 2 (plus tard) : couche réseau (snippet générique AdSense/Media.net/etc. rendu inline) + ID éditeur + consentement RGPD. Le champ `type` ('custom'|'network') existe déjà.
+
+**DB (3 migrations, préfixe 1778400000000+)**
+- `advertisements` : name, type ('custom'|'network', défaut 'custom'), html_content, enabled, weight (pondération), show_on_home + show_on_server (booléens — choix pragmatique vs table pivot), starts_at/ends_at (nullable, planification), timestamps.
+- `advertisement_categories` : pivot vers `categories`. Vide = toutes catégories ; sinon filtre sur pages serveur.
+- `advertisement_events` : log complet — advertisement_id, type ('impression'|'click'), placement, server_id (nullable), target_url (nullable), created_at.
+
+**Backend** : modèles `Advertisement`/`AdvertisementEvent`, `AdvertisementsController` (public: index?placement, impression POST, click GET→302 ; admin: adminIndex/store/update/destroy/stats), `AdvertisementPolicy` (admin only, calquée sur posts). Routes admin dans le groupe `admin` existant. SÉCURITÉ : l'endpoint `click` valide que l'URL `to` fait partie des liens du HTML de la pub (anti open-redirect), retire les caractères de contrôle et normalise via `new URL()` ; le tracking d'évènements est en try/catch (best-effort, ne casse jamais la redirection).
+
+**Frontend** : `src/http/advertisement.ts`, composant `<AdSlot placement="home|server" />` (random pondéré client-side via weight, rendu en `<iframe srcDoc sandbox>` pour isoler le CSS, réécriture des `<a href>` vers /ads/:id/click, beacon impression via sendBeacon). Slot sur `(index)` et `servers/[serverId]`. Panel admin `admin/advertisements` calqué sur `admin/posts` : CRUD, toggle, prévisualisation live (même iframe), vue stats par pub (AG Charts vues vs clics + CTR).
+
+**Décisions tranchées par le user**
+- Rendu HTML pubs maison : iframe sandboxée.
+- Stats : log d'événements complet.
+- Tracking clics : réécriture des liens vers endpoint redirect.
+- Fonctions avancées : planification dates, pondération, ciblage par catégorie.
+- Pubs réseau : phase 2, snippet générique, impressions seulement côté site.
+- Dimensions slot : le slot occupe toute la largeur de contenu du site (RestrictedWidthLayout = max-w-6xl px-4 ≈ 1120px utiles). Iframe haute de 130px desktop / 110px mobile.
+- Dédup impressions : 1 impression max par pub / session / **5 min**.
+
+Patron de référence dans le repo : module Blog (`posts`) — controller, policy, routes groupe `admin`, pages `admin/posts`. Rôles user : 'admin'|'writer'|'user'. Pubs = admin only. Voir [[advertising-ad-creation-steps]] pour le mode d'emploi.


### PR DESCRIPTION
This pull request finalizes the implementation of the custom advertising system, clarifies the conventions for ad creation, and updates the frontend to ensure ads are rendered in a fully isolated environment. The main changes include removing injected CSS resets from ad iframes (giving advertisers full control over styles), simplifying iframe styling, and adding detailed documentation for both the system plan and ad creation steps.

**Frontend rendering changes:**

* Removed injected CSS resets from the ad preview (`ad-preview.tsx`) and ad slot (`ad-slot.tsx`) components, so advertisements are rendered without any system-imposed styles. This ensures the ad's HTML/CSS is displayed exactly as authored, matching real site conditions. [[1]](diffhunk://#diff-e505cf0544247a9fdc36d17ad996dab750a222e61f3094b14bfabd735b396a46L13-R21) [[2]](diffhunk://#diff-db91825378feaad3ec5b85a7d4966c296d617d5f1b54e29f65040446ce7e8256L73-R74)
* Simplified default iframe and container styling in both the ad preview and ad slot components, removing borders, border-radius, and background color so that all visual aspects are controlled by the ad itself. [[1]](diffhunk://#diff-e505cf0544247a9fdc36d17ad996dab750a222e61f3094b14bfabd735b396a46L13-R21) [[2]](diffhunk://#diff-db91825378feaad3ec5b85a7d4966c296d617d5f1b54e29f65040446ce7e8256L130-R127)

**Documentation updates:**

* Added a comprehensive system plan (`advertising-feature-plan.md`) detailing the phased approach, database schema, backend/frontend architecture, and key decisions for the in-house advertising feature.
* Added a step-by-step guide (`advertising-ad-creation-steps.md`) for creating ads in the admin panel, including strict HTML/CSS conventions and slot dimension requirements.
* Updated the project memory index (`MEMORY.md`) to reference the new advertising system documentation and ad creation guide.