### PR TITLE
feat(blog): post view counts and "was this article helpful?" feedback

### DIFF
--- a/backend/app/controllers/posts_controller.ts
+++ b/backend/app/controllers/posts_controller.ts
@@ -5,9 +5,11 @@ import {
   CreatePostValidator,
   PreviewPlaceholderValidator,
   ResolvePlaceholdersValidator,
+  SubmitFeedbackValidator,
   UpdatePostValidator,
 } from '#validators/post'
 import type { HttpContext } from '@adonisjs/core/http'
+import db from '@adonisjs/lucid/services/db'
 import { DateTime } from 'luxon'
 
 export default class PostsController {
@@ -57,6 +59,65 @@ export default class PostsController {
       .firstOrFail()
 
     return response.ok(post)
+  }
+
+  /**
+   * @recordPostView
+   * @operationId recordPostView
+   * @tag POSTS
+   * @summary Record a view for a published post
+   * @description Increments the raw view counter of a published post. Consent-exempt and best-effort: it stores only an aggregate counter (no visitor or account identifier), so it counts every reader — logged in or not, consent given or not — on the same privacy basis as the anonymous analytics hit. Detailed, consent-aware attribution (who viewed) is captured separately by the analytics page-view pipeline. Always responds `204 No Content`. Publicly accessible.
+   * @paramPath slug - Unique slug of the post - @type(string) @example(welcome-post) @required
+   * @responseBody 204 - No content
+   */
+  async recordView({ params, response }: HttpContext) {
+    await Post.query()
+      .where('slug', params.slug)
+      .where('published', true)
+      .increment('view_count', 1)
+
+    return response.noContent()
+  }
+
+  /**
+   * @submitPostFeedback
+   * @operationId submitPostFeedback
+   * @tag POSTS
+   * @summary Submit "was this article helpful?" feedback
+   * @description Records whether the reader found the article helpful. Deduplicated by the anonymous `visitorId` (one vote per device per post); re-submitting updates the existing vote. When the request carries a valid bearer token the vote is also attributed to the logged-in account. Aggregate results are visible to admins/writers only. Returns 404 if no published post matches the slug. Publicly accessible.
+   * @paramPath slug - Unique slug of the post - @type(string) @example(welcome-post) @required
+   * @requestBody {"helpful": true, "visitorId": "f47ac10b-58cc-4372-a567-0e02b2c3d479"}
+   * @responseBody 204 - No content
+   * @responseBody 404 - {"error": "Post not found"}
+   * @responseBody 422 - {"errors": [{"message": "The helpful field must be defined", "field": "helpful", "rule": "required"}]}
+   */
+  async submitFeedback({ params, request, response, auth }: HttpContext) {
+    const post = await Post.query().where('slug', params.slug).where('published', true).first()
+    if (!post) {
+      return response.notFound({ error: 'Post not found' })
+    }
+
+    const { helpful, visitorId } = await request.validateUsing(SubmitFeedbackValidator)
+
+    // L'endpoint est public : on lit l'utilisateur s'il est connecté sans l'imposer,
+    // pour qu'un visiteur anonyme puisse aussi voter.
+    await auth.check()
+
+    const now = DateTime.now().toSQL()
+    await db
+      .table('post_feedbacks')
+      .insert({
+        post_id: post.id,
+        visitor_id: visitorId,
+        user_id: auth.user?.id ?? null,
+        helpful,
+        created_at: now,
+        updated_at: now,
+      })
+      .onConflict(['post_id', 'visitor_id'])
+      .merge({ helpful, user_id: auth.user?.id ?? null, updated_at: now })
+
+    return response.noContent()
   }
 
   /**
@@ -333,6 +394,84 @@ export default class PostsController {
       value: result,
       serverId,
       placeholderName,
+    })
+  }
+
+  /**
+   * @adminPostStats
+   * @operationId adminPostStats
+   * @tag POSTS_ADMIN
+   * @summary Post views & feedback statistics (admin/writer)
+   * @description Returns engagement statistics for a single post: the raw view total, the consent-aware analytics breakdown derived from the page-view pipeline for `/blog/{slug}` (consented views, logged-in views, unique visitors), the helpful/not-helpful feedback tallies, and the most recent logged-in viewers (who viewed). Writers may only access stats for their own posts, admins for any. Requires authentication and `update` ability on the Post policy. Returns 404 if the post does not exist.
+   * @paramPath id - Post id - @type(number) @example(7) @required
+   * @responseBody 200 - {"post": {"id": 7, "title": "Welcome", "slug": "welcome", "viewCount": 1234}, "views": {"total": 1234, "consented": 800, "loggedIn": 120, "uniqueVisitors": 640}, "feedback": {"helpful": 42, "notHelpful": 3}, "recentViewers": [{"id": 1, "username": "gabriel", "avatarUrl": "", "lastViewedAt": "2026-06-26T12:00:00.000Z"}]}
+   * @responseBody 401 - {"error": "Unauthorized"}
+   * @responseBody 403 - {"error": "Access denied. You can only view stats for your own posts."}
+   * @responseBody 404 - {"message": "Row not found", "code": "E_ROW_NOT_FOUND"}
+   */
+  async adminStats({ params, response, auth, bouncer }: HttpContext) {
+    const user = auth.user
+    if (!user) {
+      return response.unauthorized({ error: 'Unauthorized' })
+    }
+
+    const post = await Post.findOrFail(params.id)
+
+    if (await bouncer.with(PostPolicy).denies('update', post)) {
+      return response.forbidden({
+        error: 'Access denied. You can only view stats for your own posts.',
+      })
+    }
+
+    // L'analytics enregistre les vues consenties par chemin exact (cf. AnalyticsService) :
+    // on retrouve donc les vues d'un article via son URL publique `/blog/{slug}`.
+    const path = `/blog/${post.slug}`
+
+    const [analyticsRow, feedbackRow, recentViewers] = await Promise.all([
+      db
+        .from('page_views')
+        .where('path', path)
+        .select(db.raw('count(*) as consented_views'))
+        .select(db.raw('count(*) filter (where user_id is not null) as logged_in_views'))
+        .select(db.raw('count(distinct visitor_id) as unique_visitors'))
+        .first(),
+
+      db
+        .from('post_feedbacks')
+        .where('post_id', post.id)
+        .select(db.raw('count(*) filter (where helpful) as helpful'))
+        .select(db.raw('count(*) filter (where not helpful) as not_helpful'))
+        .first(),
+
+      db
+        .from('page_views')
+        .join('users', 'users.id', 'page_views.user_id')
+        .where('page_views.path', path)
+        .select('users.id as id', 'users.username as username', 'users.avatar_url as avatar_url')
+        .select(db.raw('max(page_views.created_at) as last_viewed_at'))
+        .groupBy('users.id', 'users.username', 'users.avatar_url')
+        .orderByRaw('max(page_views.created_at) desc')
+        .limit(50),
+    ])
+
+    return response.ok({
+      post: { id: post.id, title: post.title, slug: post.slug, viewCount: post.viewCount },
+      views: {
+        total: post.viewCount,
+        consented: Number(analyticsRow?.consented_views ?? 0),
+        loggedIn: Number(analyticsRow?.logged_in_views ?? 0),
+        uniqueVisitors: Number(analyticsRow?.unique_visitors ?? 0),
+      },
+      feedback: {
+        helpful: Number(feedbackRow?.helpful ?? 0),
+        notHelpful: Number(feedbackRow?.not_helpful ?? 0),
+      },
+      recentViewers: recentViewers.map((row) => ({
+        id: Number(row.id),
+        username: row.username,
+        avatarUrl: row.avatar_url,
+        lastViewedAt: row.last_viewed_at,
+      })),
     })
   }
 }

--- a/backend/app/models/post.ts
+++ b/backend/app/models/post.ts
@@ -26,6 +26,11 @@ export default class Post extends BaseModel {
   @column()
   declare published: boolean
 
+  // Compteur de vues brut (cf. migration). Incrémenté pour chaque lecteur, sans
+  // donnée personnelle ; l'attribution détaillée passe par l'analytics (page_views).
+  @column()
+  declare viewCount: number
+
   @column.dateTime()
   declare publishedAt: DateTime | null
 

--- a/backend/app/models/post_feedback.ts
+++ b/backend/app/models/post_feedback.ts
@@ -1,0 +1,34 @@
+import { DateTime } from 'luxon'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import Post from '#models/post'
+import User from '#models/user'
+
+export default class PostFeedback extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare postId: number
+
+  @column()
+  declare userId: number | null
+
+  @column()
+  declare visitorId: string
+
+  @column()
+  declare helpful: boolean
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+
+  @belongsTo(() => Post)
+  declare post: BelongsTo<typeof Post>
+
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User>
+}

--- a/backend/app/validators/post.ts
+++ b/backend/app/validators/post.ts
@@ -35,3 +35,11 @@ export const ResolvePlaceholdersValidator = vine.compile(
       .maxLength(50),
   })
 )
+
+export const SubmitFeedbackValidator = vine.compile(
+  vine.object({
+    helpful: vine.boolean(),
+    // UUID visiteur anonyme (clé de déduplication du vote).
+    visitorId: vine.string().minLength(8).maxLength(64),
+  })
+)

--- a/backend/database/migrations/1782358290000_add_view_count_to_posts_table.ts
+++ b/backend/database/migrations/1782358290000_add_view_count_to_posts_table.ts
@@ -1,0 +1,19 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'posts'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      // Compteur de vues brut, incrémenté pour chaque lecteur (connecté ou non,
+      // consentement ou non) : il ne stocke aucune donnée personnelle.
+      table.integer('view_count').unsigned().notNullable().defaultTo(0)
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('view_count')
+    })
+  }
+}

--- a/backend/database/migrations/1782358290001_create_post_feedbacks_table.ts
+++ b/backend/database/migrations/1782358290001_create_post_feedbacks_table.ts
@@ -1,0 +1,41 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'post_feedbacks'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table
+        .integer('post_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('posts')
+        .onDelete('CASCADE')
+      // Compte connecté au moment du vote (null si anonyme), pour permettre à
+      // l'admin de savoir qui a donné son avis.
+      table
+        .integer('user_id')
+        .unsigned()
+        .nullable()
+        .references('id')
+        .inTable('users')
+        .onDelete('SET NULL')
+      // UUID visiteur anonyme (même identifiant que l'analytics, stocké côté
+      // client). Sert de clé de déduplication : un vote par appareil et par post.
+      table.string('visitor_id').notNullable()
+      table.boolean('helpful').notNullable()
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+
+      table.unique(['post_id', 'visitor_id'])
+      table.index(['post_id'], 'post_feedbacks_post_id_index')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -158,6 +158,14 @@ router
       .post('posts/placeholders/resolve', '#controllers/posts_controller.resolvePlaceholders')
       .use(throttleLight('posts.placeholders.resolve', 60))
 
+    // Blog - Vues & feedback (public, consent-exempt pour le compteur)
+    router
+      .post('posts/:slug/view', '#controllers/posts_controller.recordView')
+      .use([throttleLight('posts.view', 120), NO_STORE])
+    router
+      .post('posts/:slug/feedback', '#controllers/posts_controller.submitFeedback')
+      .use([throttleLight('posts.feedback', 30), NO_STORE])
+
     // Publicités - Diffusion publique
     router
       .get('advertisements', '#controllers/advertisements_controller.index')
@@ -205,6 +213,9 @@ router
         router
           .post('posts/:id/unpublish', '#controllers/posts_controller.unpublish')
           .use(throttleLight('admin.posts.unpublish', 20))
+        router
+          .get('posts/:id/stats', '#controllers/posts_controller.adminStats')
+          .use([throttleLight('admin.posts.stats', 30), NO_STORE])
 
         // Placeholders preview (writers and admins)
         router

--- a/frontend/src/app/(pages)/admin/posts/[id]/stats/page.tsx
+++ b/frontend/src/app/(pages)/admin/posts/[id]/stats/page.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { AdminBackLink } from "@/components/admin/admin-back-link";
+import { AdminLoadingState, AdminMessageState } from "@/components/admin/admin-states";
+import { AvatarTile } from "@/components/ui/avatar-tile";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAuth } from "@/contexts/auth";
+import { getAdminPostStats } from "@/http/post";
+import { PostStats } from "@/types/post";
+import { ThumbsDown, ThumbsUp } from "lucide-react";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+const formatNumber = (value: number) => new Intl.NumberFormat("en-US").format(value);
+const formatDate = (value: string) =>
+  new Date(value).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+
+const StatCard = ({ label, value, hint }: { label: string; value: string; hint?: string }) => (
+  <div className="rounded-lg border border-border bg-card p-5 text-card-foreground shadow-xs">
+    <p className="text-xs uppercase tracking-wider text-muted-foreground">{label}</p>
+    <p className="mt-1 text-2xl font-bold tracking-tight text-foreground">{value}</p>
+    {hint && <p className="mt-1 text-xs text-muted-foreground">{hint}</p>}
+  </div>
+);
+
+const AdminPostStatsPage = () => {
+  const { user, getToken } = useAuth();
+  const token = getToken();
+  const params = useParams();
+  const postId = Number(params.id);
+
+  const [stats, setStats] = useState<PostStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token || !Number.isFinite(postId)) return;
+
+    const fetchStats = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        setStats(await getAdminPostStats(postId, token));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load statistics.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchStats();
+  }, [token, postId]);
+
+  if (!user) {
+    return <AdminLoadingState label="Loading…" />;
+  }
+
+  if (user.role !== "admin" && user.role !== "writer") {
+    return (
+      <AdminMessageState
+        tone="destructive"
+        title="Access denied"
+        description="You must be a writer or administrator to access this page."
+      />
+    );
+  }
+
+  const feedbackTotal = stats ? stats.feedback.helpful + stats.feedback.notHelpful : 0;
+  const helpfulRate =
+    feedbackTotal > 0 ? Math.round((stats!.feedback.helpful / feedbackTotal) * 100) : null;
+
+  return (
+    <div className="min-h-screen">
+      <div className="container mx-auto max-w-5xl animate-in fade-in px-4 py-8 duration-300">
+        <AdminBackLink href="/admin/posts" label="Back to articles" />
+
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            Statistics{stats ? ` — ${stats.post.title}` : ""}
+          </h1>
+          <p className="text-muted-foreground">Views, reach and reader feedback for this article.</p>
+        </div>
+
+        {error ? (
+          <AdminMessageState
+            tone="destructive"
+            title="Could not load statistics"
+            description={error}
+          />
+        ) : loading ? (
+          <div className="space-y-4">
+            <Skeleton className="h-28 w-full rounded-xl" />
+            <Skeleton className="h-28 w-full rounded-xl" />
+            <Skeleton className="h-48 w-full rounded-xl" />
+          </div>
+        ) : !stats ? (
+          <AdminMessageState
+            tone="destructive"
+            title="Not found"
+            description="This article does not exist."
+          />
+        ) : (
+          <>
+            {/* Views */}
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+              Views
+            </h2>
+            <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <StatCard
+                label="Total views"
+                value={formatNumber(stats.views.total)}
+                hint="Everyone, consent or not"
+              />
+              <StatCard
+                label="Consented views"
+                value={formatNumber(stats.views.consented)}
+                hint="Tracked via analytics"
+              />
+              <StatCard
+                label="Logged-in views"
+                value={formatNumber(stats.views.loggedIn)}
+                hint="Attributed to an account"
+              />
+              <StatCard
+                label="Unique visitors"
+                value={formatNumber(stats.views.uniqueVisitors)}
+                hint="Distinct consented devices"
+              />
+            </div>
+
+            {/* Feedback */}
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+              Feedback
+            </h2>
+            <div className="mb-8 grid gap-4 sm:grid-cols-3">
+              <div className="rounded-lg border border-border bg-card p-5 text-card-foreground shadow-xs">
+                <p className="inline-flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
+                  <ThumbsUp className="h-3.5 w-3.5 text-success" />
+                  Helpful
+                </p>
+                <p className="mt-1 text-2xl font-bold tracking-tight text-foreground">
+                  {formatNumber(stats.feedback.helpful)}
+                </p>
+              </div>
+              <div className="rounded-lg border border-border bg-card p-5 text-card-foreground shadow-xs">
+                <p className="inline-flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
+                  <ThumbsDown className="h-3.5 w-3.5 text-destructive" />
+                  Not helpful
+                </p>
+                <p className="mt-1 text-2xl font-bold tracking-tight text-foreground">
+                  {formatNumber(stats.feedback.notHelpful)}
+                </p>
+              </div>
+              <StatCard
+                label="Helpful rate"
+                value={helpfulRate === null ? "—" : `${helpfulRate} %`}
+                hint={`${formatNumber(feedbackTotal)} ${feedbackTotal === 1 ? "vote" : "votes"}`}
+              />
+            </div>
+
+            {/* Recent logged-in viewers */}
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+              Recent logged-in viewers
+            </h2>
+            <div className="overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-xs">
+              {stats.recentViewers.length === 0 ? (
+                <div className="px-6 py-12 text-center text-sm text-muted-foreground">
+                  No logged-in readers yet. Anonymous and non-consenting views still count toward
+                  the totals above.
+                </div>
+              ) : (
+                <ul className="divide-y divide-border">
+                  {stats.recentViewers.map((viewer) => (
+                    <li key={viewer.id} className="flex items-center gap-3 p-4">
+                      <AvatarTile
+                        name={viewer.username}
+                        src={viewer.avatarUrl}
+                        className="h-9 w-9 rounded-md text-sm"
+                      />
+                      <span className="min-w-0 flex-1 truncate font-medium text-foreground">
+                        {viewer.username}
+                      </span>
+                      <span className="shrink-0 text-xs text-muted-foreground">
+                        {formatDate(viewer.lastViewedAt)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AdminPostStatsPage;

--- a/frontend/src/app/(pages)/admin/posts/page.tsx
+++ b/frontend/src/app/(pages)/admin/posts/page.tsx
@@ -20,7 +20,8 @@ import {
 import { useAuth } from "@/contexts/auth";
 import { deletePost, getAdminPosts, publishPost, unpublishPost } from "@/http/post";
 import { Post } from "@/types/post";
-import { Eye, Pencil, Plus, Search, Trash2 } from "lucide-react";
+import { PostViews } from "@/components/blog/post-meta";
+import { BarChart3, Eye, Pencil, Plus, Search, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
@@ -225,6 +226,10 @@ const AdminPostsPage = () => {
                         ·
                       </span>
                       <span className="shrink-0">{estimateReadTime(post.content)}</span>
+                      <span aria-hidden className="opacity-50">
+                        ·
+                      </span>
+                      <PostViews count={post.viewCount} className="shrink-0" />
                     </div>
                   </div>
                 </div>
@@ -245,6 +250,17 @@ const AdminPostsPage = () => {
                       title="View"
                     >
                       <Eye className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      asChild
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-muted-foreground hover:text-accent"
+                      title="Statistics"
+                    >
+                      <Link href={`/admin/posts/${post.id}/stats`}>
+                        <BarChart3 className="h-4 w-4" />
+                      </Link>
                     </Button>
                     <Button
                       asChild

--- a/frontend/src/app/(pages)/blog/[slug]/page.tsx
+++ b/frontend/src/app/(pages)/blog/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { PostAuthor, formatPostDate } from "@/components/blog/post-meta";
+import { PostAuthor, PostViews, formatPostDate } from "@/components/blog/post-meta";
 import { Badge } from "@/components/ui/badge";
 import { getPostBySlug } from "@/http/post";
 import { ChevronLeft } from "lucide-react";
@@ -9,6 +9,8 @@ import { notFound } from "next/navigation";
 import { cache } from "react";
 import { BlogPostStructuredData } from "@/components/seo/structured-data";
 import ArticleBody from "@/components/blog/article-body";
+import ArticleFeedback from "@/components/blog/article-feedback";
+import ArticleViewTracker from "@/components/blog/article-view-tracker";
 import { resolveAssetUrl } from "@/lib/domain";
 import { getAlternateLanguages, getDomainConfig } from "@/lib/domain-server";
 import { renderMarkdown } from "@/lib/markdown";
@@ -81,6 +83,9 @@ export default async function BlogPostPage({ params }: Readonly<Props>) {
 
     return (
       <div className="min-h-screen animate-in fade-in slide-in-from-bottom-4 duration-500 pb-20">
+        {/* Records a best-effort, consent-exempt view once per session. */}
+        <ArticleViewTracker slug={post.slug} />
+
         {/* Structured Data for SEO */}
         <BlogPostStructuredData
           post={{
@@ -126,6 +131,8 @@ export default async function BlogPostPage({ params }: Readonly<Props>) {
               <Badge variant="accent" className="uppercase tracking-wide">
                 News
               </Badge>
+              <span className="text-border">•</span>
+              <PostViews count={post.viewCount} />
             </div>
           </header>
 
@@ -167,6 +174,9 @@ export default async function BlogPostPage({ params }: Readonly<Props>) {
                 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-inherit [&_pre_code]:text-sm
               "
               />
+
+              {/* "Was this article helpful?" feedback */}
+              <ArticleFeedback slug={post.slug} />
 
               {/* Footer Divider */}
               <div className="mt-16 flex items-center justify-between border-t border-border pt-8">

--- a/frontend/src/components/blog/article-feedback.tsx
+++ b/frontend/src/components/blog/article-feedback.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useAuth } from "@/contexts/auth";
+import { submitPostFeedback } from "@/http/post";
+import { cn } from "@/lib/utils";
+import { getVisitorId } from "@/lib/visitor-id";
+import { ThumbsDown, ThumbsUp } from "lucide-react";
+import { useEffect, useState } from "react";
+
+type Vote = "yes" | "no";
+
+const buttonClass =
+  "inline-flex items-center gap-2 rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-accent/50 hover:bg-secondary disabled:opacity-50";
+
+/**
+ * "Was this article helpful?" widget. The reader votes once; the choice is
+ * remembered locally so returning readers see a thank-you instead of the prompt.
+ * Aggregate results are admin-only (surfaced on the post stats page).
+ */
+export default function ArticleFeedback({ slug }: { slug: string }) {
+  const { getToken } = useAuth();
+  const [vote, setVote] = useState<Vote | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(false);
+
+  const storageKey = `mcstats_post_feedback_${slug}`;
+
+  // Restore a prior vote so returning readers see their choice, not the prompt.
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(storageKey);
+      if (stored === "yes" || stored === "no") setVote(stored);
+    } catch {
+      // localStorage unavailable: just show the prompt.
+    }
+  }, [storageKey]);
+
+  const handleVote = async (choice: Vote) => {
+    if (submitting || vote) return;
+
+    const visitorId = getVisitorId();
+    if (!visitorId) return;
+
+    setSubmitting(true);
+    setError(false);
+    try {
+      await submitPostFeedback(slug, choice === "yes", visitorId, getToken());
+      setVote(choice);
+      try {
+        localStorage.setItem(storageKey, choice);
+      } catch {
+        // Non-fatal: the vote is recorded server-side regardless.
+      }
+    } catch {
+      setError(true);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mt-16 rounded-xl border border-border bg-card p-6 text-center text-card-foreground">
+      {vote ? (
+        <p className="text-sm font-medium text-foreground">
+          Thanks for your feedback! {vote === "yes" ? "🎉" : "🙏"}
+        </p>
+      ) : (
+        <>
+          <p className="mb-4 text-sm font-semibold text-foreground">Was this article helpful?</p>
+          <div className="flex items-center justify-center gap-3">
+            <button
+              type="button"
+              onClick={() => handleVote("yes")}
+              disabled={submitting}
+              className={cn(buttonClass, "hover:text-success")}
+            >
+              <ThumbsUp className="h-4 w-4" />
+              Yes
+            </button>
+            <button
+              type="button"
+              onClick={() => handleVote("no")}
+              disabled={submitting}
+              className={cn(buttonClass, "hover:text-destructive")}
+            >
+              <ThumbsDown className="h-4 w-4" />
+              No
+            </button>
+          </div>
+          {error && (
+            <p className="mt-3 text-xs text-destructive">Something went wrong. Please try again.</p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/blog/article-view-tracker.tsx
+++ b/frontend/src/components/blog/article-view-tracker.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { recordPostView } from "@/http/post";
+import { useEffect } from "react";
+
+/**
+ * Records a single, best-effort view per browser session per article. The count
+ * itself is consent-exempt (no identifier is stored server-side); detailed
+ * attribution is handled separately by the analytics page-view pipeline.
+ */
+export default function ArticleViewTracker({ slug }: { slug: string }) {
+  useEffect(() => {
+    if (!slug) return;
+
+    const key = `mcstats_post_viewed_${slug}`;
+    try {
+      if (sessionStorage.getItem(key)) return;
+      sessionStorage.setItem(key, "1");
+    } catch {
+      // sessionStorage unavailable (private mode): fall through and still count.
+    }
+
+    recordPostView(slug);
+  }, [slug]);
+
+  return null;
+}

--- a/frontend/src/components/blog/post-card.tsx
+++ b/frontend/src/components/blog/post-card.tsx
@@ -1,4 +1,4 @@
-import { PostAuthor, PostEyebrow } from "@/components/blog/post-meta";
+import { PostAuthor, PostEyebrow, PostViews } from "@/components/blog/post-meta";
 import { resolveAssetUrl } from "@/lib/domain";
 import { Post } from "@/types/post";
 import Image from "next/image";
@@ -35,7 +35,10 @@ const PostCard = ({ post, featured = false }: PostCardProps) => {
         </div>
 
         <div className="flex flex-col gap-4 p-6 md:p-8">
-          <PostEyebrow date={date} />
+          <div className="flex items-center justify-between gap-2">
+            <PostEyebrow date={date} />
+            <PostViews count={post.viewCount} />
+          </div>
           <h2 className="text-2xl font-bold leading-tight tracking-tight text-foreground transition-colors group-hover:text-accent md:text-3xl">
             {post.title}
           </h2>
@@ -75,7 +78,10 @@ const PostCard = ({ post, featured = false }: PostCardProps) => {
       </div>
 
       <div className="flex flex-1 flex-col gap-3 p-5">
-        <PostEyebrow date={date} />
+        <div className="flex items-center justify-between gap-2">
+          <PostEyebrow date={date} />
+          <PostViews count={post.viewCount} />
+        </div>
         <h3 className="line-clamp-2 text-lg font-bold leading-snug tracking-tight text-foreground transition-colors group-hover:text-accent">
           {post.title}
         </h3>

--- a/frontend/src/components/blog/post-meta.tsx
+++ b/frontend/src/components/blog/post-meta.tsx
@@ -1,6 +1,8 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { letterTileGradient } from "@/components/ui/letter-tile";
 import { resolveAssetUrl } from "@/lib/domain";
+import { cn } from "@/lib/utils";
+import { Eye } from "lucide-react";
 
 export const formatPostDate = (value: Date | string) =>
   new Date(value).toLocaleDateString("en-US", {
@@ -9,10 +11,23 @@ export const formatPostDate = (value: Date | string) =>
     year: "numeric",
   });
 
+const formatViews = (value: number) => new Intl.NumberFormat("en-US").format(value);
+
 export const PostEyebrow = ({ date }: { date: Date | string }) => (
   <div className="text-[11px] font-bold uppercase tracking-[0.12em] text-accent">
     News · {formatPostDate(date)}
   </div>
+);
+
+/** Compact "eye + count" view tally, shared by the article header and post cards. */
+export const PostViews = ({ count, className }: { count: number; className?: string }) => (
+  <span
+    className={cn("inline-flex items-center gap-1 text-xs text-muted-foreground", className)}
+    title={`${formatViews(count)} ${count === 1 ? "view" : "views"}`}
+  >
+    <Eye className="h-3.5 w-3.5" />
+    {formatViews(count)}
+  </span>
 );
 
 export const PostAuthor = ({

--- a/frontend/src/http/post.ts
+++ b/frontend/src/http/post.ts
@@ -1,5 +1,5 @@
 import { getBaseUrl } from '@/app/_cheatcode'
-import { CreatePostInput, Post, PostsListResponse, UpdatePostInput } from '@/types/post'
+import { CreatePostInput, Post, PostStats, PostsListResponse, UpdatePostInput } from '@/types/post'
 import { getErrorMessage } from './auth'
 
 // Public endpoints
@@ -53,6 +53,49 @@ export const getPostBySlug = async (slug: string) => {
   return response.json() as Promise<Post>
 }
 
+/**
+ * Records a view for the article. Consent-exempt and best-effort: it only bumps
+ * an aggregate counter (no identifier), so failures are swallowed and never
+ * surface to the reader. `keepalive` lets it complete even if the page unloads.
+ */
+export const recordPostView = async (slug: string) => {
+  try {
+    await fetch(`${getBaseUrl()}/posts/${slug}/view`, {
+      method: 'POST',
+      keepalive: true,
+    })
+  } catch {
+    // Best-effort: a missed view must never break the page.
+  }
+}
+
+/**
+ * Submits "was this article helpful?" feedback. Deduplicated server-side by the
+ * anonymous visitor id; passing a token additionally attributes it to the account.
+ */
+export const submitPostFeedback = async (
+  slug: string,
+  helpful: boolean,
+  visitorId: string,
+  token?: string | null
+) => {
+  const response = await fetch(`${getBaseUrl()}/posts/${slug}/feedback`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ helpful, visitorId }),
+  })
+
+  if (!response.ok) {
+    const errorMessage = await getErrorMessage(response)
+    throw new Error(errorMessage)
+  }
+
+  return true
+}
+
 // Admin endpoints
 
 export const getAdminPosts = async (
@@ -77,6 +120,22 @@ export const getAdminPosts = async (
   }
 
   return response.json() as Promise<PostsListResponse>
+}
+
+export const getAdminPostStats = async (postId: number, token: string) => {
+  const response = await fetch(`${getBaseUrl()}/admin/posts/${postId}/stats`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  })
+
+  if (!response.ok) {
+    const errorMessage = await getErrorMessage(response)
+    throw new Error(errorMessage)
+  }
+
+  return response.json() as Promise<PostStats>
 }
 
 export const createPost = async (data: CreatePostInput, token: string) => {

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -8,11 +8,44 @@ export interface Post {
   excerpt: string | null
   coverImage: string | null
   published: boolean
+  viewCount: number
   publishedAt: Date | null
   userId: number
   author: User
   createdAt: Date
   updatedAt: Date
+}
+
+/** A logged-in reader of an article, surfaced in the admin post-stats view. */
+export interface PostViewer {
+  id: number
+  username: string
+  avatarUrl: string | null
+  lastViewedAt: string
+}
+
+/** Engagement statistics for a single post (admin/writer only). */
+export interface PostStats {
+  post: {
+    id: number
+    title: string
+    slug: string
+    viewCount: number
+  }
+  views: {
+    /** Raw counter — every reader, consent or not. */
+    total: number
+    /** Consent-aware views recorded by the analytics page-view pipeline. */
+    consented: number
+    /** Subset of consented views attributed to a logged-in account. */
+    loggedIn: number
+    uniqueVisitors: number
+  }
+  feedback: {
+    helpful: number
+    notHelpful: number
+  }
+  recentViewers: PostViewer[]
 }
 
 export interface CreatePostInput {


### PR DESCRIPTION
## Résumé

Ajoute le **nombre de vues** des articles de blog et un sondage **« cet article vous a-t-il été utile ? »**, le tout relié au système d'analytiques existant et pensé pour respecter le consentement.

## Vues

- Nouvelle colonne `view_count` sur `posts`, incrémentée via un endpoint public **consent-exempt** `POST /posts/:slug/view`. Il ne stocke **aucun identifiant** (juste un compteur agrégé) — même base de confidentialité que le « hit » anonyme de l'analytics. Donc on compte **tout le monde**, connecté ou pas, consentement ou pas. ✅ « si pas de consentement, on compte juste une vue simple ».
- L'attribution détaillée (**qui a vu**) est lue depuis le **pipeline analytics existant** (`page_views`) via le chemin `/blog/:slug` de l'article — c'est le lien avec le système d'analytiques.
- Le compteur de vues s'affiche :
  - sur la **page article publique** (entête),
  - sur les **cartes de la liste du blog**,
  - dans le **dashboard admin** (colonne + page de stats).
- Côté front, un tracker enregistre **une vue par session et par article** (sessionStorage), pour ne pas gonfler au refresh.

## Feedback « utile ? »

- Nouvelle table `post_feedbacks` + modèle `PostFeedback`. Endpoint public `POST /posts/:slug/feedback` qui enregistre un vote 👍/👎, **dédupliqué par l'identifiant visiteur anonyme** (un vote par appareil, modifiable) et **attribué au compte** si connecté.
- Widget **« Was this article helpful? »** sous chaque article ; le choix est mémorisé localement (remerciement au retour). **Les résultats (oui/non) sont réservés aux admins.**

## Admin

- Nouvel endpoint `GET /admin/posts/:id/stats` (admin, ou writer pour ses propres articles) renvoyant : total de vues, répartition analytics (vues consenties / connectées / visiteurs uniques), tallies du feedback, et la **liste des derniers lecteurs connectés** (qui a vu).
- La liste `/admin/posts` gagne un compteur de vues et un bouton vers la **page de stats par article** (`/admin/posts/[id]/stats`).

## Confidentialité / consentement

- Compteur de vues brut : consent-exempt, zéro PII.
- Attribution « qui a vu » : uniquement via les `page_views` déjà soumis au consentement (existant).
- Feedback : action volontaire, dédup via l'UUID visiteur (déjà utilisé par l'analytics), `user_id` seulement si connecté.

## Vérifications

- **Backend** : `yarn typecheck` ✅ et `yarn lint` ✅ (deps installées avec `--ignore-engines` : le projet cible Node ≥ 24, l'environnement a Node 22 — sans impact sur le typecheck).
- **Frontend** : `tsc --noEmit` ✅ et ESLint ✅ sur les fichiers modifiés.
- 2 migrations à jouer (`view_count`, `post_feedbacks`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rzm1sTHHt7ofKMFVtV8AGh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rzm1sTHHt7ofKMFVtV8AGh)_