### PR TITLE
Clean up gitignore and fix player peak computation logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-analytics/extracted_data/
-analytics/minecraft_stats.db
-analytics/data
-
 # Claude Code / BMAD
 .claude/
 _bmad/
@@ -14,3 +10,10 @@ ds-bundle/
 .design-sync/learnings/
 .design-sync/node_modules
 frontend/ds-tailwind.css
+
+# Design exports / working files (keep only SPEC.md)
+docs/new-design/*.html
+docs/new-design/*.dc*
+docs/new-design/_*
+docs/new-design/*support*.js
+docs/new-design/*(1)*

--- a/backend/database/migrations/1782100391822_recompute_peak_player_counts.ts
+++ b/backend/database/migrations/1782100391822_recompute_peak_player_counts.ts
@@ -1,0 +1,54 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'servers'
+
+  /**
+   * Recalcule le pic all-time de joueurs pour TOUS les serveurs depuis l'historique
+   * brut `server_stats`. Corrige les `peak_player_count` restés NULL ou désynchronisés.
+   * Les `server_stats` ne sont jamais purgés, donc cette source est exhaustive.
+   *
+   * Corrige le bug du backfill initial (`1782056332671`) : un ping raté insère une
+   * ligne `server_stats` avec `player_count = NULL`, et `ORDER BY player_count DESC`
+   * trie les NULL en premier (NULLS FIRST par défaut en Postgres) — `DISTINCT ON`
+   * choisissait alors une ligne NULL et écrasait le pic. D'où le filtre explicite
+   * `player_count IS NOT NULL`.
+   *
+   * DISTINCT ON garde, par serveur, la ligne au plus grand `player_count` non-NULL —
+   * et, à égalité, la plus ancienne (première fois que le pic a été atteint).
+   *
+   * Le scheduler ne fait ensuite que monter le pic (cf. start/scheduler.ts), donc ce
+   * recalcul one-shot suffit à resynchroniser.
+   */
+  async up() {
+    this.defer(async (db) => {
+      await db.rawQuery(`
+        UPDATE servers s
+        SET peak_player_count = sub.peak_count,
+            peak_player_at = sub.peak_at
+        FROM (
+          SELECT DISTINCT ON (server_id)
+            server_id,
+            player_count AS peak_count,
+            created_at AS peak_at
+          FROM server_stats
+          WHERE server_id IS NOT NULL
+            AND player_count IS NOT NULL
+          ORDER BY server_id, player_count DESC, created_at ASC
+        ) sub
+        WHERE s.id = sub.server_id
+          AND (
+            s.peak_player_count IS NULL
+            OR s.peak_player_count <> sub.peak_count
+            OR s.peak_player_at IS DISTINCT FROM sub.peak_at
+          )
+      `)
+    })
+  }
+
+  /**
+   * Recalcul de données uniquement — rien à défaire. Les valeurs restent maintenues
+   * par le scheduler.
+   */
+  async down() {}
+}

--- a/backend/database/schema.ts
+++ b/backend/database/schema.ts
@@ -316,6 +316,8 @@ export class ServerSchema extends BaseModel {
     'motdHash',
     'name',
     'nextPingAt',
+    'peakPlayerAt',
+    'peakPlayerCount',
     'port',
     'resolvedEndpoint',
     'type',
@@ -353,6 +355,10 @@ export class ServerSchema extends BaseModel {
   declare name: string
   @column.dateTime()
   declare nextPingAt: DateTime | null
+  @column.dateTime()
+  declare peakPlayerAt: DateTime | null
+  @column()
+  declare peakPlayerCount: number | null
   @column()
   declare port: number
   @column()


### PR DESCRIPTION
This pull request introduces a new migration and updates the `ServerSchema` model to fix and resynchronize the all-time peak player counts for servers. The migration recalculates and corrects any `peak_player_count` values that are missing or out of sync, addressing a bug in the initial backfill logic. The schema is also updated to ensure the new fields are properly mapped.

**Database Migration and Bug Fixes:**

* Added a migration (`1782100391822_recompute_peak_player_counts.ts`) that recalculates the all-time peak player count and timestamp for all servers, filtering out invalid data and correcting a previous bug where failed pings could overwrite peak values with `NULL`.

**Schema Updates:**

* Updated `ServerSchema` in `schema.ts` to include `peakPlayerAt` and `peakPlayerCount` as mapped columns, ensuring these fields are available and correctly typed in the model. [[1]](diffhunk://#diff-91f801db60eada53089fa8b13836fd3cc8ba85bf79c45bf946f6652be00e6c70R319-R320) [[2]](diffhunk://#diff-91f801db60eada53089fa8b13836fd3cc8ba85bf79c45bf946f6652be00e6c70R358-R361)