### PR TITLE
fix(seo): repair blog discoverability, canonical/hreflang and slugs

### DIFF
--- a/backend/app/models/post.ts
+++ b/backend/app/models/post.ts
@@ -43,16 +43,20 @@ export default class Post extends BaseModel {
 
   @beforeCreate()
   static async generateSlug(post: Post) {
-    if (!post.slug && post.title) {
-      let slug = string.slug(post.title, { lower: true })
+    // Slugifie soit le slug fourni (admin), soit le titre. `strict` retire les
+    // caractères non URL-safe (apostrophes, deux-points, parenthèses, « ? »…)
+    // qui sinon finissent tels quels dans l'URL publique.
+    const source = post.slug || post.title
+    if (!source) return
 
-      // Vérifier si le slug existe déjà et ajouter un suffixe si nécessaire
-      const existingPost = await Post.query().where('slug', slug).first()
-      if (existingPost) {
-        slug = `${slug}-${Date.now()}`
-      }
+    let slug = string.slug(source, { lower: true, strict: true }) || `post-${Date.now()}`
 
-      post.slug = slug
+    // Vérifier si le slug existe déjà et ajouter un suffixe si nécessaire
+    const existingPost = await Post.query().where('slug', slug).first()
+    if (existingPost) {
+      slug = `${slug}-${Date.now()}`
     }
+
+    post.slug = slug
   }
 }

--- a/frontend/src/app/(pages)/blog/[slug]/not-found.tsx
+++ b/frontend/src/app/(pages)/blog/[slug]/not-found.tsx
@@ -1,0 +1,24 @@
+import { Button } from "@/components/ui/button";
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
+
+export default function BlogPostNotFound() {
+  return (
+    <div className="flex items-center justify-center">
+      <div className="container mx-auto px-4 py-16 text-center">
+        <div className="mx-auto max-w-2xl rounded-xl border border-border bg-card p-8 text-card-foreground shadow-xs sm:p-12">
+          <h1 className="mb-4 text-3xl font-bold tracking-tight text-foreground">Article Not Found</h1>
+          <p className="mb-8 text-muted-foreground">
+            The article you are looking for does not exist or has been deleted.
+          </p>
+          <Button asChild variant="accent">
+            <Link href="/blog">
+              <ChevronLeft className="mr-2 h-4 w-4" />
+              Back to Blog
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(pages)/blog/[slug]/page.tsx
+++ b/frontend/src/app/(pages)/blog/[slug]/page.tsx
@@ -1,15 +1,16 @@
 import { PostAuthor, formatPostDate } from "@/components/blog/post-meta";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { getPostBySlug } from "@/http/post";
 import { ChevronLeft } from "lucide-react";
 import { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import { cache } from "react";
 import { BlogPostStructuredData } from "@/components/seo/structured-data";
 import ArticleBody from "@/components/blog/article-body";
 import { resolveAssetUrl } from "@/lib/domain";
+import { getAlternateLanguages, getDomainConfig } from "@/lib/domain-server";
 import { renderMarkdown } from "@/lib/markdown";
 
 // ISR — chaque page d'article est rebuild en arrière-plan toutes les 10 minutes (P.4.3)
@@ -25,32 +26,46 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
+  const { baseUrl } = await getDomainConfig();
 
   try {
     const post = await loadPost(slug);
 
+    const canonical = `${baseUrl}/blog/${post.slug}`;
+    // Fall back to the site OG image so cover-less posts still get a social card.
+    const image = post.coverImage
+      ? resolveAssetUrl(post.coverImage)
+      : `${baseUrl}/images/minecraft-stats/og-image.webp`;
+
     return {
-      title: `${post.title} - Minecraft Stats Blog`,
+      title: post.title,
       description: post.excerpt || post.title,
+      alternates: {
+        canonical,
+        languages: getAlternateLanguages(`/blog/${post.slug}`),
+      },
       openGraph: {
         title: post.title,
         description: post.excerpt || post.title,
         type: "article",
+        url: canonical,
         publishedTime: post.publishedAt?.toString(),
+        modifiedTime: post.updatedAt?.toString(),
         authors: [post.author.username],
-        images: post.coverImage ? [resolveAssetUrl(post.coverImage)] : [],
+        images: [image],
       },
       twitter: {
         card: "summary_large_image",
         title: post.title,
         description: post.excerpt || post.title,
-        images: post.coverImage ? [resolveAssetUrl(post.coverImage)] : [],
+        images: [image],
       },
     };
   } catch {
     return {
-      title: "Article not found - Minecraft Stats",
+      title: "Article not found",
       description: "The requested article does not exist",
+      robots: { index: false, follow: true },
     };
   }
 }
@@ -76,7 +91,6 @@ export default async function BlogPostPage({ params }: Readonly<Props>) {
             updatedAt: post.updatedAt?.toString() || post.createdAt.toString(),
             author: {
               name: post.author.username,
-              email: post.author.email,
             },
           }}
         />
@@ -96,7 +110,7 @@ export default async function BlogPostPage({ params }: Readonly<Props>) {
           {/* Header */}
           <header className="mb-8 text-center">
             <div className="mb-4 text-[11px] font-bold uppercase tracking-[0.12em] text-accent">
-              News · {formatPostDate(post.createdAt)}
+              News · {formatPostDate(post.publishedAt ?? post.createdAt)}
             </div>
             <h1 className="mb-6 text-3xl font-black leading-tight tracking-tight text-balance text-foreground sm:text-4xl md:text-5xl">
               {post.title}
@@ -115,7 +129,7 @@ export default async function BlogPostPage({ params }: Readonly<Props>) {
           {/* Cover image */}
           {post.coverImage && (
             <div className="relative mb-10 h-[220px] w-full overflow-hidden rounded-xl border border-border bg-secondary sm:h-[320px] md:h-[400px]">
-              <Image src={resolveAssetUrl(post.coverImage)} alt={post.title} className="h-full w-full object-cover" unoptimized fill />
+              <Image src={resolveAssetUrl(post.coverImage)} alt={post.title} className="h-full w-full object-cover" priority unoptimized fill />
             </div>
           )}
 
@@ -167,23 +181,7 @@ export default async function BlogPostPage({ params }: Readonly<Props>) {
       </div>
     );
   } catch {
-    return (
-      <div className="flex items-center justify-center">
-        <div className="container mx-auto px-4 py-16 text-center">
-          <div className="mx-auto max-w-2xl rounded-xl border border-border bg-card p-8 text-card-foreground shadow-xs sm:p-12">
-            <h1 className="mb-4 text-3xl font-bold tracking-tight text-foreground">Article Not Found</h1>
-            <p className="mb-8 text-muted-foreground">
-              The article you are looking for does not exist or has been deleted.
-            </p>
-            <Button asChild variant="accent">
-              <Link href="/blog">
-                <ChevronLeft className="mr-2 h-4 w-4" />
-                Back to Blog
-              </Link>
-            </Button>
-          </div>
-        </div>
-      </div>
-    );
+    // Return a real 404 (not a soft 200 page) so search engines drop missing posts.
+    notFound();
   }
 }

--- a/frontend/src/app/(pages)/blog/page.tsx
+++ b/frontend/src/app/(pages)/blog/page.tsx
@@ -1,20 +1,49 @@
 import PostCard from "@/components/blog/post-card";
+import { Button } from "@/components/ui/button";
 import { getPosts } from "@/http/post";
+import { getAlternateLanguages, getDomainConfig } from "@/lib/domain-server";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Metadata } from "next";
+import Link from "next/link";
+
+const PAGE_SIZE = 12;
 
 // ISR — la page est rebuild en arrière-plan toutes les heures (P.4.3)
 export const revalidate = 3600;
 
-export const metadata: Metadata = {
-  title: "Blog - Minecraft Stats",
-  description: "Latest news, server spotlights, and development updates.",
+type Props = {
+  searchParams: Promise<{ page?: string }>;
 };
 
-export default async function BlogPage() {
-  const posts = await getPosts(1, 20);
-  const publishedArticles = posts.data;
-  const featuredArticle = publishedArticles[0];
-  const remainingArticles = publishedArticles.slice(1);
+function parsePage(value?: string): number {
+  const page = Number.parseInt(value ?? "1", 10);
+  return Number.isFinite(page) && page > 0 ? page : 1;
+}
+
+export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
+  const { baseUrl } = await getDomainConfig();
+  const page = parsePage((await searchParams).page);
+  const path = page > 1 ? `/blog?page=${page}` : "/blog";
+
+  return {
+    title: "Blog",
+    description: "Latest news, server spotlights, and development updates.",
+    alternates: {
+      canonical: `${baseUrl}${path}`,
+      languages: getAlternateLanguages(path),
+    },
+  };
+}
+
+export default async function BlogPage({ searchParams }: Readonly<Props>) {
+  const page = parsePage((await searchParams).page);
+  const posts = await getPosts(page, PAGE_SIZE);
+  const articles = posts.data;
+  const { currentPage, lastPage } = posts.meta;
+
+  // The featured hero only makes sense on the first page.
+  const featuredArticle = currentPage === 1 ? articles[0] : undefined;
+  const remainingArticles = currentPage === 1 ? articles.slice(1) : articles;
 
   return (
     <div className="min-h-screen">
@@ -28,7 +57,7 @@ export default async function BlogPage() {
           </p>
         </header>
 
-        {publishedArticles.length === 0 ? (
+        {articles.length === 0 ? (
           <div className="rounded-xl border border-dashed border-border bg-card py-20 text-center">
             <p className="text-lg text-muted-foreground">No articles found.</p>
           </div>
@@ -40,13 +69,44 @@ export default async function BlogPage() {
             {/* Recent stories grid */}
             {remainingArticles.length > 0 && (
               <section className="space-y-5">
-                <h2 className="text-xl font-bold tracking-tight text-foreground">Recent Stories</h2>
+                {currentPage === 1 && (
+                  <h2 className="text-xl font-bold tracking-tight text-foreground">Recent Stories</h2>
+                )}
                 <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
                   {remainingArticles.map((post) => (
                     <PostCard key={post.id} post={post} />
                   ))}
                 </div>
               </section>
+            )}
+
+            {/* Pagination */}
+            {lastPage > 1 && (
+              <nav className="flex items-center justify-between border-t border-border pt-6" aria-label="Blog pagination">
+                {currentPage > 1 ? (
+                  <Button asChild variant="outline">
+                    <Link href={currentPage === 2 ? "/blog" : `/blog?page=${currentPage - 1}`} rel="prev">
+                      <ChevronLeft className="mr-1 h-4 w-4" />
+                      Previous
+                    </Link>
+                  </Button>
+                ) : (
+                  <span />
+                )}
+                <span className="text-sm text-muted-foreground">
+                  Page {currentPage} of {lastPage}
+                </span>
+                {currentPage < lastPage ? (
+                  <Button asChild variant="outline">
+                    <Link href={`/blog?page=${currentPage + 1}`} rel="next">
+                      Next
+                      <ChevronRight className="ml-1 h-4 w-4" />
+                    </Link>
+                  </Button>
+                ) : (
+                  <span />
+                )}
+              </nav>
             )}
           </>
         )}

--- a/frontend/src/app/feed.xml/route.ts
+++ b/frontend/src/app/feed.xml/route.ts
@@ -1,0 +1,79 @@
+import { getDomainConfig } from "@/lib/domain-server";
+
+// Rebuild the feed hourly, in line with the blog index.
+export const revalidate = 3600;
+
+interface FeedPost {
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  publishedAt: string | null;
+  createdAt: string;
+}
+
+interface PostsPage {
+  meta: { lastPage: number };
+  data: FeedPost[];
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+async function getRecentPosts(apiUrl: string): Promise<FeedPost[]> {
+  try {
+    const response = await fetch(`${apiUrl}/posts?page=1&limit=50`, {
+      next: { revalidate: 3600 },
+    });
+
+    if (!response.ok) return [];
+
+    const body: PostsPage = await response.json();
+    return body.data;
+  } catch (error) {
+    console.error("Error fetching posts for feed:", error);
+    return [];
+  }
+}
+
+export async function GET() {
+  const { baseUrl, apiUrl } = await getDomainConfig();
+  const posts = await getRecentPosts(apiUrl);
+
+  const items = posts
+    .map((post) => {
+      const url = `${baseUrl}/blog/${post.slug}`;
+      const date = new Date(post.publishedAt || post.createdAt).toUTCString();
+      return `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>
+      <pubDate>${date}</pubDate>
+      ${post.excerpt ? `<description>${escapeXml(post.excerpt)}</description>` : ""}
+    </item>`;
+    })
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Minecraft Stats Blog</title>
+    <link>${baseUrl}/blog</link>
+    <description>Latest news, server spotlights, and development updates.</description>
+    <language>en</language>
+    <atom:link href="${baseUrl}/feed.xml" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    },
+  });
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -88,6 +88,9 @@ export const generateMetadata = async (): Promise<Metadata> => {
     alternates: {
       canonical: baseUrl,
       languages: alternateLanguages,
+      types: {
+        "application/rss+xml": `${baseUrl}/feed.xml`,
+      },
     },
     verification: {
       google: googleSearchId,

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -11,6 +11,17 @@ interface ServerListItem {
   server: Server;
 }
 
+interface Post {
+  slug: string;
+  publishedAt: string | null;
+  updatedAt: string;
+}
+
+interface PostsPage {
+  meta: { lastPage: number };
+  data: Post[];
+}
+
 async function getAllServers(apiUrl: string): Promise<Server[]> {
   try {
     const response = await fetch(`${apiUrl}/servers`, {
@@ -34,9 +45,39 @@ async function getAllServers(apiUrl: string): Promise<Server[]> {
   }
 }
 
+async function getAllPosts(apiUrl: string): Promise<Post[]> {
+  try {
+    const posts: Post[] = [];
+    let page = 1;
+    let lastPage = 1;
+
+    // `/posts` only returns published posts; paginate through every page.
+    do {
+      const response = await fetch(`${apiUrl}/posts?page=${page}&limit=100`, {
+        next: { revalidate: 3600 },
+      });
+
+      if (!response.ok) {
+        console.error('Failed to fetch posts for sitemap');
+        break;
+      }
+
+      const body: PostsPage = await response.json();
+      posts.push(...body.data);
+      lastPage = body.meta.lastPage;
+      page += 1;
+    } while (page <= lastPage);
+
+    return posts;
+  } catch (error) {
+    console.error('Error fetching posts for sitemap:', error);
+    return [];
+  }
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const { baseUrl, apiUrl } = await getDomainConfig();
-  const servers = await getAllServers(apiUrl);
+  const [servers, posts] = await Promise.all([getAllServers(apiUrl), getAllPosts(apiUrl)]);
 
   // Static routes
   const routes: MetadataRoute.Sitemap = [
@@ -45,6 +86,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: new Date(),
       changeFrequency: 'hourly',
       priority: 1,
+    },
+    {
+      url: `${baseUrl}/blog`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.7,
     },
     {
       url: `${baseUrl}/partners`,
@@ -59,6 +106,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.3,
     },
   ];
+
+  // Dynamic blog post routes
+  const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${baseUrl}/blog/${post.slug}`,
+    lastModified: new Date(post.updatedAt || post.publishedAt || Date.now()),
+    changeFrequency: 'weekly' as const,
+    priority: 0.6,
+  }));
 
   // Dynamic server routes
   const serverRoutes: MetadataRoute.Sitemap = servers.map((server) => {
@@ -75,5 +130,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     };
   });
 
-  return [...routes, ...serverRoutes];
+  return [...routes, ...postRoutes, ...serverRoutes];
 }

--- a/frontend/src/components/seo/structured-data.tsx
+++ b/frontend/src/components/seo/structured-data.tsx
@@ -196,7 +196,6 @@ interface BlogPost {
   updatedAt: string;
   author?: {
     name: string;
-    email?: string;
   };
 }
 
@@ -206,6 +205,8 @@ interface BlogPostStructuredDataProps {
 
 export function BlogPostStructuredData({ post }: Readonly<BlogPostStructuredDataProps>) {
   const { baseUrl } = getClientDomainConfig();
+  const postUrl = `${baseUrl}/blog/${post.slug}`;
+  const inLanguage = baseUrl.includes("minecraft-stats.fr") ? "fr-FR" : "en-US";
 
   const structuredData = {
     "@context": "https://schema.org",
@@ -220,7 +221,6 @@ export function BlogPostStructuredData({ post }: Readonly<BlogPostStructuredData
     author: {
       "@type": "Person",
       name: post.author?.name || "Sportek",
-      email: post.author?.email,
     },
     publisher: {
       "@type": "Organization",
@@ -234,12 +234,20 @@ export function BlogPostStructuredData({ post }: Readonly<BlogPostStructuredData
     },
     mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": `${baseUrl}/blog/${post.slug}`,
+      "@id": postUrl,
     },
-    url: `${baseUrl}/blog/${post.slug}`,
+    url: postUrl,
     articleSection: "Minecraft Server News & Guides",
-    inLanguage: "en-US",
+    inLanguage,
     keywords: "minecraft server, server stats, gaming, minecraft",
+    breadcrumb: {
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Home", item: baseUrl },
+        { "@type": "ListItem", position: 2, name: "Blog", item: `${baseUrl}/blog` },
+        { "@type": "ListItem", position: 3, name: post.title, item: postUrl },
+      ],
+    },
   };
 
   return (

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -23,6 +23,19 @@ const md = new MarkdownIt({
   breaks: false,
 });
 
+/**
+ * La page d'article a déjà son `<h1>` (le titre). Un `#` écrit dans le corps
+ * produirait un second `<h1>`, ce qui nuit au SEO. On rétrograde uniquement le
+ * niveau 1 en `<h2>` ; les `##`/`###` voulus par l'auteur restent intacts.
+ */
+md.core.ruler.push("demote_h1", (state) => {
+  for (const token of state.tokens) {
+    if ((token.type === "heading_open" || token.type === "heading_close") && token.tag === "h1") {
+      token.tag = "h2";
+    }
+  }
+});
+
 export function renderMarkdown(content: string | null | undefined): string {
   if (!content) return "";
   return DOMPurify.sanitize(md.render(content), {


### PR DESCRIPTION
## Summary
Fixes a set of blog SEO infrastructure issues found during an audit of the deployed site. The article content was fine, but crawlers couldn't discover posts and Google treated them as duplicates of the homepage. All fixes verified with frontend lint + typecheck + production build, and backend typecheck.

## Changes
- **Sitemap & discovery** — the sitemap fetched only servers, so `/blog` and every post were invisible. Now fetches all published posts (paginated) + the index, and adds a `/feed.xml` RSS feed referenced site-wide.
- **Canonical & hreflang** — posts inherited the root canonical (the homepage). Added a self-referencing canonical and path-aware hreflang per post, and per-page on the index.
- **Pagination** — the index hardcoded `getPosts(1, 20)`, orphaning posts past the 20th. Added `?page=` pagination with Prev/Next + per-page canonical; featured hero on page 1 only.
- **Real 404s** — missing posts returned a soft 200 "Article Not Found"; now `notFound()` returns a real 404 with a dedicated `not-found.tsx`.
- **Slugs** — backend `string.slug()` ran without strict mode, leaking apostrophes/colons/parentheses into URLs. Enabled strict mode (also normalizes admin-provided slugs).
- **Metadata/structured data** — OG image fallback to the site image for cover-less posts, `modifiedTime`, de-duplicated brand suffix in the title, `BlogPosting` breadcrumbs, domain-aware `inLanguage`, author email removed from JSON-LD, visible date now uses `publishedAt`, and `priority` on the cover image (LCP).
- **Headings** — a stray markdown `#` (h1) in an article body is demoted to `h2` so each page keeps a single `h1`.

## Testing
- `yarn lint` (frontend) — pass
- `tsc --noEmit` (frontend + backend) — pass
- `yarn build` (frontend) — pass; `/feed.xml`, `/blog`, `/blog/[slug]`, `/sitemap.xml` all compile

## Notes
- **Existing slugs left unchanged.** The 3 current "ugly" slugs still resolve (HTTP 200); renaming them would break already-shared/indexed links without redirects. The fix applies to future posts. A migration + 301s can be added if we want to clean them up.
- **robots.txt AI-bot blocks untouched** — that's a strategic choice (LLM citation visibility), left as-is.
- **Global hreflang (non-blog pages)** still points at domain roots in the root layout; scoped this PR to the blog. Fixing it globally needs the request pathname in the root metadata — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)