### PR TITLE
refactor: clean-code backlog (services, validation, error handling, N+1, SWR)

### DIFF
--- a/backend/app/controllers/advertisements_controller.ts
+++ b/backend/app/controllers/advertisements_controller.ts
@@ -1,13 +1,13 @@
 import Advertisement from '#models/advertisement'
 import AdvertisementEvent from '#models/advertisement_event'
 import AdvertisementPolicy from '#policies/advertisement_policy'
+import AdvertisementStatsService from '#services/advertisement_stats_service'
 import {
   CreateAdvertisementValidator,
   UpdateAdvertisementValidator,
 } from '#validators/advertisement'
 import { parseEpochMs } from '#validators/helpers'
 import type { HttpContext } from '@adonisjs/core/http'
-import db from '@adonisjs/lucid/services/db'
 import { DateTime } from 'luxon'
 
 type Placement = 'home' | 'server'
@@ -387,30 +387,12 @@ export default class AdvertisementsController {
     const fromDate = parseEpochMs(request.input('fromDate'))
     const toDate = parseEpochMs(request.input('toDate'))
 
-    let query = db.from('advertisement_events').where('advertisement_id', ad.id)
-    if (fromDate !== null) query = query.where('created_at', '>=', new Date(fromDate))
-    if (toDate !== null) query = query.where('created_at', '<=', new Date(toDate))
-
-    const rows = await query
-      .select(db.raw('date_trunc(?, created_at) as bucket', [interval]))
-      .select(db.raw(`count(*) filter (where type = 'impression') as impressions`))
-      .select(db.raw(`count(*) filter (where type = 'click') as clicks`))
-      .groupByRaw('bucket')
-      .orderByRaw('bucket asc')
-
-    const series = rows.map((row) => ({
-      time: row.bucket,
-      impressions: Number(row.impressions),
-      clicks: Number(row.clicks),
-    }))
-
-    const totals = series.reduce(
-      (acc, row) => ({
-        impressions: acc.impressions + row.impressions,
-        clicks: acc.clicks + row.clicks,
-      }),
-      { impressions: 0, clicks: 0 }
-    )
+    const { totals, series } = await AdvertisementStatsService.getStats({
+      advertisementId: ad.id,
+      interval,
+      fromDate,
+      toDate,
+    })
 
     return response.ok({ totals, series, interval })
   }

--- a/backend/app/controllers/auth_controller.ts
+++ b/backend/app/controllers/auth_controller.ts
@@ -188,8 +188,12 @@ export default class AuthController {
    * @responseBody 302 - Redirect to the provider's authorization URL
    * @responseBody 400 - {"errors": [{"message": "Unknown OAuth provider"}]}
    */
-  async providerLogin({ ally, request }: HttpContext) {
-    const driverInstance = ally.use(request.param('provider') as 'discord' | 'google')
+  async providerLogin({ ally, request, response }: HttpContext) {
+    const provider = request.param('provider')
+    if (provider !== 'discord' && provider !== 'google') {
+      return response.badRequest({ error: 'Unsupported provider' })
+    }
+    const driverInstance = ally.use(provider)
     return await driverInstance.redirect()
   }
 

--- a/backend/app/controllers/categories_controller.ts
+++ b/backend/app/controllers/categories_controller.ts
@@ -1,7 +1,11 @@
 import Category from '#models/category'
 import CategoryPolicy from '#policies/category_policy'
 import CacheService from '#services/cache_service'
-import { CreateCategoryValidator } from '#validators/category'
+import {
+  CategoryIdValidator,
+  CreateCategoryValidator,
+  UpdateCategoryValidator,
+} from '#validators/category'
 import type { HttpContext } from '@adonisjs/core/http'
 
 const CATEGORIES_CACHE_KEY = 'categories:all'
@@ -48,15 +52,16 @@ export default class CategoriesController {
    * @operationId destroyCategory
    * @tag CATEGORIES
    * @summary Delete a category
-   * @description Deletes a category. The target id is read from the request body (rather than the URL). Authorization is enforced by `CategoryPolicy.destroy`. The categories cache is invalidated on success.
+   * @description Deletes a category. The target id is read from the request body (rather than the URL) and validated against `CategoryIdValidator` (required positive integer). Authorization is enforced by `CategoryPolicy.destroy`. The categories cache is invalidated on success.
    * @paramPath id - Category ID (ignored — id is read from the body) - @type(number) @example(3)
    * @requestBody {"id": 1}
    * @responseBody 200 - <Category>
    * @responseBody 403 - {"message": "Unauthorized"}
    * @responseBody 404 - {"message": "Row not found"}
+   * @responseBody 422 - {"errors": [{"message": "Validation failed", "field": "id"}]}
    */
   async destroy({ request, response, bouncer }: HttpContext) {
-    const { id } = request.body()
+    const { id } = await CategoryIdValidator.validate(request.body())
     const category = await Category.findOrFail(id)
     if (await bouncer.with(CategoryPolicy).denies('destroy')) {
       return response.forbidden({ message: 'Unauthorized' })
@@ -71,7 +76,7 @@ export default class CategoriesController {
    * @operationId updateCategory
    * @tag CATEGORIES
    * @summary Update a category
-   * @description Updates a category. The target id and the updated fields are both read from the request body. The body (minus `id`) is validated against `CreateCategoryValidator`. Authorization is enforced by `CategoryPolicy.update`. The categories cache is invalidated on success.
+   * @description Updates a category. The target id and the updated fields are both read from the request body and validated against `UpdateCategoryValidator` (required positive integer `id` + `name` string). Authorization is enforced by `CategoryPolicy.update`. The categories cache is invalidated on success.
    * @paramPath id - Category ID (ignored — id is read from the body) - @type(number) @example(3)
    * @requestBody {"id": 1, "name": "Survival"}
    * @responseBody 200 - <Category>
@@ -80,8 +85,7 @@ export default class CategoriesController {
    * @responseBody 422 - {"errors": [{"message": "Validation failed", "field": "name"}]}
    */
   async update({ request, response, bouncer }: HttpContext) {
-    const { id, ...data } = request.body()
-    const validatedData = await CreateCategoryValidator.validate(data)
+    const { id, ...validatedData } = await UpdateCategoryValidator.validate(request.body())
     if (await bouncer.with(CategoryPolicy).denies('update')) {
       return response.forbidden({ message: 'Unauthorized' })
     }

--- a/backend/app/controllers/posts_controller.ts
+++ b/backend/app/controllers/posts_controller.ts
@@ -1,7 +1,11 @@
 import Post from '#models/post'
 import PostPolicy from '#policies/post_policy'
 import PlaceholderService from '#services/placeholder_service'
-import { CreatePostValidator, UpdatePostValidator } from '#validators/post'
+import {
+  CreatePostValidator,
+  PreviewPlaceholderValidator,
+  UpdatePostValidator,
+} from '#validators/post'
 import type { HttpContext } from '@adonisjs/core/http'
 import { DateTime } from 'luxon'
 
@@ -291,9 +295,9 @@ export default class PostsController {
    * @description Resolves a single placeholder for a given server and returns both the raw placeholder string and the computed value, so the editor UI can show writers what the token will render to. Requires authentication and `manage` ability on the Post policy.
    * @requestBody {"placeholderName": "PLAYER_COUNT_REALTIME", "serverId": "125"}
    * @responseBody 200 - {"placeholder": "%PLAYER_COUNT_REALTIME_125%", "value": "42", "serverId": 125, "placeholderName": "PLAYER_COUNT_REALTIME"}
-   * @responseBody 400 - {"error": "placeholderName and serverId are required"}
    * @responseBody 401 - {"error": "Unauthorized"}
    * @responseBody 403 - {"error": "Access denied. Writer privileges required."}
+   * @responseBody 422 - {"errors": [{"message": "The serverId field must be defined", "field": "serverId", "rule": "required"}]}
    */
   async previewPlaceholder({ request, response, auth, bouncer }: HttpContext) {
     const user = auth.user
@@ -305,11 +309,7 @@ export default class PostsController {
       return response.forbidden({ error: 'Access denied. Writer privileges required.' })
     }
 
-    const { placeholderName, serverId } = request.only(['placeholderName', 'serverId'])
-
-    if (!placeholderName || !serverId) {
-      return response.badRequest({ error: 'placeholderName and serverId are required' })
-    }
+    const { placeholderName, serverId } = await request.validateUsing(PreviewPlaceholderValidator)
 
     const placeholder = `%${placeholderName}_${serverId}%`
     const result = await PlaceholderService.replacePlaceholders(placeholder)
@@ -317,7 +317,7 @@ export default class PostsController {
     return response.ok({
       placeholder,
       value: result,
-      serverId: Number.parseInt(serverId),
+      serverId,
       placeholderName,
     })
   }

--- a/backend/app/controllers/server_categories_controller.ts
+++ b/backend/app/controllers/server_categories_controller.ts
@@ -1,5 +1,6 @@
 import Server from '#models/server'
 import ServerCategoryPolicy from '#policies/server_category_policy'
+import { attachServerCategoryValidator } from '#validators/server_category'
 import { type HttpContext } from '@adonisjs/core/http'
 
 export default class ServerCategoriesController {
@@ -33,7 +34,7 @@ export default class ServerCategoriesController {
    * @responseBody 404 - {"message": "Row not found"}
    */
   async store({ request, response, bouncer }: HttpContext) {
-    const { serverId, categoryId } = request.body()
+    const { serverId, categoryId } = await request.validateUsing(attachServerCategoryValidator)
     const server = await Server.findOrFail(serverId)
     if (await bouncer.with(ServerCategoryPolicy).denies('update', server)) {
       return response.forbidden({ message: 'Unauthorized' })
@@ -56,7 +57,7 @@ export default class ServerCategoriesController {
    * @responseBody 404 - {"message": "Row not found"}
    */
   async destroy({ request, response, bouncer }: HttpContext) {
-    const { serverId, categoryId } = request.body()
+    const { serverId, categoryId } = await request.validateUsing(attachServerCategoryValidator)
     const server = await Server.findOrFail(serverId)
     if (await bouncer.with(ServerCategoryPolicy).denies('destroy', server)) {
       return response.forbidden({ message: 'Unauthorized' })

--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -11,7 +11,7 @@ import {
 import type { NormalizedPing } from '../../minecraft-ping/minecraft_ping.js'
 import Server from '../models/server.js'
 import CacheService from '#services/cache_service'
-import StatsService from '#services/stat_service'
+import ServerListingService from '#services/server_listing_service'
 import DuplicateDetectionService from '#services/duplicate_detection_service'
 import Language from '#models/language'
 
@@ -315,7 +315,7 @@ export default class ServersController {
       cacheKey,
       ttl,
       async () => {
-        const result = await this.runPaginateQuery({
+        const result = await ServerListingService.paginate({
           page,
           limit,
           categoryIds,
@@ -356,137 +356,5 @@ export default class ServersController {
       if (ids.length >= ServersController.MAX_IDS) break
     }
     return ids
-  }
-
-  private async runPaginateQuery(opts: {
-    page: number
-    limit: number
-    categoryIds?: string
-    languageIds?: string
-    search: string
-    type?: 'java' | 'bedrock'
-    ids: number[]
-  }) {
-    const { page, limit, categoryIds, languageIds, search, type, ids } = opts
-
-    // Ordering : on ne classe par `last_player_count` que si le dernier ping
-    // réussi est récent (< 30 min, soit ~3 cycles de 10 min). Sinon le serveur
-    // est traité comme "stale" et descend en bas, peu importe son ancien count.
-    // Évite qu'un serveur down depuis des jours reste top juste parce qu'il
-    // avait 500 joueurs avant de tomber.
-    let query = Server.query()
-      .preload('user', (userQuery) => userQuery.select('id', 'username', 'avatarUrl'))
-      .preload('categories')
-      .preload('growthStat')
-      .preload('languages')
-
-    // Restriction à une liste explicite d'IDs (section favoris) : `whereIn` avec
-    // bindings, donc safe même si les IDs venaient d'une source moins fiable.
-    if (ids.length > 0) {
-      query = query.whereIn('id', ids)
-    }
-
-    query = query
-      .orderByRaw(
-        `CASE
-          WHEN last_stats_at > now() - interval '30 minutes'
-            THEN COALESCE(last_player_count, -1)
-          ELSE -1
-         END DESC`
-      )
-      .orderBy('last_stats_at', 'desc')
-
-    if (search) {
-      query = query.where((builder) => {
-        builder.whereILike('name', `%${search}%`).orWhereILike('address', `%${search}%`)
-      })
-    }
-
-    if (type) {
-      query = query.where('type', type)
-    }
-
-    if (categoryIds) {
-      try {
-        const categoryIdList = categoryIds
-          .split(',')
-          .map((id: string) => Number.parseInt(id.trim(), 10))
-          .filter((id: number) => !Number.isNaN(id))
-        if (categoryIdList.length > 0) {
-          query = query.whereHas('categories', (builder) => {
-            builder.whereIn('categories.id', categoryIdList)
-          })
-        }
-      } catch (error) {
-        console.error('Error processing categoryIds:', error)
-      }
-    }
-
-    if (languageIds) {
-      try {
-        const languageIdList = languageIds
-          .split(',')
-          .map((id: string) => Number.parseInt(id.trim(), 10))
-          .filter((id: number) => !Number.isNaN(id))
-        if (languageIdList.length > 0) {
-          query = query.whereHas('languages', (builder) => {
-            builder.whereIn('languages.id', languageIdList)
-          })
-        }
-      } catch (error) {
-        console.error('Error processing languageIds:', error)
-      }
-    }
-
-    const servers = await query.paginate(page, limit)
-
-    const now = Date.now()
-    const fromDate = now - 24 * 60 * 60 * 1000
-
-    // Important : Lucid SimplePaginator étend Array, donc `servers.map(...)` retourne
-    // une *nouvelle SimplePaginator* (via Symbol.species), pas un Array standard.
-    // Ce paginator a un `.toJSON()` qui réécrit la réponse en `{meta, data}` →
-    // double nesting côté HTTP. On extrait `servers.all()` (le rows[] réel) avant map.
-    const serverRows = servers.all()
-    const serverIds = serverRows.map((s) => s.id)
-    const statsByServer = await StatsService.getStatsBatch({
-      serverIds,
-      fromDate,
-      toDate: now,
-      interval: '1 hour',
-    })
-
-    const serversWithStats = serverRows.map((server) => {
-      const bucketed = (statsByServer.get(server.id) ?? []).map((row) => ({
-        serverId: server.id,
-        createdAt: row.created_at,
-        playerCount: row.player_count,
-        maxCount: row.max_count,
-      }))
-
-      const lastStat =
-        server.lastStatsAt !== null && server.lastPlayerCount !== null
-          ? [
-              {
-                serverId: server.id,
-                createdAt: server.lastStatsAt,
-                playerCount: server.lastPlayerCount,
-                maxCount: server.lastMaxCount,
-              },
-            ]
-          : []
-
-      return {
-        server,
-        stats: [...lastStat, ...bucketed],
-        categories: server.categories,
-        growthStat: server.growthStat,
-      }
-    })
-
-    return {
-      data: serversWithStats,
-      meta: servers.getMeta(),
-    }
   }
 }

--- a/backend/app/controllers/stats_controller.ts
+++ b/backend/app/controllers/stats_controller.ts
@@ -28,36 +28,25 @@ export default class StatsController {
    */
   async index(ctx: HttpContext) {
     const { request, response } = ctx
-    try {
-      const validatedData = await StatValidator.validate({
-        ...request.params(),
-        ...request.qs(),
-      })
+    const validatedData = await StatValidator.validate({
+      ...request.params(),
+      ...request.qs(),
+    })
 
-      // Cas exactTime non cacheable (point-in-time, rarement réutilisé).
-      if (validatedData.exactTime) {
-        const results = await StatsService.getStats(validatedData)
-        return response.status(200).json(results)
-      }
-
-      const key = `stats:${validatedData.server_id}:${validatedData.fromDate ?? 0}:${validatedData.toDate ?? 0}:${validatedData.interval ?? 'raw'}`
-      const results = await CacheService.cacheOrFetch(
-        key,
-        300,
-        () => StatsService.getStats(validatedData),
-        { bypass: bypassFlag(ctx) }
-      )
+    // Cas exactTime non cacheable (point-in-time, rarement réutilisé).
+    if (validatedData.exactTime) {
+      const results = await StatsService.getStats(validatedData)
       return response.status(200).json(results)
-    } catch (error) {
-      console.error(error)
-      const status =
-        error && typeof error === 'object' && 'status' in error
-          ? ((error as { status?: number }).status ?? 500)
-          : 500
-      return response.status(status).json({
-        error: error instanceof Error ? error.message : 'Internal server error',
-      })
     }
+
+    const key = `stats:${validatedData.server_id}:${validatedData.fromDate ?? 0}:${validatedData.toDate ?? 0}:${validatedData.interval ?? 'raw'}`
+    const results = await CacheService.cacheOrFetch(
+      key,
+      300,
+      () => StatsService.getStats(validatedData),
+      { bypass: bypassFlag(ctx) }
+    )
+    return response.status(200).json(results)
   }
 
   /**
@@ -77,25 +66,14 @@ export default class StatsController {
    */
   async globalStats(ctx: HttpContext) {
     const { request, response } = ctx
-    try {
-      const validatedData = await GlobalStatValidator.validate(request.qs())
-      const key = CacheService.hashParams('global-stats', validatedData)
-      const results = await CacheService.cacheOrFetch(
-        key,
-        300,
-        () => StatsService.getGlobalStats(validatedData),
-        { bypass: bypassFlag(ctx) }
-      )
-      return response.status(200).json(results)
-    } catch (error) {
-      console.error(error)
-      const status =
-        error && typeof error === 'object' && 'status' in error
-          ? ((error as { status?: number }).status ?? 500)
-          : 500
-      return response.status(status).json({
-        error: error instanceof Error ? error.message : 'Internal server error',
-      })
-    }
+    const validatedData = await GlobalStatValidator.validate(request.qs())
+    const key = CacheService.hashParams('global-stats', validatedData)
+    const results = await CacheService.cacheOrFetch(
+      key,
+      300,
+      () => StatsService.getGlobalStats(validatedData),
+      { bypass: bypassFlag(ctx) }
+    )
+    return response.status(200).json(results)
   }
 }

--- a/backend/app/controllers/stats_controller.ts
+++ b/backend/app/controllers/stats_controller.ts
@@ -50,8 +50,12 @@ export default class StatsController {
       return response.status(200).json(results)
     } catch (error) {
       console.error(error)
-      return response.status(error.status ?? 500).json({
-        error: error.message ?? 'Internal server error',
+      const status =
+        error && typeof error === 'object' && 'status' in error
+          ? ((error as { status?: number }).status ?? 500)
+          : 500
+      return response.status(status).json({
+        error: error instanceof Error ? error.message : 'Internal server error',
       })
     }
   }
@@ -85,8 +89,12 @@ export default class StatsController {
       return response.status(200).json(results)
     } catch (error) {
       console.error(error)
-      return response.status(error.status ?? 500).json({
-        error: error.message ?? 'Internal server error',
+      const status =
+        error && typeof error === 'object' && 'status' in error
+          ? ((error as { status?: number }).status ?? 500)
+          : 500
+      return response.status(status).json({
+        error: error instanceof Error ? error.message : 'Internal server error',
       })
     }
   }

--- a/backend/app/controllers/uploads_controller.ts
+++ b/backend/app/controllers/uploads_controller.ts
@@ -42,6 +42,10 @@ export default class UploadsController {
       return response.badRequest({ error: image.errors })
     }
 
+    if (!image.tmpPath) {
+      return response.badRequest({ error: 'Invalid upload' })
+    }
+
     // Generate unique filename
     const fileName = `${randomUUID()}.webp`
     const uploadsPath = app.makePath('public/images/blog')
@@ -52,7 +56,7 @@ export default class UploadsController {
 
     try {
       // Read the uploaded file
-      const imageBuffer = await fs.readFile(image.tmpPath!)
+      const imageBuffer = await fs.readFile(image.tmpPath)
 
       // Convert to WebP and optimize
       await sharp(imageBuffer)

--- a/backend/app/middleware/logger_middleware.ts
+++ b/backend/app/middleware/logger_middleware.ts
@@ -19,8 +19,13 @@ export default class LoggerMiddleware {
     } catch (error) {
       const duration = Math.round(performance.now() - startTime)
       const realIp = ctx.request.header('CF-Connecting-IP') || ctx.request.ip()
+      const err = error instanceof Error ? error : new Error(String(error))
+      const status =
+        error && typeof error === 'object' && 'status' in error
+          ? (error as { status?: number }).status
+          : undefined
       ctx.logger.error(
-        `[${realIp}] ${ctx.request.method()} ${ctx.request.url()} ${error.status || 500} ${duration}ms ${error.name} ${error.message}`
+        `[${realIp}] ${ctx.request.method()} ${ctx.request.url()} ${status || 500} ${duration}ms ${err.name} ${err.message}`
       )
 
       throw error

--- a/backend/app/services/advertisement_stats_service.ts
+++ b/backend/app/services/advertisement_stats_service.ts
@@ -1,0 +1,62 @@
+import db from '@adonisjs/lucid/services/db'
+
+type Interval = 'hour' | 'day'
+
+interface AdvertisementStatsParams {
+  advertisementId: number
+  interval: Interval
+  fromDate: number | null
+  toDate: number | null
+}
+
+interface AdvertisementStatsPoint {
+  time: unknown
+  impressions: number
+  clicks: number
+}
+
+interface AdvertisementStatsTotals {
+  impressions: number
+  clicks: number
+}
+
+export default class AdvertisementStatsService {
+  /**
+   * Agrège les événements (impressions/clics) d'une publicité en buckets
+   * (`hour` ou `day`) sur la fenêtre demandée, et renvoie la série par bucket
+   * ainsi que les totaux cumulés.
+   */
+  static async getStats(params: AdvertisementStatsParams): Promise<{
+    totals: AdvertisementStatsTotals
+    series: AdvertisementStatsPoint[]
+  }> {
+    const { advertisementId, interval, fromDate, toDate } = params
+
+    let query = db.from('advertisement_events').where('advertisement_id', advertisementId)
+    if (fromDate !== null) query = query.where('created_at', '>=', new Date(fromDate))
+    if (toDate !== null) query = query.where('created_at', '<=', new Date(toDate))
+
+    const rows = await query
+      .select(db.raw('date_trunc(?, created_at) as bucket', [interval]))
+      .select(db.raw(`count(*) filter (where type = 'impression') as impressions`))
+      .select(db.raw(`count(*) filter (where type = 'click') as clicks`))
+      .groupByRaw('bucket')
+      .orderByRaw('bucket asc')
+
+    const series = rows.map((row) => ({
+      time: row.bucket,
+      impressions: Number(row.impressions),
+      clicks: Number(row.clicks),
+    }))
+
+    const totals = series.reduce(
+      (acc, row) => ({
+        impressions: acc.impressions + row.impressions,
+        clicks: acc.clicks + row.clicks,
+      }),
+      { impressions: 0, clicks: 0 }
+    )
+
+    return { totals, series }
+  }
+}

--- a/backend/app/services/placeholder_service.ts
+++ b/backend/app/services/placeholder_service.ts
@@ -74,69 +74,97 @@ export default class PlaceholderService {
   }
 
   /**
-   * Preload server data for multiple servers at once
+   * Preload server data for multiple servers at once.
+   *
+   * Toutes les données sont récupérées avec des requêtes ensemblistes
+   * (`whereIn` / `GROUP BY server_id`) pour éviter le N+1 : un serveur absent du
+   * résultat `whereIn` est traité comme introuvable (`exists: false`), et les
+   * erreurs DB ne sont plus avalées — elles remontent.
    */
   private static async preloadServerData(serverIds: number[]): Promise<Map<number, ServerData>> {
     const serversData = new Map<number, ServerData>()
 
+    if (serverIds.length === 0) {
+      return serversData
+    }
+
+    const servers = await Server.query().whereIn('id', serverIds)
+
+    // Latest stat per server (highest createdAt) — équivalent à orderBy createdAt desc + first
+    const latestStats = await ServerStat.query()
+      .whereIn('serverId', serverIds)
+      .select('*')
+      .distinctOn('serverId')
+      .orderBy('serverId', 'asc')
+      .orderBy('createdAt', 'desc')
+
+    // First stat per server (lowest createdAt) — équivalent à orderBy createdAt asc + first
+    const firstStats = await ServerStat.query()
+      .whereIn('serverId', serverIds)
+      .select('*')
+      .distinctOn('serverId')
+      .orderBy('serverId', 'asc')
+      .orderBy('createdAt', 'asc')
+
+    // Peak high per server (highest playerCount) — équivalent à orderBy playerCount desc + first
+    const peakHighStats = await ServerStat.query()
+      .whereIn('serverId', serverIds)
+      .select('*')
+      .distinctOn('serverId')
+      .orderBy('serverId', 'asc')
+      .orderBy('playerCount', 'desc')
+
+    // Peak low per server (lowest playerCount > 0) — équivalent à where > 0 + orderBy playerCount asc + first
+    const peakLowStats = await ServerStat.query()
+      .whereIn('serverId', serverIds)
+      .where('playerCount', '>', 0)
+      .select('*')
+      .distinctOn('serverId')
+      .orderBy('serverId', 'asc')
+      .orderBy('playerCount', 'asc')
+
+    // Average and median per server, en une seule requête groupée
+    const aggregatesQuery = await Database.rawQuery(
+      `
+      SELECT
+        server_id,
+        AVG(player_count)::int as avg_players,
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY player_count)::int as median_players
+      FROM server_stats
+      WHERE server_id IN (${serverIds.map(() => '?').join(', ')})
+      GROUP BY server_id
+    `,
+      serverIds
+    )
+
+    const byServerId = <T extends { serverId: number }>(rows: T[]): Map<number, T> =>
+      new Map(rows.map((row) => [row.serverId, row]))
+
+    const latestByServer = byServerId(latestStats)
+    const firstByServer = byServerId(firstStats)
+    const peakHighByServer = byServerId(peakHighStats)
+    const peakLowByServer = byServerId(peakLowStats)
+    const aggregatesByServer = new Map<number, { avg_players: number; median_players: number }>(
+      aggregatesQuery.rows.map((row: any) => [Number(row.server_id), row])
+    )
+
+    for (const server of servers) {
+      const aggregates = aggregatesByServer.get(server.id)
+
+      serversData.set(server.id, {
+        exists: true,
+        server,
+        latestStat: latestByServer.get(server.id),
+        firstStat: firstByServer.get(server.id),
+        peakHigh: peakHighByServer.get(server.id),
+        peakLow: peakLowByServer.get(server.id),
+        average: aggregates?.avg_players || 0,
+        median: aggregates?.median_players || 0,
+      })
+    }
+
     for (const serverId of serverIds) {
-      try {
-        const server = await Server.find(serverId)
-        if (!server) {
-          serversData.set(serverId, { exists: false })
-          continue
-        }
-
-        // Get latest stat
-        const latestStat = await ServerStat.query()
-          .where('serverId', serverId)
-          .orderBy('createdAt', 'desc')
-          .first()
-
-        // Get first stat (for data since date)
-        const firstStat = await ServerStat.query()
-          .where('serverId', serverId)
-          .orderBy('createdAt', 'asc')
-          .first()
-
-        // Get peak high
-        const peakHigh = await ServerStat.query()
-          .where('serverId', serverId)
-          .orderBy('playerCount', 'desc')
-          .first()
-
-        // Get peak low (excluding 0 values)
-        const peakLow = await ServerStat.query()
-          .where('serverId', serverId)
-          .where('playerCount', '>', 0)
-          .orderBy('playerCount', 'asc')
-          .first()
-
-        // Get average and median
-        const statsQuery = await Database.rawQuery(
-          `
-          SELECT
-            AVG(player_count)::int as avg_players,
-            PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY player_count)::int as median_players
-          FROM server_stats
-          WHERE server_id = ?
-        `,
-          [serverId]
-        )
-
-        const stats = statsQuery.rows[0]
-
-        serversData.set(serverId, {
-          exists: true,
-          server,
-          latestStat: latestStat ?? undefined,
-          firstStat: firstStat ?? undefined,
-          peakHigh: peakHigh ?? undefined,
-          peakLow: peakLow ?? undefined,
-          average: stats?.avg_players || 0,
-          median: stats?.median_players || 0,
-        })
-      } catch {
+      if (!serversData.has(serverId)) {
         serversData.set(serverId, { exists: false })
       }
     }

--- a/backend/app/services/server_listing_service.ts
+++ b/backend/app/services/server_listing_service.ts
@@ -1,0 +1,133 @@
+import Server from '#models/server'
+import StatsService from '#services/stat_service'
+
+export default class ServerListingService {
+  /**
+   * Construit la requête paginée du classement des serveurs à partir de
+   * paramètres déjà parsés par le contrôleur, puis transforme chaque ligne
+   * en y attachant ses stats (buckets horaires sur 24 h + dernier snapshot live).
+   */
+  static async paginate(opts: {
+    page: number
+    limit: number
+    categoryIds?: string
+    languageIds?: string
+    search: string
+    type?: 'java' | 'bedrock'
+    ids: number[]
+  }) {
+    const { page, limit, categoryIds, languageIds, search, type, ids } = opts
+
+    // Ordering : on ne classe par `last_player_count` que si le dernier ping
+    // réussi est récent (< 30 min, soit ~3 cycles de 10 min). Sinon le serveur
+    // est traité comme "stale" et descend en bas, peu importe son ancien count.
+    // Évite qu'un serveur down depuis des jours reste top juste parce qu'il
+    // avait 500 joueurs avant de tomber.
+    let query = Server.query()
+      .preload('user', (userQuery) => userQuery.select('id', 'username', 'avatarUrl'))
+      .preload('categories')
+      .preload('growthStat')
+      .preload('languages')
+
+    // Restriction à une liste explicite d'IDs (section favoris) : `whereIn` avec
+    // bindings, donc safe même si les IDs venaient d'une source moins fiable.
+    if (ids.length > 0) {
+      query = query.whereIn('id', ids)
+    }
+
+    query = query
+      .orderByRaw(
+        `CASE
+          WHEN last_stats_at > now() - interval '30 minutes'
+            THEN COALESCE(last_player_count, -1)
+          ELSE -1
+         END DESC`
+      )
+      .orderBy('last_stats_at', 'desc')
+
+    if (search) {
+      query = query.where((builder) => {
+        builder.whereILike('name', `%${search}%`).orWhereILike('address', `%${search}%`)
+      })
+    }
+
+    if (type) {
+      query = query.where('type', type)
+    }
+
+    if (categoryIds) {
+      const categoryIdList = categoryIds
+        .split(',')
+        .map((id: string) => Number.parseInt(id.trim(), 10))
+        .filter((id: number) => !Number.isNaN(id))
+      if (categoryIdList.length > 0) {
+        query = query.whereHas('categories', (builder) => {
+          builder.whereIn('categories.id', categoryIdList)
+        })
+      }
+    }
+
+    if (languageIds) {
+      const languageIdList = languageIds
+        .split(',')
+        .map((id: string) => Number.parseInt(id.trim(), 10))
+        .filter((id: number) => !Number.isNaN(id))
+      if (languageIdList.length > 0) {
+        query = query.whereHas('languages', (builder) => {
+          builder.whereIn('languages.id', languageIdList)
+        })
+      }
+    }
+
+    const servers = await query.paginate(page, limit)
+
+    const now = Date.now()
+    const fromDate = now - 24 * 60 * 60 * 1000
+
+    // Important : Lucid SimplePaginator étend Array, donc `servers.map(...)` retourne
+    // une *nouvelle SimplePaginator* (via Symbol.species), pas un Array standard.
+    // Ce paginator a un `.toJSON()` qui réécrit la réponse en `{meta, data}` →
+    // double nesting côté HTTP. On extrait `servers.all()` (le rows[] réel) avant map.
+    const serverRows = servers.all()
+    const serverIds = serverRows.map((s) => s.id)
+    const statsByServer = await StatsService.getStatsBatch({
+      serverIds,
+      fromDate,
+      toDate: now,
+      interval: '1 hour',
+    })
+
+    const serversWithStats = serverRows.map((server) => {
+      const bucketed = (statsByServer.get(server.id) ?? []).map((row) => ({
+        serverId: server.id,
+        createdAt: row.created_at,
+        playerCount: row.player_count,
+        maxCount: row.max_count,
+      }))
+
+      const lastStat =
+        server.lastStatsAt !== null && server.lastPlayerCount !== null
+          ? [
+              {
+                serverId: server.id,
+                createdAt: server.lastStatsAt,
+                playerCount: server.lastPlayerCount,
+                maxCount: server.lastMaxCount,
+              },
+            ]
+          : []
+
+      return {
+        server,
+        stats: [...lastStat, ...bucketed],
+        categories: server.categories,
+        growthStat: server.growthStat,
+      }
+    })
+
+    return {
+      data: serversWithStats,
+      meta: servers.getMeta(),
+    }
+  }
+}

--- a/backend/app/validators/category.ts
+++ b/backend/app/validators/category.ts
@@ -5,3 +5,16 @@ export const CreateCategoryValidator = vine.compile(
     name: vine.string().trim(),
   })
 )
+
+export const CategoryIdValidator = vine.compile(
+  vine.object({
+    id: vine.number().positive(),
+  })
+)
+
+export const UpdateCategoryValidator = vine.compile(
+  vine.object({
+    id: vine.number().positive(),
+    name: vine.string().trim(),
+  })
+)

--- a/backend/app/validators/post.ts
+++ b/backend/app/validators/post.ts
@@ -19,3 +19,10 @@ export const UpdatePostValidator = vine.compile(
     coverImage: vine.string().maxLength(500).optional(),
   })
 )
+
+export const PreviewPlaceholderValidator = vine.compile(
+  vine.object({
+    placeholderName: vine.string(),
+    serverId: vine.number().positive(),
+  })
+)

--- a/backend/app/validators/server_category.ts
+++ b/backend/app/validators/server_category.ts
@@ -1,0 +1,8 @@
+import vine from '@vinejs/vine'
+
+export const attachServerCategoryValidator = vine.compile(
+  vine.object({
+    serverId: vine.number().positive(),
+    categoryId: vine.number().positive(),
+  })
+)

--- a/frontend/src/app/(pages)/account/settings/page.tsx
+++ b/frontend/src/app/(pages)/account/settings/page.tsx
@@ -21,10 +21,10 @@ const SettingsPage = () => {
         description: "You have been logged out of every device.",
         variant: "success",
       });
-    } catch (error: any) {
+    } catch (error) {
       toast({
         title: "Error",
-        description: error.message,
+        description: error instanceof Error ? error.message : "Something went wrong",
         variant: "error",
       });
     }

--- a/frontend/src/app/(pages)/admin/posts/[id]/edit/page.tsx
+++ b/frontend/src/app/(pages)/admin/posts/[id]/edit/page.tsx
@@ -14,7 +14,8 @@ const EditPostPage = () => {
   const token = getToken();
   const router = useRouter();
   const params = useParams();
-  const postId = Number.parseInt(params.id as string);
+  const idParam = Array.isArray(params.id) ? params.id[0] : params.id;
+  const postId = Number.parseInt(idParam ?? "");
 
   const [post, setPost] = useState<Post | null>(null);
   const [title, setTitle] = useState("");

--- a/frontend/src/app/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
+++ b/frontend/src/app/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
@@ -24,7 +24,7 @@ import { Icon } from "@iconify/react/dist/iconify.js";
 import { useTheme } from "next-themes";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { startTransition, useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import useSWR from "swr";
 
 const TIME_RANGE_OFFSETS: Record<TimeRangeType, number> = {
@@ -161,32 +161,20 @@ const ServerPage = () => {
 
   const [dataRangeInterval, setDataRangeInterval] = useState<TimeRangeType>("1 Week");
   const [dataAggregationInterval, setDataAggregationInterval] = useState<AggregationType>("1 Hour");
-  const [isStatsLoading, setIsStatsLoading] = useState<boolean>(false);
-  const [stats, setStats] = useState<ServerStat[]>([]);
   const { resolvedTheme } = useTheme();
 
-  useEffect(() => {
-    async function fetchServerStats() {
+  const { data: statsData, isLoading: isStatsLoading } = useSWR<ServerStat[], Error>(
+    ["server-stats", serverId, dataRangeInterval, dataAggregationInterval],
+    () => {
       const now = Date.now();
       const fromDate = now - TIME_RANGE_OFFSETS[dataRangeInterval];
       const interval = dataAggregationInterval ? AGGREGATION_INTERVALS[dataAggregationInterval] : undefined;
-      const newStats = await getServerStats(
-        Number(serverId),
-        fromDate,
-        now,
-        interval
-      );
-      setStats(newStats);
-    }
+      return getServerStats(Number(serverId), fromDate, now, interval);
+    },
+    { refreshInterval: 1000 * 60 * 2 }
+  );
 
-    startTransition(() => {
-      setIsStatsLoading(true);
-    });
-    fetchServerStats().finally(() => setIsStatsLoading(false));
-
-    const intervalId = setInterval(fetchServerStats, 1000 * 60 * 2);
-    return () => clearInterval(intervalId);
-  }, [serverId, dataRangeInterval, dataAggregationInterval]);
+  const stats = useMemo(() => statsData ?? [], [statsData]);
 
   const options = useMemo((): AgCartesianChartOptions => {
     const data = stats.map((stat) => ({

--- a/frontend/src/app/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
+++ b/frontend/src/app/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
@@ -110,7 +110,7 @@ const createAreaSeries = (
       anchorTo: "pointer",
       placement: "top",
     },
-    renderer: ({ datum }: any) => {
+    renderer: ({ datum }: { datum: { time: string | number | Date; playerCount: number } }) => {
       return generateTooltipHtml(
         { time: new Date(datum.time), playerCount: datum.playerCount },
         { isDarkMode: theme === "dark" }

--- a/frontend/src/app/(pages)/servers/[serverId]/edit/page.tsx
+++ b/frontend/src/app/(pages)/servers/[serverId]/edit/page.tsx
@@ -1,34 +1,18 @@
 "use client";
+import { fetcher, getBaseUrl } from "@/app/_cheatcode";
 import EditServerForm from "@/components/form/edit-server-form";
 import Loader from "@/components/loader";
-import { getServer } from "@/http/server";
 import { Category, Server, ServerStat } from "@/types/server";
 import { useParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import useSWR from "swr";
 
 const ServerEditPage = () => {
   const { serverId } = useParams();
 
-  const [server, setServer] = useState<{ server: Server; stats: ServerStat[]; categories: Category[] }>();
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-
-  const updateServer = useCallback(async () => {
-    try {
-      const server = await getServer(Number(serverId));
-      setServer(server);
-    } catch (error) {
-      setError(error instanceof Error ? error : new Error(String(error)));
-    } finally {
-      setIsLoading(false);
-    }
-  }, [serverId]);
-
-  useEffect(() => {
-    updateServer();
-  }, [updateServer]);
-
+  const { data: server, isLoading, mutate } = useSWR<{ server: Server; stats: ServerStat[]; categories: Category[] }>(
+    `${getBaseUrl()}/servers/${serverId}`,
+    fetcher
+  );
 
   return isLoading ? (
     <div className="flex flex-col items-center justify-center h-full flex-1 py-8">
@@ -42,7 +26,7 @@ const ServerEditPage = () => {
           <div className="flex flex-col gap-2">
             <div className="flex flex-row gap-4">
               <div className="w-screen max-w-2xl">
-                <EditServerForm server={server.server} serverCategories={server.categories} updateServer={updateServer} />
+                <EditServerForm server={server.server} serverCategories={server.categories} updateServer={mutate} />
               </div>
             </div>
           </div>

--- a/frontend/src/app/(pages)/servers/[serverId]/edit/page.tsx
+++ b/frontend/src/app/(pages)/servers/[serverId]/edit/page.tsx
@@ -19,7 +19,7 @@ const ServerEditPage = () => {
       const server = await getServer(Number(serverId));
       setServer(server);
     } catch (error) {
-      setError(error as Error);
+      setError(error instanceof Error ? error : new Error(String(error)));
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/components/blog/placeholder-picker.tsx
+++ b/frontend/src/components/blog/placeholder-picker.tsx
@@ -12,7 +12,6 @@ export function PlaceholderPicker({ onInsert }: PlaceholderPickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [placeholders, setPlaceholders] = useState<PlaceholderInfo[]>([]);
   const [serverId, setServerId] = useState("");
-  const [selectedPlaceholder, setSelectedPlaceholder] = useState<string | null>(null);
   const [copiedPlaceholder, setCopiedPlaceholder] = useState<string | null>(null);
 
   useEffect(() => {
@@ -40,7 +39,6 @@ export function PlaceholderPicker({ onInsert }: PlaceholderPickerProps) {
     onInsert(placeholder);
     setIsOpen(false);
     setServerId("");
-    setSelectedPlaceholder(null);
   };
 
   const handleCopy = (placeholderName: string) => {
@@ -106,17 +104,12 @@ export function PlaceholderPicker({ onInsert }: PlaceholderPickerProps) {
             <div className="flex-1 overflow-y-auto p-4">
               <div className="space-y-3">
                 {placeholders.map((placeholder) => {
-                  const isSelected = selectedPlaceholder === placeholder.name;
                   const isCopied = copiedPlaceholder === placeholder.name;
 
                   return (
                     <div
                       key={placeholder.name}
-                      className={`p-4 rounded-lg border transition-all ${
-                        isSelected
-                          ? "border-stats-blue-500 bg-stats-blue-50 dark:bg-stats-blue-900/30"
-                          : "border-gray-200 dark:border-stats-blue-800 bg-gray-50 dark:bg-stats-blue-900/20"
-                      }`}
+                      className="p-4 rounded-lg border transition-all border-gray-200 dark:border-stats-blue-800 bg-gray-50 dark:bg-stats-blue-900/20"
                     >
                       <div className="flex items-start justify-between gap-4">
                         <div className="flex-1">

--- a/frontend/src/components/blog/tiptap-editor.tsx
+++ b/frontend/src/components/blog/tiptap-editor.tsx
@@ -121,7 +121,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
           const fullUrl = `${process.env.NEXT_PUBLIC_API_URL}${url}`;
           editor.chain().focus().setImage({ src: fullUrl }).run();
         } catch (error) {
-          console.error("Failed to upload image:", error);
+          console.error("Failed to upload image:", error instanceof Error ? error.message : error);
           alert("Failed to upload image");
         }
       }

--- a/frontend/src/components/form/add-server-form/index.tsx
+++ b/frontend/src/components/form/add-server-form/index.tsx
@@ -93,7 +93,7 @@ const AddServerForm: FC<AddServerFormProps> = ({ className, ...props }) => {
         description: "Your server has been added successfully, it will be available in a few minutes",
         variant: "success",
       });
-    } catch (error: any) {
+    } catch (error) {
       if (error instanceof DuplicateServerError) {
         const safeServerId = encodeURIComponent(String(error.existingServer.id));
         toast({
@@ -116,7 +116,7 @@ const AddServerForm: FC<AddServerFormProps> = ({ className, ...props }) => {
       }
       toast({
         title: "Error while adding server",
-        description: error?.message || "An error occurred while adding the server.",
+        description: error instanceof Error ? error.message : "An error occurred while adding the server.",
         variant: "error",
       });
     }

--- a/frontend/src/components/form/change-password-form/index.tsx
+++ b/frontend/src/components/form/change-password-form/index.tsx
@@ -49,10 +49,10 @@ const ChangePasswordForm: FC<ChangePasswordFormProps> = ({ className, ...props }
         description: "Your password has been changed successfully",
         variant: "success",
       });
-    } catch (error: any) {
+    } catch (error) {
       toast({
         title: "Error while changing password",
-        description: error.message,
+        description: error instanceof Error ? error.message : "Error while changing password",
         variant: "error",
       });
     }

--- a/frontend/src/components/form/edit-server-form/index.tsx
+++ b/frontend/src/components/form/edit-server-form/index.tsx
@@ -105,10 +105,10 @@ const EditServerForm: FC<EditServerFormProps> = ({ server, serverCategories, upd
       });
       router.replace("/");
       router.refresh();
-    } catch (error: any) {
+    } catch (error) {
       toast({
         title: "Error while editing server",
-        description: error.message,
+        description: error instanceof Error ? error.message : "Error while editing server",
         variant: "error",
       });
     }
@@ -125,10 +125,10 @@ const EditServerForm: FC<EditServerFormProps> = ({ server, serverCategories, upd
       });
       router.replace("/");
       router.refresh();
-    } catch (error: any) {
+    } catch (error) {
       toast({
         title: "Error while deleting server",
-        description: error.message,
+        description: error instanceof Error ? error.message : "Error while deleting server",
         variant: "error",
       });
     }

--- a/frontend/src/components/home/charts/global-stats-chart.tsx
+++ b/frontend/src/components/home/charts/global-stats-chart.tsx
@@ -109,9 +109,9 @@ const createAreaSeries = (
       anchorTo: 'pointer',
       placement: 'top',
     },
-    renderer: ({ datum }: any) => {
+    renderer: ({ datum }: { datum: Record<string, number | Date> }) => {
       return generateTooltipHtml(
-        { time: new Date(datum.time), playerCount: datum[yKey] ?? 0 },
+        { time: new Date(datum.time), playerCount: Number(datum[yKey] ?? 0) },
         { isDarkMode: theme === 'dark' }
       );
     },

--- a/frontend/src/components/home/latest-articles-section.tsx
+++ b/frontend/src/components/home/latest-articles-section.tsx
@@ -1,32 +1,16 @@
 "use client";
 
 import { getPosts } from "@/http/post";
-import { Post } from "@/types/post";
 import { Icon } from "@iconify/react/dist/iconify.js";
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import useSWR from "swr";
 
 const LatestArticlesSection = () => {
-  const [posts, setPosts] = useState<Post[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data, isLoading } = useSWR(["posts", 1, 3], () => getPosts(1, 3));
+  const posts = data?.data ?? [];
 
-  useEffect(() => {
-    const fetchPosts = async () => {
-      try {
-        const response = await getPosts(1, 3);
-        setPosts(response.data);
-      } catch (error) {
-        console.error("Failed to fetch posts:", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchPosts();
-  }, []);
-
-  if (loading) {
+  if (isLoading) {
     return (
       <section className="space-y-4">
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">

--- a/frontend/src/components/home/selects/server-select.tsx
+++ b/frontend/src/components/home/selects/server-select.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import useSWR from "swr";
 import { Check, ChevronsUpDown } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { fetcher } from "@/app/_cheatcode";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -21,6 +23,13 @@ export interface Server {
   name: string;
 }
 
+interface ServerListEntry {
+  server?: {
+    id?: number;
+    name?: string;
+  };
+}
+
 interface ServerSelectProps {
   selectedServers: number[];
   onChange: (servers: number[]) => void;
@@ -29,31 +38,20 @@ interface ServerSelectProps {
 
 export const ServerSelect = ({ selectedServers, onChange, disabled }: ServerSelectProps) => {
   const [open, setOpen] = useState(false);
-  const [servers, setServers] = useState<Server[]>([]);
   const [search, setSearch] = useState("");
   const apiUrl = getClientApiUrl();
 
-  useEffect(() => {
-    const fetchServers = async () => {
-      try {
-        const response = await fetch(apiUrl + "/servers");
-        if (!response.ok) throw new Error('Failed to fetch servers');
-        const data = await response.json();
-        
-        // Vérifier et formater les données du serveur
-        const formattedServers = Array.isArray(data) ? data.map(obtainData => ({
+  const { data } = useSWR<ServerListEntry[]>(`${apiUrl}/servers`, fetcher);
+
+  // Vérifier et formater les données du serveur
+  const servers: Server[] = Array.isArray(data)
+    ? data
+        .map((obtainData) => ({
           id: obtainData.server?.id,
-          name: obtainData.server?.name ?? `Serveur ${obtainData.server?.id ?? 'Inconnu'}`
-        })).filter(server => server.id != null) : [];
-        
-        setServers(formattedServers);
-      } catch (error) {
-        console.error('Error fetching servers:', error);
-        setServers([]);
-      }
-    };
-    fetchServers();
-  }, [apiUrl]);
+          name: obtainData.server?.name ?? `Serveur ${obtainData.server?.id ?? "Inconnu"}`,
+        }))
+        .filter((server): server is Server => server.id != null)
+    : [];
 
   const handleServerToggle = (serverId: number) => {
     const newSelection = selectedServers.includes(serverId)

--- a/frontend/src/components/ui/multi-select.tsx
+++ b/frontend/src/components/ui/multi-select.tsx
@@ -28,34 +28,27 @@ export function FancyMultiSelect({ elements, title, onSelectionChange, className
   const [selected, setSelected] = React.useState<readonly { value: string; label: string }[]>(defaultSelected || []);
   const [inputValue, setInputValue] = React.useState("");
 
-  React.useEffect(() => {
-    onSelectionChange?.(selected.map((s) => s.value));
-  }, [selected, onSelectionChange]);
+  const handleUnselect = (element: { value: string; label: string }) => {
+    const next = selected.filter((s) => s.value !== element.value);
+    setSelected(next);
+    onSelectionChange?.(next.map((s) => s.value));
+  };
 
-  const handleUnselect = React.useCallback((element: { value: string; label: string }) => {
-    setSelected((prev) => prev.filter((s) => s.value !== element.value));
-  }, []);
-
-  const handleKeyDown = React.useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
-      const input = inputRef.current;
-      if (input) {
-        if (e.key === "Delete" || e.key === "Backspace") {
-          if (input.value === "") {
-            setSelected((prev) => {
-              const newSelected = [...prev];
-              newSelected.pop();
-              return newSelected;
-            });
-          }
-        }
-        if (e.key === "Escape") {
-          input.blur();
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const input = inputRef.current;
+    if (input) {
+      if (e.key === "Delete" || e.key === "Backspace") {
+        if (input.value === "") {
+          const next = selected.slice(0, -1);
+          setSelected(next);
+          onSelectionChange?.(next.map((s) => s.value));
         }
       }
-    },
-    []
-  );
+      if (e.key === "Escape") {
+        input.blur();
+      }
+    }
+  };
 
   if (elements.length === 0) {
     return null;
@@ -116,7 +109,9 @@ export function FancyMultiSelect({ elements, title, onSelectionChange, className
                       onSelect={() => {
                         if (!selected.some((s) => s.value === element.value)) {
                           setInputValue("");
-                          setSelected((prev) => [...prev, element]);
+                          const next = [...selected, element];
+                          setSelected(next);
+                          onSelectionChange?.(next.map((s) => s.value));
                         }
                       }}
                       className={"cursor-pointer"}

--- a/frontend/src/components/ui/use-toast.ts
+++ b/frontend/src/components/ui/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,

--- a/frontend/src/contexts/auth.tsx
+++ b/frontend/src/contexts/auth.tsx
@@ -3,7 +3,8 @@ import { getBaseUrl } from "@/app/_cheatcode";
 import { changeUserPassword, getUser, loginUser, logoutAllUser, logoutUser, registerUser } from "@/http/auth";
 import { User } from "@/types/auth";
 import { useRouter } from "next/navigation";
-import { createContext, startTransition, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import useSWR from "swr";
 
 interface AuthContextProps {
   user: User | null;
@@ -33,38 +34,70 @@ export const useAuth = () => {
 };
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const [user, setUser] = useState<User | null>(null);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  // `token` is kept in React state (not just localStorage) so it can drive the
+  // SWR key reactively: writing a token re-fetches /me, removing it disables the read.
+  const [token, setToken] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem("accessToken");
+  });
   const router = useRouter();
+
+  const {
+    data: meUser,
+    error: meError,
+    mutate: mutateMe,
+  } = useSWR(token ? (["me", token] as const) : null, ([, t]) => getUser(t));
 
   const getToken = useCallback(() => {
     if (typeof window === "undefined") return null;
     return localStorage.getItem("accessToken");
   }, []);
 
-  const saveToken = useCallback((token: string) => {
+  const saveToken = useCallback((newToken: string) => {
     if (typeof window === "undefined") return;
-    localStorage.setItem("accessToken", token);
+    localStorage.setItem("accessToken", newToken);
+    setToken(newToken);
   }, []);
 
   const removeToken = useCallback(() => {
     if (typeof window === "undefined") return;
     localStorage.removeItem("accessToken");
+    setToken(null);
+  }, []);
+
+  // A bad/expired token makes /me throw; clear the session like the old fetchUser did.
+  // Also drop any synchronous override so isLoggedIn falls back to the (now logged-out)
+  // derived value instead of staying stale-true after the token is cleared.
+  useEffect(() => {
+    if (meError) {
+      removeToken();
+      setLoggedInOverride(null);
+    }
+  }, [meError, removeToken]);
+
+  // `isLoggedIn` is derived from the /me read, but consumers (login/logout/OAuth
+  // callback) flip it synchronously via setIsLoggedIn. The override lets those
+  // synchronous updates win until the next /me read settles. null = use derived.
+  const [loggedInOverride, setLoggedInOverride] = useState<boolean | null>(null);
+
+  const user = meError ? null : meUser ?? null;
+  const isLoggedIn = loggedInOverride ?? (!meError && Boolean(token) && Boolean(meUser));
+
+  // Compat shims for the previous useState setters exposed in the public API.
+  const setUser = useCallback(
+    (next: User | null) => {
+      mutateMe(next ?? undefined, { revalidate: false });
+    },
+    [mutateMe]
+  );
+
+  const setIsLoggedIn = useCallback((next: boolean) => {
+    setLoggedInOverride(next);
   }, []);
 
   const fetchUser = useCallback(async () => {
-    try {
-      const token = getToken();
-      if (!token) return;
-      const response = await getUser(token);
-      setUser(response || null);
-      setIsLoggedIn(true);
-    } catch {
-      setUser(null);
-      setIsLoggedIn(false);
-      removeToken();
-    }
-  }, [getToken, setUser, setIsLoggedIn, removeToken]);
+    await mutateMe();
+  }, [mutateMe]);
 
   const login = useCallback(
     async (email: string, password: string) => {
@@ -147,12 +180,6 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     router.push(`${getBaseUrl()}/login/google`);
   }, [router]);
 
-  useEffect(() => {
-    startTransition(() => {
-      fetchUser();
-    });
-  }, [fetchUser]);
-
   const contextValue = useMemo(() => {
     return {
       user,
@@ -172,6 +199,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     };
   }, [
     user,
+    setUser,
     login,
     register,
     logout,

--- a/frontend/src/contexts/auth.tsx
+++ b/frontend/src/contexts/auth.tsx
@@ -74,11 +74,11 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         saveToken(response.accessToken.token);
         setIsLoggedIn(true);
         router.push("/");
-      } catch (error: any) {
+      } catch (error) {
         setUser(null);
         setIsLoggedIn(false);
         removeToken();
-        return { message: error.message };
+        return { message: error instanceof Error ? error.message : String(error) };
       }
     },
     [router, setUser, saveToken, setIsLoggedIn, removeToken]
@@ -89,8 +89,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       try {
         await registerUser({ username, email, password });
         router.push("/");
-      } catch (error: any) {
-        throw new Error(error.message);
+      } catch (error) {
+        throw new Error(error instanceof Error ? error.message : String(error));
       }
     },
     [router]
@@ -131,9 +131,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     async (oldPassword: string, newPassword: string) => {
       try {
         await changeUserPassword({ oldPassword, newPassword }, getToken() ?? "");
-      } catch (error: any) {
-        console.log("AuthError", error.message);
-        throw new Error(error.message);
+      } catch (error) {
+        console.log("AuthError", error instanceof Error ? error.message : String(error));
+        throw new Error(error instanceof Error ? error.message : String(error));
       }
     },
     [getToken]

--- a/frontend/src/http/auth.ts
+++ b/frontend/src/http/auth.ts
@@ -70,8 +70,8 @@ export const getUser = async (token: string) => {
     throw new Error(errorMessage);
   }
 
-  const user = await response.json();
-  return user.user as User | undefined;
+  const body = (await response.json()) as { user?: User };
+  return body.user;
 };
 
 export const changeUserPassword = async (credentials: { oldPassword: string; newPassword: string }, token: string) => {
@@ -126,8 +126,8 @@ export const logoutAllUser = async (token: string) => {
   return response.json();
 };
 
-export const getErrorMessage = async (response: Response) => {
-  const error = await response.json();
+export const getErrorMessage = async (response: Response): Promise<string | undefined> => {
+  const error = (await response.json()) as { error?: { message?: string }; errors?: { message?: string }[]; message?: string };
   const errorMessage = error?.error?.message || error?.errors?.[0]?.message || error?.message;
   return errorMessage;
 };


### PR DESCRIPTION
## Summary
Follow-up to the merged PR #183 (which shipped the safe fixes). This applies the **higher-risk backlog** from the same framework-best-practices audit — the behavior-changing findings that were originally documented for review. 3 commits, each verified: backend (`tsc`, `eslint`, `node ace build`) and frontend (`tsc`, `eslint`, `next build`) all green.

## Commits
1. **batch 1 — type-safety & dead code** — `any`/`as`/`!` → precise types/guards across 16 files; remove dead `selectedPlaceholder` state. (no behavior change)
2. **backend behavioral** — service extraction (A1), VineJS validation (A2), error handling (A6), N+1 fix (A4).
3. **frontend behavioral** — React effect fixes (R5/R2/R11) + fetch-in-effect → SWR (R9/N2).

## Highlights
### AdonisJS
- **A1** extract data/aggregation from controllers → `ServerListingService.paginate`, `AdvertisementStatsService.getStats` (logic moved verbatim).
- **A2** VineJS validation on `server_categories` attach/detach, `categories` id, `posts.previewPlaceholder` — invalid input now returns **422**.
- **A6** stop swallowing errors: `stats_controller` defers to the exception handler; removed try/catch around pure CSV parsing; no more bare `catch {}` in `placeholder_service`.
- **A4** N+1 in `placeholder_service.preloadServerData`: ~6×N per-server queries → set-based (`whereIn` + `DISTINCT ON` + grouped avg/median).

### React / Next.js
- **R5/R2/R11** `use-toast` deps `[state]`→`[]`; `multi-select` notifies parent from handlers (not an Effect) + drop needless `useCallback`.
- **R9/N2** migrate ad-hoc `useEffect`+fetch → **SWR**: `latest-articles-section`, home `server-select`, server **edit** page, server **detail** stats (`setInterval`→`refreshInterval`), and the **auth context** `/me` bootstrap (public API preserved; `token` drives the SWR key; fixed an `isLoggedIn` reset on token expiry).

## ⚠️ Needs runtime QA before merge
Compiles/lints/builds green but changes runtime behavior, not runtime-tested:
- **Backend (DB):** N+1 aggregate parity (min/max/avg/median/first/last/latest), the new 422 responses, and changed error shapes from `stats_controller`.
- **Frontend (browser):** session/login/logout (SWR-migrated auth context), server edit + detail pages, home sections.

## Notes
- Audit checklist lives in the local skill `framework-best-practices` (`.claude/`, gitignored).
- Untracked `.ds-sync/`, `ds-bundle/`, `frontend/ds-tailwind.css` are from a separate design-sync tool — not part of this PR.