### PR TITLE
feat(admin): user detail view with profile and uploaded servers

### DIFF
--- a/backend/app/controllers/users_controller.ts
+++ b/backend/app/controllers/users_controller.ts
@@ -1,3 +1,4 @@
+import Server from '#models/server'
 import User from '#models/user'
 import UserPolicy from '#policies/user_policy'
 import { CreateUserValidator, UpdateUserValidator } from '#validators/user'
@@ -153,6 +154,59 @@ export default class UsersController {
     const users = await query.paginate(page, limit)
 
     return response.ok(users)
+  }
+
+  /**
+   * @adminShowUser
+   * @operationId adminShowUser
+   * @tag USERS_ADMIN
+   * @summary Get a user's profile and uploaded servers (admin only)
+   * @description Returns a single user's full profile — including the normally hidden `email`, the registration `provider` (`null` for email/password sign-ups), and `verified` status — alongside every server they have uploaded. Requires an authenticated admin (gated by `UserPolicy.manage`).
+   * @paramPath id - User ID - @type(number) @example(7) @required
+   * @responseBody 200 - {"user": {"id": 7, "username": "gabriel", "email": "gabriel@example.com", "role": "user", "verified": true, "provider": "discord", "avatarUrl": "", "createdAt": "2025-01-01T00:00:00.000Z", "updatedAt": "2026-05-28T12:00:00.000Z"}, "servers": [{"id": 1, "name": "Hypixel", "address": "mc.hypixel.net", "port": 25565, "type": "java", "imageUrl": "", "lastPlayerCount": 1200, "peakPlayerCount": 5000, "lastOnlineAt": "2026-05-28T12:00:00.000Z", "createdAt": "2025-01-01T00:00:00.000Z"}], "stats": {"serverCount": 1}}
+   * @responseBody 401 - {"error": "Unauthorized"}
+   * @responseBody 403 - {"error": "Access denied. Admin privileges required."}
+   * @responseBody 404 - {"error": "User not found"}
+   */
+  async adminShow({ params, response, auth, bouncer }: HttpContext) {
+    const currentUser = auth.user
+    if (!currentUser) {
+      return response.unauthorized({ error: 'Unauthorized' })
+    }
+
+    if (await bouncer.with(UserPolicy).denies('manage')) {
+      return response.forbidden({ error: 'Access denied. Admin privileges required.' })
+    }
+
+    const user = await User.find(params.id)
+    if (!user) {
+      return response.notFound({ error: 'User not found' })
+    }
+
+    const servers = await Server.query()
+      .where('user_id', user.id)
+      .preload('languages')
+      .orderBy('created_at', 'desc')
+
+    // `email` and `provider` are intentionally surfaced here even though the model
+    // hides `email` from default serialization — this admin-only view needs them.
+    return response.ok({
+      user: {
+        id: user.id,
+        username: user.username,
+        email: user.email,
+        role: user.role,
+        verified: user.verified,
+        provider: user.provider,
+        avatarUrl: user.avatarUrl,
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+      },
+      servers,
+      stats: {
+        serverCount: servers.length,
+      },
+    })
   }
 
   /**

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -221,6 +221,9 @@ router
           .get('users', '#controllers/users_controller.adminIndex')
           .use(throttleLight('admin.users.index', 20))
         router
+          .get('users/:id', '#controllers/users_controller.adminShow')
+          .use([throttleLight('admin.users.show', 30), NO_STORE])
+        router
           .patch('users/:id/role', '#controllers/users_controller.updateRole')
           .use(throttleLight('admin.users.updateRole', 10))
 

--- a/frontend/src/app/(pages)/admin/users/[id]/page.tsx
+++ b/frontend/src/app/(pages)/admin/users/[id]/page.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import DashboardHero from "@/components/account/dashboard-hero";
+import DashboardLayout from "@/components/account/dashboard-layout";
+import DashboardStatTile from "@/components/account/dashboard-stat-tile";
+import { AdminBackLink } from "@/components/admin/admin-back-link";
+import { AdminLoadingState, AdminMessageState } from "@/components/admin/admin-states";
+import ServerImage from "@/components/serveur/card/server-image";
+import { Badge, BadgeProps } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAuth } from "@/contexts/auth";
+import { AdminUserDetailResponse, getAdminUserDetail } from "@/http/user";
+import { RegistrationProvider } from "@/types/auth";
+import { Icon } from "@iconify/react/dist/iconify.js";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+const ONLINE_WINDOW_MS = 1000 * 60 * 30;
+const formatNumber = (value: number) => new Intl.NumberFormat("en-US").format(value);
+const formatDate = (value: string | Date) =>
+  new Date(value).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+
+const isOnline = (lastOnlineAt: string | Date | null) =>
+  lastOnlineAt ? Date.now() - new Date(lastOnlineAt).getTime() < ONLINE_WINDOW_MS : false;
+
+const getRoleBadgeVariant = (role: string): BadgeProps["variant"] => {
+  switch (role) {
+    case "admin":
+      return "destructive";
+    case "writer":
+      return "accent";
+    default:
+      return "secondary";
+  }
+};
+
+/** Human-readable registration method derived from the OAuth provider (null = email & password). */
+const getRegistration = (provider: RegistrationProvider) => {
+  switch (provider) {
+    case "discord":
+      return { label: "Discord", icon: "ic:baseline-discord" };
+    case "google":
+      return { label: "Google", icon: "logos:google-icon" };
+    default:
+      return { label: "Email & password", icon: "material-symbols:mail-outline" };
+  }
+};
+
+const InfoRow = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="flex flex-col gap-1 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+    <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">{label}</span>
+    <span className="text-sm text-foreground">{children}</span>
+  </div>
+);
+
+const AdminUserDetailPage = () => {
+  const { user, getToken } = useAuth();
+  const token = getToken();
+  const params = useParams();
+  const userId = Number(params.id);
+
+  const [detail, setDetail] = useState<AdminUserDetailResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token || !Number.isFinite(userId)) return;
+
+    const fetchDetail = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        setDetail(await getAdminUserDetail(userId, token));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load this user.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDetail();
+  }, [token, userId]);
+
+  if (!user) {
+    return <AdminLoadingState label="Loading..." />;
+  }
+
+  if (user.role !== "admin") {
+    return (
+      <AdminMessageState
+        tone="destructive"
+        title="Access Denied"
+        description="You must be an administrator to access this page."
+      />
+    );
+  }
+
+  const profile = detail?.user;
+  const servers = detail?.servers ?? [];
+  const registration = profile ? getRegistration(profile.provider) : null;
+  const onlineCount = servers.filter((s) => isOnline(s.lastOnlineAt)).length;
+  const playersTracked = servers.reduce((total, s) => total + (s.lastPlayerCount ?? 0), 0);
+
+  return (
+    <DashboardLayout>
+      <div>
+        <AdminBackLink href="/admin/users" label="Back to users" />
+      </div>
+
+      <DashboardHero
+        title={profile ? profile.username : "User"}
+        subtitle={profile ? "Account details and uploaded servers." : "Loading account…"}
+        badge={profile ? `${profile.role.charAt(0).toUpperCase() + profile.role.slice(1)}` : undefined}
+        avatar={profile ? { name: profile.username, src: profile.avatarUrl } : undefined}
+      />
+
+      {error ? (
+        <AdminMessageState tone="destructive" title="Could not load user" description={error} />
+      ) : loading ? (
+        <div className="space-y-4">
+          <Skeleton className="h-40 w-full rounded-xl" />
+          <Skeleton className="h-64 w-full rounded-xl" />
+        </div>
+      ) : !profile ? (
+        <AdminMessageState
+          tone="destructive"
+          title="User not found"
+          description="This user does not exist."
+        />
+      ) : (
+        <>
+          {/* Stat tiles */}
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <DashboardStatTile label="Servers" value={formatNumber(detail?.stats.serverCount ?? 0)} />
+            <DashboardStatTile label="Online Now" value={formatNumber(onlineCount)} dot="success" />
+            <DashboardStatTile label="Offline" value={formatNumber(servers.length - onlineCount)} dot="muted" />
+            <DashboardStatTile label="Players Tracked" value={formatNumber(playersTracked)} />
+          </div>
+
+          {/* Account info */}
+          <div className="overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-xs">
+            <div className="border-b border-border px-5 py-4">
+              <h2 className="text-base font-semibold text-foreground">Account information</h2>
+            </div>
+            <div className="divide-y divide-border">
+              <InfoRow label="User ID">
+                <span className="font-mono">{profile.id}</span>
+              </InfoRow>
+              <InfoRow label="Username">{profile.username}</InfoRow>
+              <InfoRow label="Email">
+                <a href={`mailto:${profile.email}`} className="text-accent hover:underline">
+                  {profile.email}
+                </a>
+              </InfoRow>
+              <InfoRow label="Role">
+                <Badge variant={getRoleBadgeVariant(profile.role)}>
+                  {profile.role.charAt(0).toUpperCase() + profile.role.slice(1)}
+                </Badge>
+              </InfoRow>
+              <InfoRow label="Registration">
+                <span className="inline-flex items-center gap-2">
+                  {registration && <Icon icon={registration.icon} className="h-4 w-4" />}
+                  {registration?.label}
+                </span>
+              </InfoRow>
+              <InfoRow label="Email verified">
+                <Badge variant={profile.verified ? "success" : "secondary"}>
+                  {profile.verified ? "Verified" : "Not verified"}
+                </Badge>
+              </InfoRow>
+              <InfoRow label="Joined">{formatDate(profile.createdAt)}</InfoRow>
+              <InfoRow label="Last updated">{formatDate(profile.updatedAt)}</InfoRow>
+            </div>
+          </div>
+
+          {/* Uploaded servers */}
+          <div className="overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-xs">
+            <div className="border-b border-border px-5 py-4">
+              <h2 className="text-base font-semibold text-foreground">
+                Uploaded servers
+                <span className="ml-2 text-sm font-normal text-muted-foreground">
+                  ({servers.length})
+                </span>
+              </h2>
+            </div>
+
+            {servers.length === 0 ? (
+              <div className="flex flex-col items-center gap-3 px-6 py-16 text-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-secondary text-muted-foreground">
+                  <Icon icon="mynaui:servers" className="h-6 w-6" />
+                </div>
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-foreground">No servers uploaded</p>
+                  <p className="text-xs text-muted-foreground">
+                    This user has not added any servers yet.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="divide-y divide-border">
+                {servers.map((server) => {
+                  const online = isOnline(server.lastOnlineAt);
+                  return (
+                    <div
+                      key={server.id}
+                      className="flex flex-wrap items-center gap-x-4 gap-y-3 p-4 transition-colors hover:bg-secondary/40"
+                    >
+                      <ServerImage imageUrl={server.imageUrl ?? ""} name={server.name} className="h-10 w-10" />
+                      <div className="min-w-0 flex-1">
+                        <Link
+                          href={`/servers/${server.id}/${server.name}`}
+                          className="block truncate text-sm font-semibold text-foreground transition-colors hover:text-accent"
+                        >
+                          {server.name}
+                        </Link>
+                        <div className="truncate font-mono text-xs text-muted-foreground">
+                          {server.address}
+                          {server.port !== 25565 ? `:${server.port}` : ""}
+                        </div>
+                      </div>
+                      <Badge variant={online ? "success" : "secondary"} className="gap-1.5">
+                        <span
+                          className={
+                            online
+                              ? "h-1.5 w-1.5 rounded-full bg-current"
+                              : "h-1.5 w-1.5 rounded-full bg-muted-foreground"
+                          }
+                        />
+                        {online ? "Online" : "Offline"}
+                      </Badge>
+                      <div className="w-20 text-right">
+                        <div className="text-sm font-bold tabular-nums text-foreground">
+                          {formatNumber(server.lastPlayerCount ?? 0)}
+                        </div>
+                        <div className="text-[11px] text-muted-foreground">
+                          peak {formatNumber(server.peakPlayerCount ?? 0)}
+                        </div>
+                      </div>
+                      <div className="hidden w-24 text-right text-xs text-muted-foreground sm:block">
+                        {formatDate(server.createdAt)}
+                      </div>
+                      <Link
+                        href={`/servers/${server.id}/${server.name}`}
+                        aria-label="View server"
+                        title="View"
+                        className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                      >
+                        <Icon icon="material-symbols:visibility-outline" className="h-4 w-4" />
+                      </Link>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </DashboardLayout>
+  );
+};
+
+export default AdminUserDetailPage;

--- a/frontend/src/app/(pages)/admin/users/page.tsx
+++ b/frontend/src/app/(pages)/admin/users/page.tsx
@@ -20,6 +20,7 @@ import { useAuth } from "@/contexts/auth";
 import { getAdminUsers, updateUserRole } from "@/http/user";
 import { User } from "@/types/auth";
 import { Search } from "lucide-react";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 const PAGE_SIZE = 20;
@@ -216,10 +217,13 @@ const AdminUsersPage = () => {
                 key={u.id}
                 className="flex flex-col gap-3 p-4 transition-colors hover:bg-secondary/40 sm:flex-row sm:items-center"
               >
-                <div className="flex min-w-0 flex-1 items-center gap-3">
+                <Link
+                  href={`/admin/users/${u.id}`}
+                  className="group flex min-w-0 flex-1 items-center gap-3"
+                >
                   <LetterTile name={u.username} className="h-10 w-10 rounded-md text-sm" />
                   <div className="min-w-0">
-                    <p className="truncate font-medium text-foreground">
+                    <p className="truncate font-medium text-foreground transition-colors group-hover:text-accent">
                       {u.username}
                       {u.id === user.id && <span className="ml-2 text-xs text-accent">(you)</span>}
                     </p>
@@ -227,7 +231,7 @@ const AdminUsersPage = () => {
                       Joined {new Date(u.createdAt).toLocaleDateString()}
                     </p>
                   </div>
-                </div>
+                </Link>
 
                 <div className="flex items-center justify-between gap-4 sm:justify-end">
                   <Badge variant={getRoleBadgeVariant(u.role)}>

--- a/frontend/src/http/user.ts
+++ b/frontend/src/http/user.ts
@@ -1,5 +1,6 @@
 import { getBaseUrl } from '@/app/_cheatcode'
-import { User } from '@/types/auth'
+import { AdminUserProfile, User } from '@/types/auth'
+import { AdminUserServer } from '@/types/server'
 import { getErrorMessage } from './auth'
 
 export interface UsersListResponse {
@@ -9,6 +10,14 @@ export interface UsersListResponse {
     perPage: number
     currentPage: number
     lastPage: number
+  }
+}
+
+export interface AdminUserDetailResponse {
+  user: AdminUserProfile
+  servers: AdminUserServer[]
+  stats: {
+    serverCount: number
   }
 }
 
@@ -45,6 +54,22 @@ export const getAdminUsers = async (
   }
 
   return response.json() as Promise<UsersListResponse>
+}
+
+export const getAdminUserDetail = async (userId: number, token: string) => {
+  const response = await fetch(`${getBaseUrl()}/admin/users/${userId}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  })
+
+  if (!response.ok) {
+    const errorMessage = await getErrorMessage(response)
+    throw new Error(errorMessage)
+  }
+
+  return response.json() as Promise<AdminUserDetailResponse>
 }
 
 export const updateUserRole = async (

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -9,6 +9,19 @@ export type User = {
   updatedAt: Date;
 };
 
+/** How a user signed up: `null` means email & password, otherwise the OAuth provider. */
+export type RegistrationProvider = "discord" | "google" | null;
+
+/**
+ * Full profile exposed to admins. Builds on the public `User` shape (minus the
+ * transient verification-token expiry) and adds fields hidden from the public
+ * API: the registration `provider` and email `verified` status.
+ */
+export type AdminUserProfile = Omit<User, "verificationTokenExpires"> & {
+  verified: boolean;
+  provider: RegistrationProvider;
+};
+
 export type Error = {
   error: string;
 };

--- a/frontend/src/types/server.ts
+++ b/frontend/src/types/server.ts
@@ -30,6 +30,12 @@ export interface Server {
   languages: Language[];
 }
 
+/**
+ * A server as listed under a user in the admin user-detail view. Same shape as
+ * `Server` minus the owner relation (the owner is already the page's subject).
+ */
+export type AdminUserServer = Omit<Server, "user">;
+
 export interface ServerStat {
   id: number;
   serverId: number;


### PR DESCRIPTION
## Résumé

Permet aux admins de consulter, pour chaque utilisateur, son profil détaillé et la liste des serveurs qu'il a ajoutés. Depuis le dashboard admin, un clic sur un utilisateur ouvre une page de détail.

## Ce que ça apporte

Sur la nouvelle page `/admin/users/[id]` :
- **Infos du compte** : email, méthode d'inscription (Discord, Google ou Email & mot de passe), statut de vérification de l'email, rôle, date d'inscription et dernière mise à jour.
- **Serveurs uploadés** : liste complète des serveurs de l'utilisateur avec statut online/offline, joueurs actuels, pic de joueurs et date d'ajout — chaque serveur est cliquable vers sa page publique.
- **Tuiles de stats** : nombre de serveurs, online, offline, joueurs suivis.

## Détails techniques

**Backend**
- Nouvelle route `GET /api/v1/admin/users/:id` → `UsersController.adminShow`, protégée par `UserPolicy.manage` (admin uniquement), rate-limitée + `NO_STORE`.
- La réponse expose volontairement `email` et `provider` (normalement masqués par la sérialisation du modèle) car c'est une vue admin, plus les serveurs (avec `languages` préchargés) et un `serverCount`.
- Documentée via les annotations Swagger comme le reste de l'API.

**Frontend**
- Nouvelle page `/admin/users/[id]` (App Router), réutilisant les composants existants (`DashboardLayout`, `DashboardHero`, `DashboardStatTile`, `AdminBackLink`, `ServerImage`, `Badge`).
- Chaque ligne de la liste `/admin/users` renvoie maintenant vers la page de détail.
- Client HTTP : `getAdminUserDetail`.
- Les nouveaux types réutilisent les types existants (`Omit<User, …>` et `Omit<Server, "user">`) pour éviter de redupliquer les champs.

## Vérifications

- `tsc --noEmit` et ESLint passent sur les fichiers modifiés (frontend).
- Backend : `node_modules` non installable dans cet environnement (le proxy interrompt le téléchargement des binaires natifs `sharp`/`swc`), mais les changements reprennent à l'identique les patterns existants (`adminIndex`, `mine`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rzm1sTHHt7ofKMFVtV8AGh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rzm1sTHHt7ofKMFVtV8AGh)_