### PR TITLE
refactor: full clean-code pass from framework best-practices audit

### DIFF
--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -123,17 +123,13 @@ export default class ServersController {
       categories.map((name) => Category.findBy('name', name))
     )
 
-    await server
-      .related('categories')
-      .attach(categoriesToAttach.filter((c) => c !== null).map((c) => c!.id))
+    await server.related('categories').attach(categoriesToAttach.flatMap((c) => (c ? [c.id] : [])))
 
     const languagesToAttach = await Promise.all(
       languages.map((code) => Language.findBy('code', code))
     )
 
-    await server
-      .related('languages')
-      .attach(languagesToAttach.filter((l) => l !== null).map((l) => l!.id))
+    await server.related('languages').attach(languagesToAttach.flatMap((l) => (l ? [l.id] : [])))
 
     await server.related('user').associate(user)
     return server
@@ -216,9 +212,7 @@ export default class ServersController {
         categories.map((name) => Category.findBy('name', name))
       )
 
-      await server
-        .related('categories')
-        .sync(categoriesToAttach.filter((c) => c !== null).map((c) => c!.id))
+      await server.related('categories').sync(categoriesToAttach.flatMap((c) => (c ? [c.id] : [])))
     }
 
     if (languages) {
@@ -226,9 +220,7 @@ export default class ServersController {
         languages.map((code) => Language.findBy('code', code))
       )
 
-      await server
-        .related('languages')
-        .sync(languagesToAttach.filter((l) => l !== null).map((l) => l!.id))
+      await server.related('languages').sync(languagesToAttach.flatMap((l) => (l ? [l.id] : [])))
     }
 
     return server.merge(dataToUpdate).save()

--- a/backend/app/controllers/uploads_controller.ts
+++ b/backend/app/controllers/uploads_controller.ts
@@ -73,7 +73,7 @@ export default class UploadsController {
     } catch (error) {
       return response.internalServerError({
         error: 'Failed to process image',
-        details: error.message,
+        details: error instanceof Error ? error.message : 'Unknown error',
       })
     }
   }

--- a/backend/app/services/stat_service.ts
+++ b/backend/app/services/stat_service.ts
@@ -9,7 +9,7 @@ export default class StatsService {
     created_at: DateTime
     max_count: number
     player_count: number
-  }): any {
+  }): { serverId: number; createdAt: DateTime; playerCount: number; maxCount: number } {
     return {
       serverId: input.server_id,
       createdAt: input.created_at,
@@ -156,7 +156,7 @@ export default class StatsService {
         ORDER BY 1
       `
 
-      const bindings: any = { serverId }
+      const bindings: Record<string, string | number | number[]> = { serverId }
       if (fromDateSql) bindings.fromDate = fromDateSql
       if (toDateSql) bindings.toDate = toDateSql
 
@@ -198,7 +198,7 @@ export default class StatsService {
       ORDER BY 1
     `
 
-    const bindings: any = { serverId }
+    const bindings: Record<string, string | number | number[]> = { serverId }
     if (fromDateSql) bindings.fromDate = fromDateSql
     if (toDateSql) bindings.toDate = toDateSql
 
@@ -537,17 +537,23 @@ export default class StatsService {
       ORDER BY bucket
     `
 
-    const bindings: any = {}
+    const bindings: Record<string, string | number | number[]> = {}
     if (fromDateSql) bindings.fromDate = fromDateSql
     if (toDateSql) bindings.toDate = toDateSql
     if (params.categoryId) bindings.categoryId = params.categoryId
     if (params.languageId) bindings.languageId = params.languageId
 
     const result = await Database.rawQuery(rawQuery, bindings)
-    return result.rows.map((row: any) => ({
-      createdAt: row.created_at,
-      playerCount: Number(row.player_count),
-      maxCount: Number(row.max_count),
-    }))
+    return result.rows.map(
+      (row: {
+        created_at: string | Date
+        player_count: string | number
+        max_count: string | number
+      }) => ({
+        createdAt: row.created_at,
+        playerCount: Number(row.player_count),
+        maxCount: Number(row.max_count),
+      })
+    )
   }
 }

--- a/backend/start/scheduler.ts
+++ b/backend/start/scheduler.ts
@@ -105,7 +105,7 @@ async function tryAcquirePingLock(serverId: number): Promise<boolean> {
     return result === 'OK'
   } catch (error) {
     logger.warn(
-      { serverId, err: error.message },
+      { serverId, err: error instanceof Error ? error.message : String(error) },
       'PING_LOCK: redis unavailable, proceeding without lock'
     )
     return true
@@ -201,7 +201,7 @@ async function updateServerInfo(server: Server, overwriteImage = false): Promise
     }
   } catch (error) {
     logger.warn(
-      `SCHEDULER: ping failed for ${server.name} (${server.address}:${server.port}): ${error.message}`
+      `SCHEDULER: ping failed for ${server.name} (${server.address}:${server.port}): ${error instanceof Error ? error.message : String(error)}`
     )
   }
 
@@ -292,7 +292,10 @@ scheduler
     try {
       await pingDueServers(false)
     } catch (error) {
-      logger.error({ err: error.message }, 'SCHEDULER: pingDueServers failed')
+      logger.error(
+        { err: error instanceof Error ? error.message : String(error) },
+        'SCHEDULER: pingDueServers failed'
+      )
     }
   })
   .everyFiveMinutes()

--- a/frontend/src/app/(pages)/cgu/page.tsx
+++ b/frontend/src/app/(pages)/cgu/page.tsx
@@ -89,9 +89,9 @@ const CGU = () => {
         <p>
           Nous utilisons le local storage pour gérer l&apos;authentification. Pour plus d&apos;informations, veuillez
           consulter notre politique de confidentialité{" "}
-          <a href="/cgu" className="text-blue-500">
+          <Link href="/cgu" className="text-blue-500">
             ici
-          </a>
+          </Link>
           .
         </p>
         <h3 className="text-lg font-medium mb-1">Stockage et Sécurité des Données</h3>

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -7,6 +7,10 @@ interface Server {
   updatedAt: string;
 }
 
+interface ServerListItem {
+  server: Server;
+}
+
 async function getAllServers(apiUrl: string): Promise<Server[]> {
   try {
     const response = await fetch(`${apiUrl}/servers`, {
@@ -18,8 +22,8 @@ async function getAllServers(apiUrl: string): Promise<Server[]> {
       return [];
     }
 
-    const data = await response.json();
-    return data.map((item: any) => ({
+    const data: ServerListItem[] = await response.json();
+    return data.map((item) => ({
       id: item.server.id,
       name: item.server.name,
       updatedAt: item.server.updatedAt,

--- a/frontend/src/components/form/add-server-form/index.tsx
+++ b/frontend/src/components/form/add-server-form/index.tsx
@@ -12,6 +12,7 @@ import { DuplicateServerError } from "@/http/server";
 import { cn } from "@/lib/utils";
 import { Category, Language } from "@/types/server";
 import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
 import { FC } from "react";
 import { useForm } from "react-hook-form";
 import useSWRImmutable from "swr/immutable";
@@ -100,12 +101,12 @@ const AddServerForm: FC<AddServerFormProps> = ({ className, ...props }) => {
           description: (
             <span>
               This server is already on Minecraft Stats as{" "}
-              <a
+              <Link
                 className="font-semibold underline"
                 href={`/servers/${safeServerId}`}
               >
                 {error.existingServer.name}
-              </a>
+              </Link>
               .
             </span>
           ),

--- a/frontend/src/contexts/auth.tsx
+++ b/frontend/src/contexts/auth.tsx
@@ -59,7 +59,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       const response = await getUser(token);
       setUser(response || null);
       setIsLoggedIn(true);
-    } catch (error: any) {
+    } catch {
       setUser(null);
       setIsLoggedIn(false);
       removeToken();


### PR DESCRIPTION
## Summary
Multi-agent audit of the codebase against current React 19 / Next.js 16 / AdonisJS 6 / strict-TypeScript-6 best practices, **with the full set of findings now applied** (58 findings across 4 commits). Built with workflows + agents: research (4 agents) → new local skill `framework-best-practices` → audit (7 agents, 58 findings) → apply (multiple agents, one per file/unit).

Each commit is verified: backend (`tsc --noEmit`, `eslint .`, `node ace build`) and frontend (`tsc --noEmit`, `eslint src`, `next build`) are **all green**.

## Commits
1. **safe fixes** — narrow catches, `flatMap` instead of `!`, `next/link`.
2. **batch 1 — type-safety & dead code** — `any`/`as`/`!` → precise types/guards across 16 files; remove dead state.
3. **backend behavioral** — service extraction, VineJS validation, error handling, N+1 fix.
4. **frontend behavioral** — React effect fixes + fetch-in-effect → SWR.

## What changed by theme
### TypeScript (no behavior change)
Narrow all untyped `catch` before reading `.message`/`.status`; replace `any`/`as`/non-null `!` with precise types or guards (controllers, scheduler, services, http client, contexts, chart tooltips, sitemap); remove dead `selectedPlaceholder` state.

### AdonisJS
- **A1** extract data/aggregation out of controllers → `ServerListingService.paginate`, `AdvertisementStatsService.getStats` (logic moved verbatim).
- **A2** validate input with VineJS on `server_categories` (attach/detach), `categories` (id), and `posts.previewPlaceholder` — invalid input now returns **422**.
- **A6** stop swallowing/normalizing errors: `stats_controller` defers to the framework exception handler; removed try/catch around pure CSV parsing; no more bare `catch {}` in `placeholder_service`.
- **A4** fix the N+1 in `placeholder_service.preloadServerData`: ~6×N per-server queries → set-based (`whereIn` + `DISTINCT ON` per-server latest/first/peak + one grouped avg/median).

### React / Next.js
- **R5** `use-toast` subscribe Effect deps `[state]` → `[]`.
- **R2/R11** `multi-select` notifies the parent from handlers, not a state-mirroring Effect; drop needless `useCallback`.
- **R9/N2** migrate ad-hoc `useEffect`+fetch to **SWR**: `latest-articles-section`, home `server-select`, server **edit** page, server **detail** stats (manual `setInterval` → `refreshInterval`), and the **auth context** `/me` bootstrap (public API preserved; `token` drives the SWR key).

## ⚠️ Needs runtime QA before merge
These commits compile/lint/build green but change runtime behavior and were **not** runtime-tested (no DB/browser in CI):
- **Backend (DB):** the N+1 aggregate rewrite (verify min/max/avg/median/first/last/latest match), the new 422 validation responses, and the changed error shapes from `stats_controller`.
- **Frontend (browser):** session/login/logout via the SWR-migrated **auth context**, the server **edit** + **detail** pages, and the home sections.

## Notes
- The audit checklist lives in a new local skill `framework-best-practices` (`.claude/`, gitignored like the repo's other skills).
- The non-clean-code untracked files in the tree (`.ds-sync/`, `ds-bundle/`, `frontend/ds-tailwind.css`) are from a separate design-sync tool and are **not** part of this PR.