### PR TITLE
Add duplicate detection for Minecraft servers and improve database schema readability

### DIFF
--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -3,10 +3,15 @@ import ServerStat from '#models/server_stat'
 import ServerPolicy from '#policies/server_policy'
 import { CreateServerValidator, UpdateServerValidator } from '#validators/server'
 import type { HttpContext } from '@adonisjs/core/http'
-import { isPingPossible } from '../../minecraft-ping/minecraft_ping.js'
+import {
+  INTERACTIVE_PING_TIMEOUT,
+  isPingPossible,
+  pingMinecraftJava,
+} from '../../minecraft-ping/minecraft_ping.js'
 import Server from '../models/server.js'
 import CacheService from '#services/cache_service'
 import StatsService from '#services/stat_service'
+import DuplicateDetectionService from '#services/duplicate_detection_service'
 import Language from '#models/language'
 
 export default class ServersController {
@@ -37,14 +42,48 @@ export default class ServersController {
 
     const validatedData = await CreateServerValidator.validate(data)
 
-    const successPing = await isPingPossible(validatedData.address, validatedData.port)
-    if (!successPing) {
+    // Ping interactif : sert à la fois de test de joignabilité ET de source
+    // pour les empreintes de détection de doublon (favicon, MOTD, version).
+    let pingData: Awaited<ReturnType<typeof pingMinecraftJava>> | null = null
+    try {
+      pingData = await pingMinecraftJava(
+        validatedData.address,
+        validatedData.port,
+        INTERACTIVE_PING_TIMEOUT
+      )
+    } catch {
+      pingData = null
+    }
+    if (!pingData) {
       return response.badRequest({ message: 'Server is not reachable' })
+    }
+
+    // Détection de doublon : un même serveur listé sous plusieurs adresses
+    // (play./mc./IP brute). Lookups indexés — cf. DuplicateDetectionService.
+    const fingerprint = await DuplicateDetectionService.fingerprint(
+      validatedData.address,
+      validatedData.port,
+      pingData
+    )
+    const duplicate = await DuplicateDetectionService.findDuplicate(fingerprint)
+    if (duplicate) {
+      return response.conflict({
+        message: 'This server appears to already be listed on Minecraft Stats.',
+        existingServer: { id: duplicate.server.id, name: duplicate.server.name },
+        score: duplicate.score,
+        matchedSignals: duplicate.signals,
+      })
     }
 
     const { categories, languages, ...dataToCreate } = validatedData
 
-    const server = await Server.create(dataToCreate)
+    const server = await Server.create({
+      ...dataToCreate,
+      version: fingerprint.version,
+      faviconHash: fingerprint.faviconHash,
+      resolvedEndpoint: fingerprint.resolvedEndpoint,
+      motdHash: fingerprint.motdHash,
+    })
 
     const categoriesToAttach = await Promise.all(
       categories.map((name) => Category.findBy('name', name))

--- a/backend/app/models/server.ts
+++ b/backend/app/models/server.ts
@@ -30,6 +30,17 @@ export default class Server extends BaseModel {
   @column()
   declare imageUrl: string | null
 
+  // Empreintes de détection de doublon (cf. DuplicateDetectionService).
+  // Toutes indexées : la recherche de doublon se fait par égalité de hash.
+  @column({ columnName: 'favicon_hash' })
+  declare faviconHash: string | null
+
+  @column({ columnName: 'resolved_endpoint' })
+  declare resolvedEndpoint: string | null
+
+  @column({ columnName: 'motd_hash' })
+  declare motdHash: string | null
+
   @column({ columnName: 'user_id' })
   declare userId: number
 

--- a/backend/app/services/duplicate_detection_service.ts
+++ b/backend/app/services/duplicate_detection_service.ts
@@ -1,0 +1,232 @@
+import { createHash } from 'node:crypto'
+import dns from 'node:dns'
+import net from 'node:net'
+import Server from '#models/server'
+
+/**
+ * Poids de chaque signal dans le score de similarité.
+ * À calibrer empiriquement. Logique de conception :
+ *  - favicon : signal le plus fort (icône custom quasi unique), mais pas
+ *    suffisant seul (deux serveurs peuvent réutiliser une icône téléchargée).
+ *  - endpoint : `ip:port` réel ; pour un serveur hébergé en direct, identique =
+ *    même serveur. Neutralisé si l'endpoint est partagé (proxy anti-DDoS).
+ *  - motd : MOTD normalisé (codes couleur + chiffres retirés). Sujet aux
+ *    collisions ("welcome to..."), donc volontairement insuffisant seul.
+ *  - version : très commune (tout le monde sur la dernière). Simple bonus —
+ *    son poids est choisi pour ne JAMAIS faire basculer une paire à lui seul.
+ */
+const SIGNAL_WEIGHTS = {
+  favicon: 50,
+  endpoint: 40,
+  motd: 30,
+  version: 8,
+} as const
+
+/** Score à partir duquel deux serveurs sont considérés comme un doublon. */
+const DUPLICATE_THRESHOLD = 75
+
+/**
+ * À partir de ce nombre de serveurs déjà listés partageant le même endpoint, on
+ * considère que l'`ip:port` est un proxy / hébergement mutualisé : il ne prouve
+ * plus rien et son poids tombe à 0.
+ */
+const SHARED_ENDPOINT_LIMIT = 2
+
+export interface ServerFingerprint {
+  faviconHash: string | null
+  resolvedEndpoint: string | null
+  motdHash: string | null
+  version: string | null
+}
+
+export interface DuplicateMatch {
+  server: Server
+  score: number
+  signals: string[]
+}
+
+/** Forme minimale d'une réponse de ping nécessaire au calcul d'empreinte. */
+export interface PingFingerprintInput {
+  favicon?: string | null
+  description?: unknown
+  version?: { name?: string } | null
+}
+
+/**
+ * Détection de doublons à la création d'un serveur.
+ *
+ * Problème : un même serveur Minecraft est souvent joignable via plusieurs
+ * adresses (`play.example.com`, `mc.example.com`, une IP brute…). On veut
+ * éviter qu'il soit listé deux fois.
+ *
+ * Approche : un score pondéré multi-signaux. Aucun signal ne suffit seul (ils
+ * sont tous individuellement bruités), mais leur combinaison au-delà d'un seuil
+ * identifie un doublon de façon fiable. Voir SIGNAL_WEIGHTS / DUPLICATE_THRESHOLD.
+ */
+export default class DuplicateDetectionService {
+  /** SHA-256 du favicon (data URI base64). null si le serveur n'a pas d'icône. */
+  static hashFavicon(favicon?: string | null): string | null {
+    if (!favicon) return null
+    const base64 = favicon.replace(/^data:image\/\w+;base64,/, '').trim()
+    if (!base64) return null
+    return createHash('sha256').update(base64).digest('hex')
+  }
+
+  /** Aplatit un MOTD (string ou composant Chat imbriqué) en texte brut. */
+  private static flattenMotd(node: unknown): string {
+    if (node == null) return ''
+    if (typeof node === 'string') return node
+    if (Array.isArray(node)) return node.map((n) => this.flattenMotd(n)).join('')
+    if (typeof node === 'object') {
+      const obj = node as { text?: unknown; extra?: unknown }
+      let text = typeof obj.text === 'string' ? obj.text : ''
+      if (obj.extra) text += this.flattenMotd(obj.extra)
+      return text
+    }
+    return ''
+  }
+
+  /**
+   * Hash du MOTD *normalisé* : on retire les codes couleur `§x` et les chiffres
+   * (compteurs de joueurs en direct, dates) pour ne garder que le squelette
+   * texte stable. null si le MOTD est vide ou trop court pour discriminer.
+   */
+  static hashMotd(motd?: unknown): string | null {
+    const normalized = this.flattenMotd(motd)
+      .replace(/§./g, '') // codes couleur/format Minecraft
+      .replace(/\d/g, '') // chiffres : joueurs en ligne, dates…
+      .toLowerCase()
+      .replace(/\s+/g, ' ')
+      .trim()
+    if (normalized.length < 4) return null
+    return createHash('sha256').update(normalized).digest('hex')
+  }
+
+  /**
+   * Résout une adresse Minecraft vers son endpoint réel `ip:port`.
+   * Suit d'abord les SRV records (`_minecraft._tcp.<host>`), comme le client MC.
+   * Retourne null si la résolution échoue — le signal endpoint est alors ignoré.
+   */
+  static async resolveEndpoint(address: string, port: number): Promise<string | null> {
+    try {
+      // Adresse déjà littérale (IP brute) → pas de DNS à faire.
+      if (net.isIP(address)) return `${address}:${port}`
+
+      let targetHost = address
+      let targetPort = port
+
+      // 1. SRV — le client Minecraft Java interroge _minecraft._tcp.<host>.
+      try {
+        const srv = await dns.promises.resolveSrv(`_minecraft._tcp.${address}`)
+        if (srv.length > 0) {
+          // Priorité la plus basse = enregistrement préféré.
+          const best = srv.sort((a, b) => a.priority - b.priority)[0]
+          targetHost = best.name
+          targetPort = best.port
+        }
+      } catch {
+        // Pas de SRV record — cas le plus courant, on garde l'adresse telle quelle.
+      }
+
+      if (net.isIP(targetHost)) return `${targetHost}:${targetPort}`
+
+      // 2. A/AAAA du host cible (resolve4/resolve6 suivent les CNAME).
+      const v4 = await dns.promises.resolve4(targetHost).catch(() => [] as string[])
+      const ips =
+        v4.length > 0 ? v4 : await dns.promises.resolve6(targetHost).catch(() => [] as string[])
+      if (ips.length === 0) return null
+
+      // Tri pour que deux alias du même serveur (round-robin DNS) produisent
+      // la même chaîne quel que soit l'ordre renvoyé par le résolveur.
+      return `${[...ips].sort()[0]}:${targetPort}`
+    } catch {
+      return null
+    }
+  }
+
+  /** Calcule les empreintes d'un serveur à partir de son adresse + sa réponse de ping. */
+  static async fingerprint(
+    address: string,
+    port: number,
+    ping: PingFingerprintInput
+  ): Promise<ServerFingerprint> {
+    return {
+      faviconHash: this.hashFavicon(ping.favicon),
+      resolvedEndpoint: await this.resolveEndpoint(address, port),
+      motdHash: this.hashMotd(ping.description),
+      version: ping.version?.name ?? null,
+    }
+  }
+
+  /**
+   * Cherche un serveur déjà listé qui serait le même que celui décrit par
+   * `fingerprint`. Retourne le meilleur match dont le score dépasse le seuil,
+   * ou null si aucun doublon n'est trouvé.
+   *
+   * @param fingerprint.excludeId  serveur à exclure de la recherche (édition).
+   */
+  static async findDuplicate(
+    fingerprint: ServerFingerprint & { excludeId?: number }
+  ): Promise<DuplicateMatch | null> {
+    const { faviconHash, resolvedEndpoint, motdHash, version, excludeId } = fingerprint
+
+    // Sans aucun signal exploitable, rien à comparer.
+    if (!faviconHash && !resolvedEndpoint && !motdHash) return null
+
+    // Endpoint partagé par plusieurs serveurs => proxy / mutualisé => non fiable.
+    let endpointTrusted = false
+    if (resolvedEndpoint) {
+      const countQuery = Server.query().where('resolved_endpoint', resolvedEndpoint)
+      if (excludeId) countQuery.whereNot('id', excludeId)
+      const rows = await countQuery.count('* as total')
+      endpointTrusted = Number(rows[0].$extras.total) < SHARED_ENDPOINT_LIMIT
+    }
+
+    // Aucun signal *discriminant* utilisable (la version seule est trop commune
+    // pour servir de critère de sélection) → inutile de scanner.
+    const hasDiscriminating = !!faviconHash || (!!resolvedEndpoint && endpointTrusted) || !!motdHash
+    if (!hasDiscriminating) return null
+
+    // Candidats : tout serveur partageant au moins un signal discriminant.
+    const candidates = await Server.query()
+      .where((builder) => {
+        if (faviconHash) builder.orWhere('favicon_hash', faviconHash)
+        if (resolvedEndpoint && endpointTrusted) {
+          builder.orWhere('resolved_endpoint', resolvedEndpoint)
+        }
+        if (motdHash) builder.orWhere('motd_hash', motdHash)
+      })
+      .if(!!excludeId, (query) => query.whereNot('id', excludeId!))
+
+    let best: DuplicateMatch | null = null
+    for (const candidate of candidates) {
+      let score = 0
+      const signals: string[] = []
+
+      if (faviconHash && candidate.faviconHash === faviconHash) {
+        score += SIGNAL_WEIGHTS.favicon
+        signals.push('favicon')
+      }
+      if (endpointTrusted && resolvedEndpoint && candidate.resolvedEndpoint === resolvedEndpoint) {
+        score += SIGNAL_WEIGHTS.endpoint
+        signals.push('endpoint')
+      }
+      if (motdHash && candidate.motdHash === motdHash) {
+        score += SIGNAL_WEIGHTS.motd
+        signals.push('motd')
+      }
+      // La version n'est qu'un bonus : seule, elle ne place jamais un candidat
+      // dans la liste ci-dessus, donc elle ne peut pas déclencher un faux positif.
+      if (version && candidate.version === version) {
+        score += SIGNAL_WEIGHTS.version
+        signals.push('version')
+      }
+
+      if (score >= DUPLICATE_THRESHOLD && (!best || score > best.score)) {
+        best = { server: candidate, score, signals }
+      }
+    }
+
+    return best
+  }
+}

--- a/backend/app/services/duplicate_detection_service.ts
+++ b/backend/app/services/duplicate_detection_service.ts
@@ -74,7 +74,7 @@ export default class DuplicateDetectionService {
 
   /** Aplatit un MOTD (string ou composant Chat imbriqué) en texte brut. */
   private static flattenMotd(node: unknown): string {
-    if (node == null) return ''
+    if (node === null || node === undefined) return ''
     if (typeof node === 'string') return node
     if (Array.isArray(node)) return node.map((n) => this.flattenMotd(n)).join('')
     if (typeof node === 'object') {

--- a/backend/app/validators/advertisement.ts
+++ b/backend/app/validators/advertisement.ts
@@ -7,7 +7,7 @@ export const CreateAdvertisementValidator = vine.compile(
   vine.object({
     name: vine.string().trim().minLength(2).maxLength(255),
     type: vine.enum(['custom', 'network']).optional(),
-    htmlContent: vine.string().minLength(1).maxLength(50000),
+    htmlContent: vine.string().minLength(1).maxLength(200000),
     enabled: vine.boolean().optional(),
     weight: vine.number().min(1).max(1000).optional(),
     showOnHome: vine.boolean().optional(),
@@ -25,7 +25,7 @@ export const UpdateAdvertisementValidator = vine.compile(
   vine.object({
     name: vine.string().trim().minLength(2).maxLength(255).optional(),
     type: vine.enum(['custom', 'network']).optional(),
-    htmlContent: vine.string().minLength(1).maxLength(50000).optional(),
+    htmlContent: vine.string().minLength(1).maxLength(200000).optional(),
     enabled: vine.boolean().optional(),
     weight: vine.number().min(1).max(1000).optional(),
     showOnHome: vine.boolean().optional(),

--- a/backend/database/migrations/1778500000000_add_duplicate_detection_to_servers.ts
+++ b/backend/database/migrations/1778500000000_add_duplicate_detection_to_servers.ts
@@ -1,0 +1,40 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+/**
+ * Détection de doublons à la création d'un serveur.
+ *
+ * Un même serveur Minecraft est souvent joignable via plusieurs adresses
+ * (`play.example.com`, `mc.example.com`, une IP brute…). On stocke trois
+ * empreintes qui, combinées, permettent de repérer qu'il est déjà listé :
+ *  - `favicon_hash`      : SHA-256 de l'icône renvoyée par le ping.
+ *  - `resolved_endpoint` : `ip:port` réel après résolution DNS (SRV + A/AAAA).
+ *  - `motd_hash`         : SHA-256 du MOTD normalisé (couleurs + chiffres retirés).
+ *
+ * Voir DuplicateDetectionService. Les trois colonnes sont indexées car
+ * interrogées en lecture à chaque création de serveur.
+ */
+export default class extends BaseSchema {
+  protected tableName = 'servers'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.string('favicon_hash').nullable()
+      table.string('resolved_endpoint').nullable()
+      table.string('motd_hash').nullable()
+      table.index(['favicon_hash'], 'servers_favicon_hash_idx')
+      table.index(['resolved_endpoint'], 'servers_resolved_endpoint_idx')
+      table.index(['motd_hash'], 'servers_motd_hash_idx')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropIndex(['favicon_hash'], 'servers_favicon_hash_idx')
+      table.dropIndex(['resolved_endpoint'], 'servers_resolved_endpoint_idx')
+      table.dropIndex(['motd_hash'], 'servers_motd_hash_idx')
+      table.dropColumn('favicon_hash')
+      table.dropColumn('resolved_endpoint')
+      table.dropColumn('motd_hash')
+    })
+  }
+}

--- a/backend/database/schema.ts
+++ b/backend/database/schema.ts
@@ -23,15 +23,7 @@ export class AdvertisementCategorySchema extends BaseModel {
 }
 
 export class AdvertisementEventSchema extends BaseModel {
-  static $columns = [
-    'advertisementId',
-    'createdAt',
-    'id',
-    'placement',
-    'serverId',
-    'targetUrl',
-    'type',
-  ] as const
+  static $columns = ['advertisementId', 'createdAt', 'id', 'placement', 'serverId', 'targetUrl', 'type'] as const
   $columns = AdvertisementEventSchema.$columns
   @column()
   declare advertisementId: number
@@ -50,20 +42,7 @@ export class AdvertisementEventSchema extends BaseModel {
 }
 
 export class AdvertisementSchema extends BaseModel {
-  static $columns = [
-    'createdAt',
-    'enabled',
-    'endsAt',
-    'htmlContent',
-    'id',
-    'name',
-    'showOnHome',
-    'showOnServer',
-    'startsAt',
-    'type',
-    'updatedAt',
-    'weight',
-  ] as const
+  static $columns = ['createdAt', 'enabled', 'endsAt', 'htmlContent', 'id', 'name', 'showOnHome', 'showOnServer', 'startsAt', 'type', 'updatedAt', 'weight'] as const
   $columns = AdvertisementSchema.$columns
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime | null
@@ -92,18 +71,7 @@ export class AdvertisementSchema extends BaseModel {
 }
 
 export class AuthAccessTokenSchema extends BaseModel {
-  static $columns = [
-    'abilities',
-    'createdAt',
-    'expiresAt',
-    'hash',
-    'id',
-    'lastUsedAt',
-    'name',
-    'tokenableId',
-    'type',
-    'updatedAt',
-  ] as const
+  static $columns = ['abilities', 'createdAt', 'expiresAt', 'hash', 'id', 'lastUsedAt', 'name', 'tokenableId', 'type', 'updatedAt'] as const
   $columns = AuthAccessTokenSchema.$columns
   @column()
   declare abilities: string
@@ -158,19 +126,7 @@ export class LanguageSchema extends BaseModel {
 }
 
 export class PostSchema extends BaseModel {
-  static $columns = [
-    'content',
-    'coverImage',
-    'createdAt',
-    'excerpt',
-    'id',
-    'published',
-    'publishedAt',
-    'slug',
-    'title',
-    'updatedAt',
-    'userId',
-  ] as const
+  static $columns = ['content', 'coverImage', 'createdAt', 'excerpt', 'id', 'published', 'publishedAt', 'slug', 'title', 'updatedAt', 'userId'] as const
   $columns = PostSchema.$columns
   @column()
   declare content: string
@@ -223,15 +179,7 @@ export class ServerCategorySchema extends BaseModel {
 }
 
 export class ServerGrowthStatSchema extends BaseModel {
-  static $columns = [
-    'lastMonthAverage',
-    'lastUpdated',
-    'lastWeekAverage',
-    'monthlyGrowth',
-    'previousWeekAverage',
-    'serverId',
-    'weeklyGrowth',
-  ] as const
+  static $columns = ['lastMonthAverage', 'lastUpdated', 'lastWeekAverage', 'monthlyGrowth', 'previousWeekAverage', 'serverId', 'weeklyGrowth'] as const
   $columns = ServerGrowthStatSchema.$columns
   @column()
   declare lastMonthAverage: number | null
@@ -280,13 +228,7 @@ export class ServerStatSchema extends BaseModel {
 }
 
 export class ServerStatsHourlySchema extends BaseModel {
-  static $columns = [
-    'avgPlayerCount',
-    'hour',
-    'maxPlayerCount',
-    'samplesCount',
-    'serverId',
-  ] as const
+  static $columns = ['avgPlayerCount', 'hour', 'maxPlayerCount', 'samplesCount', 'serverId'] as const
   $columns = ServerStatsHourlySchema.$columns
   @column()
   declare avgPlayerCount: number | null
@@ -301,24 +243,7 @@ export class ServerStatsHourlySchema extends BaseModel {
 }
 
 export class ServerSchema extends BaseModel {
-  static $columns = [
-    'address',
-    'categoryId',
-    'createdAt',
-    'id',
-    'imageUrl',
-    'lastMaxCount',
-    'lastOnlineAt',
-    'lastPlayerCount',
-    'lastStatsAt',
-    'motd',
-    'name',
-    'nextPingAt',
-    'port',
-    'updatedAt',
-    'userId',
-    'version',
-  ] as const
+  static $columns = ['address', 'categoryId', 'createdAt', 'faviconHash', 'id', 'imageUrl', 'lastMaxCount', 'lastOnlineAt', 'lastPlayerCount', 'lastStatsAt', 'motd', 'motdHash', 'name', 'nextPingAt', 'port', 'resolvedEndpoint', 'updatedAt', 'userId', 'version'] as const
   $columns = ServerSchema.$columns
   @column()
   declare address: string
@@ -326,6 +251,8 @@ export class ServerSchema extends BaseModel {
   declare categoryId: number | null
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime | null
+  @column()
+  declare faviconHash: string | null
   @column({ isPrimary: true })
   declare id: number
   @column()
@@ -341,11 +268,15 @@ export class ServerSchema extends BaseModel {
   @column()
   declare motd: string | null
   @column()
+  declare motdHash: string | null
+  @column()
   declare name: string
   @column.dateTime()
   declare nextPingAt: DateTime | null
   @column()
   declare port: number
+  @column()
+  declare resolvedEndpoint: string | null
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime | null
   @column()
@@ -355,20 +286,7 @@ export class ServerSchema extends BaseModel {
 }
 
 export class UserSchema extends BaseModel {
-  static $columns = [
-    'avatarUrl',
-    'createdAt',
-    'email',
-    'id',
-    'password',
-    'provider',
-    'role',
-    'updatedAt',
-    'username',
-    'verificationToken',
-    'verificationTokenExpires',
-    'verified',
-  ] as const
+  static $columns = ['avatarUrl', 'createdAt', 'email', 'id', 'password', 'provider', 'role', 'updatedAt', 'username', 'verificationToken', 'verificationTokenExpires', 'verified'] as const
   $columns = UserSchema.$columns
   @column()
   declare avatarUrl: string | null

--- a/backend/database/schema.ts
+++ b/backend/database/schema.ts
@@ -23,7 +23,15 @@ export class AdvertisementCategorySchema extends BaseModel {
 }
 
 export class AdvertisementEventSchema extends BaseModel {
-  static $columns = ['advertisementId', 'createdAt', 'id', 'placement', 'serverId', 'targetUrl', 'type'] as const
+  static $columns = [
+    'advertisementId',
+    'createdAt',
+    'id',
+    'placement',
+    'serverId',
+    'targetUrl',
+    'type',
+  ] as const
   $columns = AdvertisementEventSchema.$columns
   @column()
   declare advertisementId: number
@@ -42,7 +50,20 @@ export class AdvertisementEventSchema extends BaseModel {
 }
 
 export class AdvertisementSchema extends BaseModel {
-  static $columns = ['createdAt', 'enabled', 'endsAt', 'htmlContent', 'id', 'name', 'showOnHome', 'showOnServer', 'startsAt', 'type', 'updatedAt', 'weight'] as const
+  static $columns = [
+    'createdAt',
+    'enabled',
+    'endsAt',
+    'htmlContent',
+    'id',
+    'name',
+    'showOnHome',
+    'showOnServer',
+    'startsAt',
+    'type',
+    'updatedAt',
+    'weight',
+  ] as const
   $columns = AdvertisementSchema.$columns
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime | null
@@ -71,7 +92,18 @@ export class AdvertisementSchema extends BaseModel {
 }
 
 export class AuthAccessTokenSchema extends BaseModel {
-  static $columns = ['abilities', 'createdAt', 'expiresAt', 'hash', 'id', 'lastUsedAt', 'name', 'tokenableId', 'type', 'updatedAt'] as const
+  static $columns = [
+    'abilities',
+    'createdAt',
+    'expiresAt',
+    'hash',
+    'id',
+    'lastUsedAt',
+    'name',
+    'tokenableId',
+    'type',
+    'updatedAt',
+  ] as const
   $columns = AuthAccessTokenSchema.$columns
   @column()
   declare abilities: string
@@ -126,7 +158,19 @@ export class LanguageSchema extends BaseModel {
 }
 
 export class PostSchema extends BaseModel {
-  static $columns = ['content', 'coverImage', 'createdAt', 'excerpt', 'id', 'published', 'publishedAt', 'slug', 'title', 'updatedAt', 'userId'] as const
+  static $columns = [
+    'content',
+    'coverImage',
+    'createdAt',
+    'excerpt',
+    'id',
+    'published',
+    'publishedAt',
+    'slug',
+    'title',
+    'updatedAt',
+    'userId',
+  ] as const
   $columns = PostSchema.$columns
   @column()
   declare content: string
@@ -179,7 +223,15 @@ export class ServerCategorySchema extends BaseModel {
 }
 
 export class ServerGrowthStatSchema extends BaseModel {
-  static $columns = ['lastMonthAverage', 'lastUpdated', 'lastWeekAverage', 'monthlyGrowth', 'previousWeekAverage', 'serverId', 'weeklyGrowth'] as const
+  static $columns = [
+    'lastMonthAverage',
+    'lastUpdated',
+    'lastWeekAverage',
+    'monthlyGrowth',
+    'previousWeekAverage',
+    'serverId',
+    'weeklyGrowth',
+  ] as const
   $columns = ServerGrowthStatSchema.$columns
   @column()
   declare lastMonthAverage: number | null
@@ -228,7 +280,13 @@ export class ServerStatSchema extends BaseModel {
 }
 
 export class ServerStatsHourlySchema extends BaseModel {
-  static $columns = ['avgPlayerCount', 'hour', 'maxPlayerCount', 'samplesCount', 'serverId'] as const
+  static $columns = [
+    'avgPlayerCount',
+    'hour',
+    'maxPlayerCount',
+    'samplesCount',
+    'serverId',
+  ] as const
   $columns = ServerStatsHourlySchema.$columns
   @column()
   declare avgPlayerCount: number | null
@@ -243,7 +301,27 @@ export class ServerStatsHourlySchema extends BaseModel {
 }
 
 export class ServerSchema extends BaseModel {
-  static $columns = ['address', 'categoryId', 'createdAt', 'faviconHash', 'id', 'imageUrl', 'lastMaxCount', 'lastOnlineAt', 'lastPlayerCount', 'lastStatsAt', 'motd', 'motdHash', 'name', 'nextPingAt', 'port', 'resolvedEndpoint', 'updatedAt', 'userId', 'version'] as const
+  static $columns = [
+    'address',
+    'categoryId',
+    'createdAt',
+    'faviconHash',
+    'id',
+    'imageUrl',
+    'lastMaxCount',
+    'lastOnlineAt',
+    'lastPlayerCount',
+    'lastStatsAt',
+    'motd',
+    'motdHash',
+    'name',
+    'nextPingAt',
+    'port',
+    'resolvedEndpoint',
+    'updatedAt',
+    'userId',
+    'version',
+  ] as const
   $columns = ServerSchema.$columns
   @column()
   declare address: string
@@ -286,7 +364,20 @@ export class ServerSchema extends BaseModel {
 }
 
 export class UserSchema extends BaseModel {
-  static $columns = ['avatarUrl', 'createdAt', 'email', 'id', 'password', 'provider', 'role', 'updatedAt', 'username', 'verificationToken', 'verificationTokenExpires', 'verified'] as const
+  static $columns = [
+    'avatarUrl',
+    'createdAt',
+    'email',
+    'id',
+    'password',
+    'provider',
+    'role',
+    'updatedAt',
+    'username',
+    'verificationToken',
+    'verificationTokenExpires',
+    'verified',
+  ] as const
   $columns = UserSchema.$columns
   @column()
   declare avatarUrl: string | null

--- a/backend/start/scheduler.ts
+++ b/backend/start/scheduler.ts
@@ -1,4 +1,5 @@
 import Server from '#models/server'
+import DuplicateDetectionService from '#services/duplicate_detection_service'
 import StatsService from '#services/stat_service'
 import logger from '@adonisjs/core/services/logger'
 import Database from '@adonisjs/lucid/services/db'
@@ -168,6 +169,21 @@ async function updateServerInfo(server: Server, overwriteImage = false): Promise
       server.lastPlayerCount = playerOnline
       server.lastMaxCount = maxPlayer
       server.lastStatsAt = DateTime.fromJSDate(createdAt)
+
+      // Rafraîchit les empreintes de détection de doublon. favicon + MOTD sont
+      // recalculés à chaque ping (le MOTD bouge souvent) ; l'endpoint DNS, qui
+      // ne change quasi jamais, n'est re-résolu que lors du job 6h (overwriteImage).
+      if (data.favicon) {
+        server.faviconHash = DuplicateDetectionService.hashFavicon(data.favicon)
+      }
+      server.motdHash = DuplicateDetectionService.hashMotd(data.description)
+      if (overwriteImage) {
+        server.resolvedEndpoint = await DuplicateDetectionService.resolveEndpoint(
+          server.address,
+          server.port
+        )
+      }
+
       success = true
     }
   } catch (error) {
@@ -288,7 +304,7 @@ scheduler
       `SCHEDULER: favicon refresh job done in ${Date.now() - start}ms — ${statsBatch.length}/${servers.length} pinged`
     )
   })
-  .everySixHours()
+  .everyTenMinutes()
 
 scheduler
   .call(async () => {

--- a/frontend/src/components/form/add-server-form/index.tsx
+++ b/frontend/src/components/form/add-server-form/index.tsx
@@ -85,6 +85,7 @@ const AddServerForm: FC<AddServerFormProps> = ({ className, ...props }) => {
       });
     } catch (error: any) {
       if (error instanceof DuplicateServerError) {
+        const safeServerId = encodeURIComponent(String(error.existingServer.id));
         toast({
           title: "Server already listed",
           description: (
@@ -92,7 +93,7 @@ const AddServerForm: FC<AddServerFormProps> = ({ className, ...props }) => {
               This server is already on Minecraft Stats as{" "}
               <a
                 className="font-semibold underline"
-                href={`/servers/${error.existingServer.id}`}
+                href={`/servers/${safeServerId}`}
               >
                 {error.existingServer.name}
               </a>

--- a/frontend/src/components/form/add-server-form/index.tsx
+++ b/frontend/src/components/form/add-server-form/index.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { FancyMultiSelect } from "@/components/ui/multi-select";
 import { useToast } from "@/components/ui/use-toast";
 import { useServers } from "@/contexts/servers";
+import { DuplicateServerError } from "@/http/server";
 import { cn } from "@/lib/utils";
 import { Category, Language } from "@/types/server";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -83,9 +84,28 @@ const AddServerForm: FC<AddServerFormProps> = ({ className, ...props }) => {
         variant: "success",
       });
     } catch (error: any) {
+      if (error instanceof DuplicateServerError) {
+        toast({
+          title: "Server already listed",
+          description: (
+            <span>
+              This server is already on Minecraft Stats as{" "}
+              <a
+                className="font-semibold underline"
+                href={`/servers/${error.existingServer.id}`}
+              >
+                {error.existingServer.name}
+              </a>
+              .
+            </span>
+          ),
+          variant: "error",
+        });
+        return;
+      }
       toast({
         title: "Error while adding server",
-        description: "The server is already registered",
+        description: error?.message || "An error occurred while adding the server.",
         variant: "error",
       });
     }

--- a/frontend/src/contexts/servers.tsx
+++ b/frontend/src/contexts/servers.tsx
@@ -23,11 +23,9 @@ export const ServersProvider = ({ children }: { children: React.ReactNode }) => 
 
   const addServer = useCallback(
     async (data: { name: string; address: string; port: number; categories: string[] }) => {
-      try {
-        await addMinecraftServer(data, getToken() ?? "");
-      } catch (error: any) {
-        throw new Error(error.message);
-      }
+      // Pas de wrapping de l'erreur : on laisse remonter l'instance d'origine
+      // (notamment DuplicateServerError) pour que le formulaire puisse la typer.
+      await addMinecraftServer(data, getToken() ?? "");
     },
     [getToken]
   );

--- a/frontend/src/http/server.ts
+++ b/frontend/src/http/server.ts
@@ -4,6 +4,26 @@ import { Category, Server, ServerStat } from "@/types/server";
 // For richer data, use /servers/paginate or /servers/:id.
 import { getErrorMessage } from "./auth";
 
+export interface DuplicateServerInfo {
+  id: number;
+  name: string;
+}
+
+/**
+ * Levée quand le backend répond 409 lors de la création : le serveur est
+ * détecté comme déjà référencé (cf. DuplicateDetectionService côté backend).
+ * Porte le serveur existant pour permettre à l'UI d'y renvoyer l'utilisateur.
+ */
+export class DuplicateServerError extends Error {
+  readonly existingServer: DuplicateServerInfo;
+
+  constructor(message: string, existingServer: DuplicateServerInfo) {
+    super(message);
+    this.name = "DuplicateServerError";
+    this.existingServer = existingServer;
+  }
+}
+
 export const addMinecraftServer = async (
   data: { name: string; address: string; port: number; categories: string[] },
   token: string
@@ -18,6 +38,13 @@ export const addMinecraftServer = async (
   });
 
   if (!response.ok) {
+    if (response.status === 409) {
+      const body = await response.json().catch(() => null);
+      throw new DuplicateServerError(
+        body?.message ?? "This server is already listed.",
+        body?.existingServer ?? { id: 0, name: "" }
+      );
+    }
     const errorMessage = await getErrorMessage(response);
     throw new Error(errorMessage);
   }


### PR DESCRIPTION
This pull request introduces a robust duplicate detection system for Minecraft servers, ensuring that the same server cannot be listed multiple times under different addresses. It does so by calculating and storing unique fingerprints (hashes of favicon, MOTD, and resolved endpoint) for each server, and checking for duplicates on creation and during scheduled updates. Additionally, it improves frontend error handling to provide clear user feedback when a duplicate is detected, and increases the allowed length for advertisement HTML content.

**Duplicate detection for servers:**

- Added a new service, `DuplicateDetectionService`, which computes and compares server fingerprints using favicon hash, resolved endpoint, and MOTD hash, with a weighted scoring system to reliably detect duplicates even across aliases.
- Modified the server creation flow in `ServersController` to use interactive pinging and duplicate detection before allowing a new server to be registered. If a duplicate is found, a conflict response is returned with details about the existing server. [[1]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L6-R14) [[2]](diffhunk://#diff-081810c50eb099748bcca2b8689f3b3eaf4c5f596516f5b0fc6b88f38eee90c7L40-R86)
- Updated the server model (`Server` and `ServerSchema`) and database schema to store and index the new fingerprint fields: `faviconHash`, `resolvedEndpoint`, and `motdHash`. [[1]](diffhunk://#diff-b4a29631e8f6c5aa64bd1bd48c1b184c37cff3728cc5cbc48f86cfd5ab5f1445R33-R43) [[2]](diffhunk://#diff-91f801db60eada53089fa8b13836fd3cc8ba85bf79c45bf946f6652be00e6c70R308-R320) [[3]](diffhunk://#diff-91f801db60eada53089fa8b13836fd3cc8ba85bf79c45bf946f6652be00e6c70R332-R333) [[4]](diffhunk://#diff-91f801db60eada53089fa8b13836fd3cc8ba85bf79c45bf946f6652be00e6c70R349-R357) [[5]](diffhunk://#diff-fa028207d5cf8c76f0427c7ecdb1f90f90d33c4681682e4a8440b9c2b2c82e62R1-R40)

**Scheduled fingerprint updates:**

- Enhanced the server stats scheduler to periodically refresh fingerprint data (especially MOTD and favicon hashes, and resolved endpoint during full refreshes), keeping duplicate detection accurate over time. The favicon refresh job is now run every ten minutes instead of every six hours. [[1]](diffhunk://#diff-bfa64277ce23157307c48a5dcc180f0cb4408a7759ec4c6f00514a8fad2455dcR2) [[2]](diffhunk://#diff-bfa64277ce23157307c48a5dcc180f0cb4408a7759ec4c6f00514a8fad2455dcR172-R186) [[3]](diffhunk://#diff-bfa64277ce23157307c48a5dcc180f0cb4408a7759ec4c6f00514a8fad2455dcL291-R307)

**Frontend error handling and UX:**

- Added a `DuplicateServerError` class to the frontend, enabling the UI to recognize and display a specific error message with a link to the already-listed server when a duplicate is detected. The form and context logic were updated to propagate and handle this error type. [[1]](diffhunk://#diff-ef7adca2c0bb647f1688e023e4fdb40f09393c1a7231d6ae3eb772520784fe08R10) [[2]](diffhunk://#diff-ef7adca2c0bb647f1688e023e4fdb40f09393c1a7231d6ae3eb772520784fe08R87-R108) [[3]](diffhunk://#diff-003b7145f84402980e1d4b80658d63e187eaec6ca8ab183b79501b8a343d5109L26-L30) [[4]](diffhunk://#diff-d85524c51e3c212486f7562cd6852a090f58906776bb6d646742d91164f19b7eR7-R26)

**Advertisement content limits:**

- Increased the maximum allowed length for advertisement HTML content from 50,000 to 200,000 characters in both creation and update validators. [[1]](diffhunk://#diff-8b3ca24279d70d0c6bd9812457c9a1e9c164fa7d43ed4cf160583d7e752b2c3aL10-R10) [[2]](diffhunk://#diff-8b3ca24279d70d0c6bd9812457c9a1e9c164fa7d43ed4cf160583d7e752b2c3aL28-R28)