### PR TITLE
feat: add support for Bedrock servers with type distinction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,267 +1,82 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code when working in this repository.
+
+## Skills — check BEFORE acting
+
+This repo ships custom skills that encode conventions easy to get wrong. Check whether one
+covers your task and invoke it (Skill tool) instead of improvising.
+
+| When you are…                                          | Use skill                      |
+| ------------------------------------------------------ | ------------------------------ |
+| Writing/editing app code (React/TS/AdonisJS)           | `writing-clean-code`           |
+| Creating an Adonis model/controller/migration/etc.     | `scaffolding-adonis-resources` |
+| Committing, branching, or opening a PR                 | `creating-commits-and-prs`     |
+
+`writing-clean-code` and `writing-clean-tests` apply to _most_ code changes — consult them
+by default, don't wait to be asked.
 
 ## Project Overview
 
-Minecraft Stats is a full-stack web application that tracks player count statistics for Minecraft servers. It consists of:
-- **Backend**: AdonisJS 6 API (TypeScript) with PostgreSQL database
-- **Frontend**: Next.js 15 (React 19) with TypeScript, using Turbopack
-- **MCP server** (`mcp/`): Standalone Node/TypeScript service exposing the public read-only API to AI agents via the Model Context Protocol (Streamable HTTP). Tools are auto-generated at startup from the backend's live OpenAPI spec (`/swagger`), filtered by an explicit public allowlist. See `mcp/README.md`.
+Full-stack app tracking player-count statistics for Minecraft servers. It pings each server
+every 10 minutes, stores historical data, and exposes a public API + web UI for growth trends.
 
-The application pings Minecraft servers every 10 minutes to collect player statistics, stores historical data, and provides a public API and web interface to visualize server growth and trends.
+- **Backend** (`backend/`): AdonisJS 6 (TypeScript, Lucid ORM) + PostgreSQL
+- **Frontend** (`frontend/`): Next.js 15 / React 19 (App Router, Turbopack)
+- **MCP server** (`mcp/`): exposes the public read-only API to AI agents over MCP. Tools are
+  auto-generated at startup from the backend's live OpenAPI spec (`/swagger`), filtered by a
+  public allowlist. See `mcp/README.md`.
 
 ## Architecture
 
-### Backend (AdonisJS)
-
-**Framework**: AdonisJS 6 with Lucid ORM, running on Node.js
-
-**Key Components**:
-- **Models** (`app/models/`):
-  - `Server` - Minecraft server information with relationships to categories, languages, stats, and users
-  - `ServerStat` - Time-series data for player counts (collected every 10 minutes)
-  - `ServerGrowthStat` - Calculated weekly/monthly growth metrics
-  - `Category` - Server categorization (e.g., Survival, Creative, PvP)
-  - `Language` - Server language tags (FR, EN, etc.)
-  - `User` - Authentication and server ownership
-
-- **Controllers** (`app/controllers/`):
-  - `ServersController` - CRUD operations and pagination for servers
-  - `StatsController` - Retrieves stats with interval aggregation (30 min, 1 hour, 6 hours, etc.)
-  - `CategoriesController` - Category management
-  - `AuthController` - Login, register, OAuth (Google/Discord), email verification
-  - `WebsiteStatsController` - Global platform statistics
-
-- **Services** (`app/services/`):
-  - `StatsService` - Statistical calculations, interval aggregation, growth metrics computation
-
-- **Policies** (`app/policies/`): Authorization using Bouncer (user can only modify their own servers)
-
-- **Minecraft Ping** (`minecraft-ping/minecraft_ping.ts`): Uses `@minescope/mineping` to query Java Minecraft servers for status, player count, version, MOTD, and favicon
-
-- **Scheduled Tasks** (`start/scheduler.ts`):
-  - Every 10 minutes: Ping all servers with uniform spacing to avoid rate limits
-  - Every 6 hours: Refresh server favicons and calculate growth statistics
-
-**Database**: PostgreSQL with migrations in `database/migrations/`
-
-**API Routes** (`start/routes.ts`): All endpoints under `/api/v1` with rate limiting via `@adonisjs/limiter`
-
-**Import Aliases**: Uses `#` prefix (e.g., `#models/server`, `#controllers/auth_controller`)
-
-### Frontend (Next.js)
-
-**Framework**: Next.js 15 with App Router, React 19, and Turbopack for dev mode
-
-**Key Directories**:
-- `src/app/` - Next.js App Router pages and layouts
-  - `(pages)/` - Main application pages
-  - `(auth)/` - Login, sign-up, OAuth callbacks
-  - `account/` - User account settings, server management
-
-- `src/components/` - React components organized by feature:
-  - `serveur/` - Server cards, stats visualization
-  - `form/` - Login, sign-up, password change forms
-  - `ui/` - Radix UI components (shadcn/ui style)
-  - `dark-mode/` - Theme provider and toggle
-  - `metrics/` - Google Analytics, Microsoft Clarity
-
-- `src/contexts/` - React Context providers:
-  - `auth.tsx` - User authentication state
-  - `servers.tsx` - Server data management with SWR
-  - `favorite.tsx` - Favorite servers (localStorage)
-
-- `src/http/` - API client functions:
-  - `auth.ts` - Authentication endpoints
-  - `server.ts` - Server CRUD and stats fetching
-
-- `src/types/` - TypeScript type definitions
-
-**Styling**: Tailwind CSS with custom configuration, shadcn/ui components
-
-**Data Fetching**: SWR for server-side rendering and client-side caching
-
-**Charts**: AG Charts for visualizing player statistics
-
-## Development Commands
-
-### Backend (run from `backend/` directory)
-
-```bash
-# Install dependencies
-yarn install
-
-# Development server with hot module reload
-yarn dev
-
-# Build for production
-yarn build
-
-# Start production server
-yarn start
-
-# Database migrations
-node ace migration:run
-node ace migration:rollback
-
-# Run tests
-yarn test
-
-# Linting and formatting
-yarn lint
-yarn lint:fix
-yarn format
-
-# Type checking
-yarn typecheck
-
-# Generate Swagger documentation
-node ace docs:generate
-
-# Run scheduler (for background tasks)
-node ace scheduler:run
-
-# Docker commands
-yarn build:docker
-yarn run:docker
-yarn start:docker
-yarn stop:docker
-```
-
-### Frontend (run from `frontend/` directory)
-
-```bash
-# Install dependencies
-yarn install
-
-# Development server with Turbopack
-yarn dev
-
-# Build for production
-yarn build
-
-# Start production server
-yarn start
-
-# Linting
-yarn lint
-```
-
-### Database Setup
-
-The backend requires PostgreSQL. For local development, use Docker Compose as described in `backend/README.md`:
-
-```bash
-# From project root, create docker-compose.override.yml for local dev
-docker compose --env-file ./.env.development up -d
-```
-
-After starting PostgreSQL, run migrations from `backend/`:
-```bash
-node ace migration:run
-```
-
-## Key Architectural Patterns
-
-### Stats Aggregation System
-
-The `StatsService` provides flexible time-series querying:
-- **Raw stats**: All data points (collected every 10 minutes)
-- **Interval aggregation**: Groups stats by intervals (30 min, 1 hour, 2 hours, 6 hours, 1 day, 1 week) using PostgreSQL `floor(extract(epoch...))` for efficient bucketing
-- **Exact time lookup**: If data doesn't exist at exact timestamp, averages between nearest before/after data points
-- **Growth calculations**: Weekly/monthly growth percentages stored in `ServerGrowthStat`
-
-Stats queries accept `fromDate`, `toDate` (epoch milliseconds), and `interval` parameters.
-
-### Scheduler Uniform Spacing
-
-To avoid overwhelming servers or network, the scheduler spaces out pings uniformly across 10-minute windows using `pLimit(1)` and calculated delays between each server.
-
-### Language Sync Pattern
-
-The `Server.syncLanguages()` method handles many-to-many language relationships with manual transaction control to ensure atomic updates when adding/removing language tags.
-
-### Authentication Flow
-
-- **Session-based**: Uses AdonisJS Auth with access tokens stored in database
-- **OAuth**: Google and Discord via Ally provider
-- **Email verification**: JWT-based email verification flow with mail templates (MJML)
-- **Password hashing**: Argon2 via `@adonisjs/hash`
-
-### Frontend State Management
-
-- **SWR** for server data with automatic revalidation
-- **React Context** for auth state and favorites
-- **localStorage** for client-side persistence (favorites, theme)
-
-## API Documentation
-
-Swagger/OpenAPI docs are auto-generated via `adonis-autoswagger`:
-- View docs at `/docs` (Scalar UI)
-- JSON spec at `/swagger`
-
-## Testing
-
-Backend uses Japa test runner:
-- Unit tests: `tests/unit/**/*.spec.ts`
-- Functional tests: `tests/functional/**/*.spec.ts`
-
-Run with: `node ace test` or `yarn test`
-
-## Image Handling
-
-Server favicons are:
-1. Fetched from Minecraft server ping response (base64)
-2. Saved as PNG to `backend/public/images/servers/{server_id}.png`
-3. Converted to WebP using Sharp for optimal web delivery
-4. Served via static file middleware
-
-## Environment Variables
-
-Backend requires (see `backend/config/` for usage):
-- Database: `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_DATABASE`
-- App: `PORT`, `HOST`, `NODE_ENV`, `APP_KEY`
-- Mail: SMTP configuration
-- OAuth: Google/Discord client IDs and secrets
-- Redis: For rate limiting
-
-Frontend requires:
-- `NEXT_PUBLIC_API_URL` - Backend API base URL
-
-## Common Development Workflows
-
-### Adding a new server endpoint
-
-1. Define route in `backend/start/routes.ts` with rate limiting
-2. Create/update controller in `backend/app/controllers/`
-3. Add validation in `backend/app/validators/` using VineJS
-4. Apply authorization via policies in `backend/app/policies/`
-5. Update Swagger annotations for auto-documentation
-6. Add frontend HTTP client function in `frontend/src/http/`
-
-### Adding a new migration
-
-```bash
-cd backend
-node ace make:migration create_table_name
-# Edit migration file in database/migrations/
-node ace migration:run
-```
-
-### Modifying stats calculation logic
-
-Stats logic is centralized in `backend/app/services/stat_service.ts`. The service handles all aggregation, interpolation, and growth calculations. Update methods there and ensure scheduler in `start/scheduler.ts` calls the updated logic.
-
-## Performance Considerations
-
-- Rate limiting configured per-route in `start/limiter.ts`
-- Stats queries use PostgreSQL native aggregation for efficiency
-- Frontend images lazy-loaded with progressive loading component
-- Next.js optimizes images automatically (WebP, responsive sizes)
-- Console logs removed in production builds (`removeConsole: true`)
-- SWR caching reduces redundant API calls
-
-## Package Management
-
-Both frontend and backend use Yarn 1.22.22 as specified in `packageManager` field.
+### Backend (`backend/`)
+
+- **Models** (`app/models/`): `Server`, `ServerStat` (10-min time series), `ServerGrowthStat`
+  (weekly/monthly growth), `Category`, `Language`, `User`. `Server` has relations to all of these.
+- **Controllers** (`app/controllers/`): Servers, Stats, Categories, Auth (login/register/OAuth/
+  email verify), WebsiteStats.
+- **Services** (`app/services/stat_service.ts`): `StatsService` — **all** aggregation,
+  interpolation, and growth math lives here. Change it here, not in callers.
+- **Policies** (`app/policies/`): Bouncer authorization (a user may only modify their own servers).
+- **Minecraft ping** (`minecraft-ping/minecraft_ping.ts`): `@minescope/mineping` queries.
+- **Scheduler** (`start/scheduler.ts`): every 10 min ping all servers (uniform spacing via
+  `pLimit(1)` + computed delays to avoid rate limits); every 6 h refresh favicons + growth stats.
+- **Routes** (`start/routes.ts`): all under `/api/v1`, rate-limited (`start/limiter.ts`).
+- **Import aliases**: `#` prefix, e.g. `#models/server`, `#controllers/auth_controller`.
+
+### Frontend (`frontend/`)
+
+- `src/app/` — App Router pages: `(pages)/`, `(auth)/`, `account/`.
+- `src/components/` — by feature: `serveur/`, `form/`, `ui/` (shadcn/Radix), `dark-mode/`, `metrics/`.
+- `src/contexts/` — `auth.tsx`, `servers.tsx` (SWR), `favorite.tsx` (localStorage).
+- `src/http/` — API client (`auth.ts`, `server.ts`). `src/types/` — TS types.
+- Tailwind + shadcn/ui, SWR for data, AG Charts for stats.
+
+## Key Patterns
+
+- **Stats aggregation** (`StatsService`): raw 10-min points; interval bucketing (30 min → 1 week)
+  via PG `floor(extract(epoch...))`; exact-time lookups average nearest before/after points; growth
+  % stored in `ServerGrowthStat`. Queries take `fromDate`/`toDate` (epoch ms) + `interval`.
+- **`Server.syncLanguages()`**: many-to-many language sync with manual transaction control for atomicity.
+- **Auth**: session-based (DB access tokens) + Google/Discord OAuth (Ally) + JWT email verification
+  (MJML mail templates); passwords hashed with Argon2.
+- **Favicons**: ping returns base64 → saved PNG at `public/images/servers/{id}.png` → WebP via Sharp.
+
+## Commands
+
+Both apps use **Yarn 1.22.22**. Standard scripts: `yarn dev | build | start | lint`.
+
+- Backend extras: `yarn test` (Japa), `yarn typecheck`, `node ace migration:run|rollback`,
+  `node ace make:migration <name>`, `node ace docs:generate`, `node ace scheduler:run`.
+- Local DB: `docker compose --env-file ./.env.development up -d` (see `backend/README.md`),
+  then `node ace migration:run`.
+- Tests live in `backend/tests/{unit,functional}/**/*.spec.ts`.
+
+## Conventions
+
+- **New endpoint**: route (`routes.ts`, rate-limited) → controller → VineJS validator
+  (`app/validators/`) → policy → Swagger annotations → frontend client in `src/http/`.
+- **API docs**: auto-generated (`adonis-autoswagger`) — UI at `/docs`, JSON at `/swagger`.
+- **Env vars**: backend needs DB_*, APP_KEY, PORT/HOST/NODE_ENV, SMTP, OAuth, Redis (see
+  `backend/config/`); frontend needs `NEXT_PUBLIC_API_URL`.
+- Production builds strip console logs (`removeConsole: true`).

--- a/backend/app/constants/server_type.ts
+++ b/backend/app/constants/server_type.ts
@@ -1,0 +1,9 @@
+export type ServerType = 'java' | 'bedrock'
+
+export const SERVER_TYPES: ServerType[] = ['java', 'bedrock']
+
+/** Port par défaut selon l'édition : Java écoute en TCP 25565, Bedrock en UDP 19132. */
+export const DEFAULT_PORT: Record<ServerType, number> = {
+  java: 25565,
+  bedrock: 19132,
+}

--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -6,8 +6,9 @@ import type { HttpContext } from '@adonisjs/core/http'
 import {
   INTERACTIVE_PING_TIMEOUT,
   isPingPossible,
-  pingMinecraftJava,
+  pingMinecraftServer,
 } from '../../minecraft-ping/minecraft_ping.js'
+import type { NormalizedPing } from '../../minecraft-ping/minecraft_ping.js'
 import Server from '../models/server.js'
 import CacheService from '#services/cache_service'
 import StatsService from '#services/stat_service'
@@ -32,6 +33,7 @@ export default class ServersController {
       'name',
       'address',
       'port',
+      'type',
       'image_url',
       'last_player_count',
       'last_stats_at',
@@ -55,19 +57,29 @@ export default class ServersController {
    * @responseBody 422 - {"errors": [{"message": "Validation failed", "field": "address"}]}
    */
   async store({ request, auth, response }: HttpContext) {
-    const data = request.only(['name', 'address', 'port', 'imageUrl', 'categories', 'languages'])
+    const data = request.only([
+      'name',
+      'address',
+      'port',
+      'type',
+      'imageUrl',
+      'categories',
+      'languages',
+    ])
     const user = auth.user
     if (!user) {
       return response.unauthorized({ message: 'Unauthorized' })
     }
 
     const validatedData = await CreateServerValidator.validate(data)
+    const type = validatedData.type ?? 'java'
 
     // Ping interactif : sert à la fois de test de joignabilité ET de source
     // pour les empreintes de détection de doublon (favicon, MOTD, version).
-    let pingData: Awaited<ReturnType<typeof pingMinecraftJava>> | null = null
+    let pingData: NormalizedPing | null = null
     try {
-      pingData = await pingMinecraftJava(
+      pingData = await pingMinecraftServer(
+        type,
         validatedData.address,
         validatedData.port,
         INTERACTIVE_PING_TIMEOUT
@@ -100,6 +112,7 @@ export default class ServersController {
 
     const server = await Server.create({
       ...dataToCreate,
+      type,
       version: fingerprint.version,
       faviconHash: fingerprint.faviconHash,
       resolvedEndpoint: fingerprint.resolvedEndpoint,
@@ -172,7 +185,15 @@ export default class ServersController {
    * @responseBody 422 - {"errors": [{"message": "Validation failed", "field": "port"}]}
    */
   async update({ params, request, response, bouncer }: HttpContext) {
-    const data = request.only(['name', 'address', 'port', 'imageUrl', 'categories', 'languages'])
+    const data = request.only([
+      'name',
+      'address',
+      'port',
+      'type',
+      'imageUrl',
+      'categories',
+      'languages',
+    ])
     const validatedData = await UpdateServerValidator.validate(data)
     const server = await Server.findByOrFail('id', params.id)
     if (await bouncer.with(ServerPolicy).denies('update', server)) {
@@ -182,6 +203,7 @@ export default class ServersController {
     const { categories, languages, ...dataToUpdate } = validatedData
 
     const successPing = await isPingPossible(
+      validatedData.type ?? server.type,
       validatedData.address ?? server.address,
       validatedData.port ?? server.port
     )
@@ -246,6 +268,7 @@ export default class ServersController {
    * @paramQuery categoryIds - CSV of category ids to filter on (e.g. "1,2,3") - @type(string) @example(1,3,5)
    * @paramQuery languageIds - CSV of language ids to filter on (e.g. "1,2,3") - @type(string) @example(1,2)
    * @paramQuery search - Case-insensitive substring matched against name and address - @type(string) @example(hypixel)
+   * @paramQuery type - Filter by server edition. Any other value is ignored. - @type(string) @enum(java, bedrock)
    * @paramQuery ids - Restrict to specific server ids. Accepts CSV ("1,2,3") OR repeated param ("ids=1&ids=2"). Positive integers only, deduplicated, max 20 ids (extras dropped). Used for the favorites section. - @type(string) @example(12,34,56)
    * @paramQuery nocache - Set to "1" to bypass the response cache. Only honored in non-production environments or for admin users. - @type(string) @enum(1)
    * @responseBody 200 - {"data": [{"server": "<Server>", "stats": [{"serverId": 1, "createdAt": "2026-05-28T12:00:00.000Z", "playerCount": 1200, "maxCount": 5000}], "categories": ["<Category>"], "growthStat": "<ServerGrowthStat>"}], "meta": {"total": 100, "perPage": 10, "currentPage": 1, "lastPage": 10, "firstPage": 1}}
@@ -258,6 +281,9 @@ export default class ServersController {
     const languageIds = request.input('languageIds')
     const search = request.input('search', '')
     const idsParam = request.input('ids')
+    // Édition (java/bedrock). Toute autre valeur est ignorée (pas de filtre).
+    const typeParam = request.input('type')
+    const type = typeParam === 'java' || typeParam === 'bedrock' ? typeParam : undefined
 
     // `ids` restreint la requête à une liste explicite de serveurs — utilisé par
     // la section "favoris", qui affiche les favoris de l'utilisateur dans leur
@@ -281,6 +307,7 @@ export default class ServersController {
       categoryIds,
       languageIds,
       search,
+      type,
       ids: ids.join(','),
     })
 
@@ -302,6 +329,7 @@ export default class ServersController {
           categoryIds,
           languageIds,
           search,
+          type,
           ids,
         })
         return result
@@ -344,9 +372,10 @@ export default class ServersController {
     categoryIds?: string
     languageIds?: string
     search: string
+    type?: 'java' | 'bedrock'
     ids: number[]
   }) {
-    const { page, limit, categoryIds, languageIds, search, ids } = opts
+    const { page, limit, categoryIds, languageIds, search, type, ids } = opts
 
     // Ordering : on ne classe par `last_player_count` que si le dernier ping
     // réussi est récent (< 30 min, soit ~3 cycles de 10 min). Sinon le serveur
@@ -379,6 +408,10 @@ export default class ServersController {
       query = query.where((builder) => {
         builder.whereILike('name', `%${search}%`).orWhereILike('address', `%${search}%`)
       })
+    }
+
+    if (type) {
+      query = query.where('type', type)
     }
 
     if (categoryIds) {

--- a/backend/app/models/server.ts
+++ b/backend/app/models/server.ts
@@ -6,6 +6,7 @@ import Language from './language.js'
 import ServerGrowthStat from './server_growth_stat.js'
 import User from './user.js'
 import { LanguageCode } from '../constants/languages.js'
+import type { ServerType } from '../constants/server_type.js'
 import db from '@adonisjs/lucid/services/db'
 
 export default class Server extends BaseModel {
@@ -20,6 +21,10 @@ export default class Server extends BaseModel {
 
   @column()
   declare port: number
+
+  // Édition du serveur — détermine le protocole de ping (cf. minecraft_ping.ts).
+  @column()
+  declare type: ServerType
 
   @column()
   declare version: string | null

--- a/backend/app/validators/server.ts
+++ b/backend/app/validators/server.ts
@@ -1,5 +1,6 @@
 import vine from '@vinejs/vine'
 import { LanguageCode } from '../constants/languages.js'
+import { SERVER_TYPES } from '../constants/server_type.js'
 import { publicHostField } from './helpers.js'
 
 export enum ServerCategory {
@@ -21,6 +22,7 @@ export const CreateServerValidator = vine.compile(
     name: vine.string(),
     address: publicHostField(),
     port: vine.number().max(65535).min(1),
+    type: vine.enum(SERVER_TYPES).optional(),
     imageUrl: vine.string().optional(),
     categories: vine.array(vine.string()),
     version: vine.string().optional(),
@@ -34,6 +36,7 @@ export const UpdateServerValidator = vine.compile(
     name: vine.string().optional(),
     address: publicHostField().optional(),
     port: vine.number().max(65535).min(1).optional(),
+    type: vine.enum(SERVER_TYPES).optional(),
     imageUrl: vine.string().optional(),
     categories: vine.array(vine.string()).optional(),
     version: vine.string().optional(),

--- a/backend/database/migrations/1778600000000_add_type_to_servers.ts
+++ b/backend/database/migrations/1778600000000_add_type_to_servers.ts
@@ -1,0 +1,22 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+/**
+ * Support des serveurs Bedrock. `type` distingue l'édition à pinger : le protocole
+ * diffère (Java = handshake TCP 25565, Bedrock = Unconnected Ping RakNet UDP 19132).
+ * Défaut 'java' : tous les serveurs déjà listés sont des serveurs Java.
+ */
+export default class extends BaseSchema {
+  protected tableName = 'servers'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.string('type').notNullable().defaultTo('java')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('type')
+    })
+  }
+}

--- a/backend/minecraft-ping/minecraft_ping.ts
+++ b/backend/minecraft-ping/minecraft_ping.ts
@@ -1,4 +1,5 @@
-import { pingJava } from '@minescope/mineping'
+import { pingBedrock, pingJava } from '@minescope/mineping'
+import type { ServerType } from '../app/constants/server_type.js'
 
 /**
  * Timeout par défaut pour les pings périodiques. 5s : laisse une chance aux serveurs
@@ -14,23 +15,58 @@ export const DEFAULT_PING_TIMEOUT = 5000
  */
 export const INTERACTIVE_PING_TIMEOUT = 5000
 
-export const pingMinecraftJava = async (
+/**
+ * Forme de ping normalisée commune aux deux éditions. Les réponses brutes de
+ * `@minescope/mineping` diffèrent (Java expose `version.name`, `description`, un
+ * favicon ; Bedrock expose `version.minecraft`, `name`, et aucun favicon). Les
+ * appelants (scheduler, controller, détection de doublon) ne dépendent que de ces
+ * champs, donc on aplatit les deux protocoles vers cette structure unique.
+ */
+export interface NormalizedPing {
+  players: { online: number; max: number }
+  version: { name: string }
+  // Absent en Bedrock : le pong RakNet ne contient pas d'icône de serveur.
+  favicon?: string
+  description?: unknown
+}
+
+/**
+ * Ping un serveur Minecraft de l'édition donnée et renvoie une réponse normalisée.
+ * Rejette si le serveur est injoignable (timeout, refus de connexion…).
+ */
+export const pingMinecraftServer = async (
+  type: ServerType,
   address: string,
-  port: number = 25565,
+  port: number,
   timeout: number = DEFAULT_PING_TIMEOUT
-) => {
-  try {
-    const data = await pingJava(address, { port, timeout })
-    return data
-  } catch (error) {
-    throw new Error(error)
+): Promise<NormalizedPing> => {
+  if (type === 'bedrock') {
+    const data = await pingBedrock(address, { port, timeout })
+    return {
+      players: { online: data.players.online, max: data.players.max },
+      version: { name: data.version.minecraft },
+      // Pas de favicon en Bedrock ; le nom du MOTD sert d'empreinte de doublon.
+      description: data.name,
+    }
+  }
+
+  const data = await pingJava(address, { port, timeout })
+  return {
+    players: { online: data.players?.online ?? 0, max: data.players?.max ?? 0 },
+    version: { name: data.version.name },
+    favicon: data.favicon,
+    description: data.description,
   }
 }
 
-export const isPingPossible = async (address: string, port: number = 25565) => {
+export const isPingPossible = async (
+  type: ServerType,
+  address: string,
+  port: number
+): Promise<boolean> => {
   try {
-    const data = await pingMinecraftJava(address, port, INTERACTIVE_PING_TIMEOUT)
-    return !!data
+    await pingMinecraftServer(type, address, port, INTERACTIVE_PING_TIMEOUT)
+    return true
   } catch (error) {
     console.error(error)
     return false

--- a/backend/start/scheduler.ts
+++ b/backend/start/scheduler.ts
@@ -11,7 +11,7 @@ import path, { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import pLimit from 'p-limit'
 import sharp from 'sharp'
-import { pingMinecraftJava } from '../minecraft-ping/minecraft_ping.js'
+import { pingMinecraftServer } from '../minecraft-ping/minecraft_ping.js'
 
 type ServerStatRow = {
   server_id: number
@@ -139,7 +139,7 @@ async function updateServerInfo(server: Server, overwriteImage = false): Promise
   const createdAt = new Date()
 
   try {
-    const data = await pingMinecraftJava(server.address, server.port)
+    const data = await pingMinecraftServer(server.type, server.address, server.port)
     if (data) {
       if (data.favicon && (overwriteImage || !server.imageUrl)) {
         try {

--- a/frontend/src/components/form/add-server-form/index.tsx
+++ b/frontend/src/components/form/add-server-form/index.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { FancyMultiSelect } from "@/components/ui/multi-select";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/components/ui/use-toast";
 import { useServers } from "@/contexts/servers";
 import { DuplicateServerError } from "@/http/server";
@@ -18,6 +19,12 @@ import { z } from "zod";
 
 interface AddServerFormProps extends React.HTMLAttributes<HTMLFormElement> {}
 
+/** Port d'écoute par défaut selon l'édition (Java TCP 25565, Bedrock UDP 19132). */
+const DEFAULT_PORT: Record<"java" | "bedrock", string> = {
+  java: "25565",
+  bedrock: "19132",
+};
+
 const AddServerForm: FC<AddServerFormProps> = ({ className, ...props }) => {
   const { data, isLoading, error } = useSWRImmutable<Category[]>(`${getBaseUrl()}/categories`, fetcher);
   const { data: languagesData } = useSWRImmutable<Language[]>(`${getBaseUrl()}/languages`, fetcher);
@@ -29,6 +36,7 @@ const AddServerForm: FC<AddServerFormProps> = ({ className, ...props }) => {
     .object({
       name: z.string().min(1).trim(),
       address: z.string().min(1).trim(),
+      type: z.enum(["java", "bedrock"]),
       port: z.string().min(1).max(5),
       categories: z.array(z.string()),
       languages: z.array(z.string()),
@@ -57,7 +65,8 @@ const AddServerForm: FC<AddServerFormProps> = ({ className, ...props }) => {
     defaultValues: {
       name: "",
       address: "",
-      port: "25565",
+      type: "java",
+      port: DEFAULT_PORT.java,
       categories: [],
       languages: [],
     },
@@ -142,6 +151,35 @@ const AddServerForm: FC<AddServerFormProps> = ({ className, ...props }) => {
                   <FormDescription>The address of the server</FormDescription>
                   <FormControl>
                     <Input type="text" placeholder="" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Edition</FormLabel>
+                  <FormDescription>Java or Bedrock edition</FormDescription>
+                  <FormControl>
+                    <Select
+                      value={field.value}
+                      onValueChange={(value: "java" | "bedrock") => {
+                        field.onChange(value);
+                        // Bascule le port sur la valeur par défaut de l'édition choisie.
+                        form.setValue("port", DEFAULT_PORT[value]);
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="java">Java</SelectItem>
+                        <SelectItem value="bedrock">Bedrock</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/frontend/src/components/form/edit-server-form/index.tsx
+++ b/frontend/src/components/form/edit-server-form/index.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { FancyMultiSelect } from "@/components/ui/multi-select";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/components/ui/use-toast";
 import { useAuth } from "@/contexts/auth";
 import { deleteServer, editServer } from "@/http/server";
@@ -41,6 +42,7 @@ const EditServerForm: FC<EditServerFormProps> = ({ server, serverCategories, upd
    .object({
      name: z.string().min(1).trim(),
      address: z.string().min(1).trim(),
+     type: z.enum(["java", "bedrock"]),
      port: z.string().min(1).max(5),
      categories: z.array(z.string()),
      languages: z.array(z.string()),
@@ -70,6 +72,7 @@ const EditServerForm: FC<EditServerFormProps> = ({ server, serverCategories, upd
     defaultValues: {
       name: server.name,
       address: server.address,
+      type: server.type,
       port: server.port.toString(),
       categories: serverCategories.map((category) => category.name),
       languages: server.languages.map((language) => language.code),
@@ -161,6 +164,28 @@ const EditServerForm: FC<EditServerFormProps> = ({ server, serverCategories, upd
                   <FormDescription>The address of the server</FormDescription>
                   <FormControl>
                     <Input type="text" placeholder="" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Edition</FormLabel>
+                  <FormDescription>Java or Bedrock edition</FormDescription>
+                  <FormControl>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="java">Java</SelectItem>
+                        <SelectItem value="bedrock">Bedrock</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/frontend/src/components/home/server-cards-section.tsx
+++ b/frontend/src/components/home/server-cards-section.tsx
@@ -35,6 +35,7 @@ const ServerCardsSection = () => {
   const [search, setSearch] = useState("");
   const [selectedCategories, setSelectedCategories] = useState<number[]>([]);
   const [selectedLanguages, setSelectedLanguages] = useState<number[]>([]);
+  const [selectedType, setSelectedType] = useState<"all" | "java" | "bedrock">("all");
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
   const debouncedSearch = useDebounce(search, 300);
@@ -46,9 +47,10 @@ const ServerCardsSection = () => {
   const searchParam = debouncedSearch ? `&search=${encodeURIComponent(debouncedSearch)}` : "";
   const categoriesParam = selectedCategories.length > 0 ? `&categoryIds=${selectedCategories.join(",")}` : "";
   const languagesParam = selectedLanguages.length > 0 ? `&languageIds=${selectedLanguages.join(",")}` : "";
+  const typeParam = selectedType !== "all" ? `&type=${selectedType}` : "";
 
   const { data, isValidating, isLoading } = useSWR<PaginatedResponse>(
-    `${apiUrl}/servers/paginate?page=${currentPage}&limit=${pageSize}${searchParam}${categoriesParam}${languagesParam}`,
+    `${apiUrl}/servers/paginate?page=${currentPage}&limit=${pageSize}${searchParam}${categoriesParam}${languagesParam}${typeParam}`,
     fetcher,
     { keepPreviousData: true }
   );
@@ -73,6 +75,11 @@ const ServerCardsSection = () => {
     setCurrentPage(1);
   };
 
+  const updateType = (type: "all" | "java" | "bedrock") => {
+    setSelectedType(type);
+    setCurrentPage(1);
+  };
+
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
   };
@@ -86,10 +93,12 @@ const ServerCardsSection = () => {
     setSearch("");
     setSelectedCategories([]);
     setSelectedLanguages([]);
+    setSelectedType("all");
     setCurrentPage(1);
   };
 
-  const hasActiveFilters = search || selectedCategories.length > 0 || selectedLanguages.length > 0;
+  const hasActiveFilters =
+    search || selectedCategories.length > 0 || selectedLanguages.length > 0 || selectedType !== "all";
   const isFetching = isLoading || isValidating;
 
   const rangeStart = totalServers === 0 ? 0 : (currentPage - 1) * pageSize + 1;
@@ -144,6 +153,16 @@ const ServerCardsSection = () => {
               emptyMessage="No languages found."
               className="flex-1 sm:flex-none"
             />
+            <Select value={selectedType} onValueChange={(v) => updateType(v as "all" | "java" | "bedrock")}>
+              <SelectTrigger aria-label="Edition" className="h-9 flex-1 sm:w-auto sm:flex-none">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All editions</SelectItem>
+                <SelectItem value="java">Java</SelectItem>
+                <SelectItem value="bedrock">Bedrock</SelectItem>
+              </SelectContent>
+            </Select>
             <Button
               variant="ghost"
               size="icon"

--- a/frontend/src/components/serveur/card/index.tsx
+++ b/frontend/src/components/serveur/card/index.tsx
@@ -50,7 +50,7 @@ const ServerCard = ({ server, stats, categories, growthStat, isFull, showChart =
           </div>
         </div>
         <div className="flex flex-row items-center justify-between gap-2 w-full">
-          <ServerCategories categories={categories} version={server.version ?? undefined} isFull={isFull} />
+          <ServerCategories categories={categories} version={server.version ?? undefined} type={server.type} isFull={isFull} />
           <FavoriteButton serverId={server.id} serverName={server.name} />
         </div>
       </div>

--- a/frontend/src/components/serveur/card/server-category.tsx
+++ b/frontend/src/components/serveur/card/server-category.tsx
@@ -1,16 +1,29 @@
 import { Badge } from "@/components/ui/badge";
-import { Category } from "@/types/server";
+import { Category, ServerType } from "@/types/server";
+import { cn } from "@/lib/utils";
 import { extractVersions, formatVersion } from "@/utils/server-version";
 
 interface ServerCategoriesProps {
   categories: Category[];
   version?: string;
+  type?: ServerType;
   isFull?: boolean;
 }
 
-const ServerCategories = ({ categories, version, isFull }: ServerCategoriesProps) => {
+const ServerCategories = ({ categories, version, type, isFull }: ServerCategoriesProps) => {
   return (
     <div className="flex flex-row items-center gap-1 truncate">
+      <Badge
+        variant="outline"
+        className={cn(
+          "text-xs",
+          type === "bedrock"
+            ? "border-emerald-500/60 text-emerald-600 dark:text-emerald-400"
+            : "border-sky-500/60 text-sky-600 dark:text-sky-400"
+        )}
+      >
+        {type === "bedrock" ? "Bedrock" : "Java"}
+      </Badge>
       <Badge
         variant="secondary"
         className="bg-stats-blue-900 dark:bg-stats-blue-950 text-white hover:bg-stats-blue-800 dark:hover:bg-stats-blue-800/80"

--- a/frontend/src/contexts/servers.tsx
+++ b/frontend/src/contexts/servers.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { addMinecraftServer } from "@/http/server";
+import { addMinecraftServer, ServerPayload } from "@/http/server";
 import { createContext, useCallback, useContext, useMemo } from "react";
 import { useAuth } from "./auth";
 
 interface ServersContextProps {
-  addServer: (data: { name: string; address: string; port: number; categories: string[] }) => Promise<void>;
+  addServer: (data: ServerPayload) => Promise<void>;
 }
 
 export const ServersContext = createContext<ServersContextProps | null>(null);
@@ -22,7 +22,7 @@ export const ServersProvider = ({ children }: { children: React.ReactNode }) => 
   const { getToken } = useAuth();
 
   const addServer = useCallback(
-    async (data: { name: string; address: string; port: number; categories: string[] }) => {
+    async (data: ServerPayload) => {
       // Pas de wrapping de l'erreur : on laisse remonter l'instance d'origine
       // (notamment DuplicateServerError) pour que le formulaire puisse la typer.
       await addMinecraftServer(data, getToken() ?? "");

--- a/frontend/src/http/server.ts
+++ b/frontend/src/http/server.ts
@@ -1,5 +1,13 @@
 import { getBaseUrl } from "@/app/_cheatcode";
-import { Category, Server, ServerStat } from "@/types/server";
+import { Category, Server, ServerStat, ServerType } from "@/types/server";
+
+export interface ServerPayload {
+  name: string;
+  address: string;
+  port: number;
+  type: ServerType;
+  categories: string[];
+}
 // Note: GET /api/v1/servers is a lightweight endpoint that returns only { server } (no stats/categories).
 // For richer data, use /servers/paginate or /servers/:id.
 import { getErrorMessage } from "./auth";
@@ -25,7 +33,7 @@ export class DuplicateServerError extends Error {
 }
 
 export const addMinecraftServer = async (
-  data: { name: string; address: string; port: number; categories: string[] },
+  data: ServerPayload,
   token: string
 ) => {
   const response = await fetch(`${getBaseUrl()}/servers`, {
@@ -119,7 +127,7 @@ export const deleteServer = async (serverId: number, token: string) => {
 
 export const editServer = async (
   serverId: number,
-  data: { name: string; address: string; port: number; categories: string[] },
+  data: ServerPayload,
   token: string
 ) => {
   const response = await fetch(`${getBaseUrl()}/servers/${serverId}`, {

--- a/frontend/src/types/server.ts
+++ b/frontend/src/types/server.ts
@@ -9,11 +9,14 @@ export interface Language {
   updatedAt: Date;
 }
 
+export type ServerType = "java" | "bedrock";
+
 export interface Server {
   id: number;
   name: string;
   address: string;
   port: number;
+  type: ServerType;
   version: string | null;
   imageUrl: string;
   user: User;


### PR DESCRIPTION
- Introduced `ServerType` and `SERVER_TYPES` constants to manage server types.
- Updated `Server` model to include `type` column with default value 'java'.
- Modified `ServersController` to handle server type during creation and updates.
- Enhanced `pingMinecraftServer` function to support both Java and Bedrock editions.
- Updated frontend forms to include server type selection and default port handling.
- Adjusted server listing and card components to display server type.
- Added migration to alter `servers` table and include `type` column.