### PR TITLE
Détection de doublons : signal domaine racine + compte de joueurs

### DIFF
--- a/backend/app/models/server.ts
+++ b/backend/app/models/server.ts
@@ -8,6 +8,7 @@ import User from './user.js'
 import { LanguageCode } from '../constants/languages.js'
 import type { ServerType } from '../constants/server_type.js'
 import { normalizeWebsite } from '#utils/website'
+import { deriveServerWebsite } from '#utils/server_website'
 import db from '@adonisjs/lucid/services/db'
 
 export default class Server extends BaseModel {
@@ -51,6 +52,12 @@ export default class Server extends BaseModel {
 
   @column({ columnName: 'motd_hash' })
   declare motdHash: string | null
+
+  // Domaine racine (eTLD+1) dérivé de l'adresse : `mc.hypixel.net` -> `hypixel.net`.
+  // Indexé, peuplé par `deriveHostDomainColumn` ci-dessous. Sert de signal fort
+  // à la détection de doublon (cf. DuplicateDetectionService).
+  @column({ columnName: 'host_domain' })
+  declare hostDomain: string | null
 
   @column({ columnName: 'user_id' })
   declare userId: number
@@ -110,6 +117,16 @@ export default class Server extends BaseModel {
   static normalizeWebsiteColumn(server: Server) {
     if (server.website) {
       server.website = normalizeWebsite(server.website)
+    }
+  }
+
+  // Keep `host_domain` in sync with the address on every write path (create,
+  // owner edit, scheduler ping). Derived from the address — the same eTLD+1
+  // extraction used for the website. Existing rows self-heal on their next save.
+  @beforeSave()
+  static deriveHostDomainColumn(server: Server) {
+    if (server.$dirty.address !== undefined || server.hostDomain === null) {
+      server.hostDomain = deriveServerWebsite(server.address)
     }
   }
 

--- a/backend/app/services/duplicate_detection_service.ts
+++ b/backend/app/services/duplicate_detection_service.ts
@@ -2,23 +2,39 @@ import { createHash } from 'node:crypto'
 import dns from 'node:dns'
 import net from 'node:net'
 import Server from '#models/server'
+import { deriveServerWebsite } from '#utils/server_website'
 
 /**
  * Poids de chaque signal dans le score de similarité.
  * À calibrer empiriquement. Logique de conception :
- *  - favicon : signal le plus fort (icône custom quasi unique), mais pas
- *    suffisant seul (deux serveurs peuvent réutiliser une icône téléchargée).
+ *  - domain : domaine racine (eTLD+1) de l'adresse. `mc.hypixel.net` et
+ *    `hypixel.net` le partagent → signal fort. Neutralisé si beaucoup de
+ *    serveurs partagent le domaine (hébergeurs à sous-domaines type minehut.gg).
+ *  - favicon : icône custom quasi unique, mais pas suffisante seule (deux
+ *    serveurs peuvent réutiliser une icône téléchargée / l'icône par défaut d'un
+ *    hébergeur).
  *  - endpoint : `ip:port` réel ; pour un serveur hébergé en direct, identique =
  *    même serveur. Neutralisé si l'endpoint est partagé (proxy anti-DDoS).
  *  - motd : MOTD normalisé (codes couleur + chiffres retirés). Sujet aux
  *    collisions ("welcome to..."), donc volontairement insuffisant seul.
+ *  - players : nombre de joueurs connectés. Deux serveurs au même instant avec
+ *    un compte à ±10 % sont très probablement le même backend. Bruité à bas
+ *    volume (tout le monde a ~10 joueurs), donc plancher + jamais décisif seul.
  *  - version : très commune (tout le monde sur la dernière). Simple bonus —
  *    son poids est choisi pour ne JAMAIS faire basculer une paire à lui seul.
+ *
+ * Calibrage : aucun signal ne franchit le seuil seul. Les combinaisons qui le
+ * franchissent (≥ 75) sont celles où deux signaux indépendants concordent :
+ * domain+favicon=90, domain+endpoint=85, domain+motd=75, favicon+endpoint=85,
+ * favicon+motd=75, domain+players+version=75… Le cas hypixel.net/mc.hypixel.net
+ * (endpoint proxyfié, MOTD rotatif) marque domain+favicon+players ≈ 112.
  */
 const SIGNAL_WEIGHTS = {
-  favicon: 50,
+  domain: 45,
+  favicon: 45,
   endpoint: 40,
   motd: 30,
+  players: 22,
   version: 8,
 } as const
 
@@ -32,10 +48,30 @@ const DUPLICATE_THRESHOLD = 75
  */
 const SHARED_ENDPOINT_LIMIT = 2
 
+/**
+ * À partir de ce nombre de serveurs partageant le même domaine racine, on le
+ * considère comme un hébergeur à sous-domaines (minehut.gg, *.aternos.me…) : il
+ * ne discrimine plus rien et son poids tombe à 0. Volontairement généreux — un
+ * réseau légitime peut lister quelques sous-domaines (mc., play., eu.…).
+ */
+const SHARED_DOMAIN_LIMIT = 5
+
+/**
+ * Plancher en deçà duquel le signal "joueurs" est ignoré : à faible volume, des
+ * dizaines de serveurs sans rapport stationnent à quelques joueurs, la
+ * proximité ne prouve donc rien.
+ */
+const PLAYER_SIMILARITY_FLOOR = 50
+
+/** Écart relatif maximal entre deux comptes de joueurs pour les juger proches. */
+const PLAYER_SIMILARITY_TOLERANCE = 0.1
+
 export interface ServerFingerprint {
+  domain: string | null
   faviconHash: string | null
   resolvedEndpoint: string | null
   motdHash: string | null
+  playerCount: number | null
   version: string | null
 }
 
@@ -50,6 +86,7 @@ export interface PingFingerprintInput {
   favicon?: string | null
   description?: unknown
   version?: { name?: string } | null
+  players?: { online?: number } | null
 }
 
 /**
@@ -144,6 +181,24 @@ export default class DuplicateDetectionService {
     }
   }
 
+  /**
+   * Domaine racine (eTLD+1) de l'adresse — `mc.hypixel.net` -> `hypixel.net`.
+   * Réutilise l'extraction de l'adresse->site web. null pour une IP/localhost.
+   */
+  static hostDomain(address: string): string | null {
+    return deriveServerWebsite(address)
+  }
+
+  /**
+   * Deux comptes de joueurs sont-ils suffisamment proches pour suggérer le même
+   * serveur ? Faux si l'un des deux est inconnu ou sous le plancher de bruit.
+   */
+  static playerCountsClose(a: number | null, b: number | null): boolean {
+    if (a === null || b === null) return false
+    if (a < PLAYER_SIMILARITY_FLOOR || b < PLAYER_SIMILARITY_FLOOR) return false
+    return Math.abs(a - b) / Math.max(a, b) <= PLAYER_SIMILARITY_TOLERANCE
+  }
+
   /** Calcule les empreintes d'un serveur à partir de son adresse + sa réponse de ping. */
   static async fingerprint(
     address: string,
@@ -151,9 +206,11 @@ export default class DuplicateDetectionService {
     ping: PingFingerprintInput
   ): Promise<ServerFingerprint> {
     return {
+      domain: this.hostDomain(address),
       faviconHash: this.hashFavicon(ping.favicon),
       resolvedEndpoint: await this.resolveEndpoint(address, port),
       motdHash: this.hashMotd(ping.description),
+      playerCount: ping.players?.online ?? null,
       version: ping.version?.name ?? null,
     }
   }
@@ -168,28 +225,43 @@ export default class DuplicateDetectionService {
   static async findDuplicate(
     fingerprint: ServerFingerprint & { excludeId?: number }
   ): Promise<DuplicateMatch | null> {
-    const { faviconHash, resolvedEndpoint, motdHash, version, excludeId } = fingerprint
+    const { domain, faviconHash, resolvedEndpoint, motdHash, playerCount, version, excludeId } =
+      fingerprint
 
-    // Sans aucun signal exploitable, rien à comparer.
-    if (!faviconHash && !resolvedEndpoint && !motdHash) return null
+    // Sans aucun signal indexable exploitable, rien à comparer. (`players` et
+    // `version` ne servent qu'à corroborer un candidat déjà sélectionné.)
+    if (!domain && !faviconHash && !resolvedEndpoint && !motdHash) return null
 
-    // Endpoint partagé par plusieurs serveurs => proxy / mutualisé => non fiable.
-    let endpointTrusted = false
-    if (resolvedEndpoint) {
-      const countQuery = Server.query().where('resolved_endpoint', resolvedEndpoint)
-      if (excludeId) countQuery.whereNot('id', excludeId)
-      const rows = await countQuery.count('* as total')
-      endpointTrusted = Number(rows[0].$extras.total) < SHARED_ENDPOINT_LIMIT
+    const countSharing = async (column: string, value: string): Promise<number> => {
+      const query = Server.query().where(column, value)
+      if (excludeId) query.whereNot('id', excludeId)
+      const rows = await query.count('* as total')
+      return Number(rows[0].$extras.total)
     }
 
-    // Aucun signal *discriminant* utilisable (la version seule est trop commune
+    // Endpoint partagé par plusieurs serveurs => proxy / mutualisé => non fiable.
+    const endpointTrusted = resolvedEndpoint
+      ? (await countSharing('resolved_endpoint', resolvedEndpoint)) < SHARED_ENDPOINT_LIMIT
+      : false
+
+    // Domaine partagé par trop de serveurs => hébergeur à sous-domaines => non fiable.
+    const domainTrusted = domain
+      ? (await countSharing('host_domain', domain)) < SHARED_DOMAIN_LIMIT
+      : false
+
+    // Aucun signal *discriminant* utilisable (players/version sont trop communs
     // pour servir de critère de sélection) → inutile de scanner.
-    const hasDiscriminating = !!faviconHash || (!!resolvedEndpoint && endpointTrusted) || !!motdHash
+    const hasDiscriminating =
+      (!!domain && domainTrusted) ||
+      !!faviconHash ||
+      (!!resolvedEndpoint && endpointTrusted) ||
+      !!motdHash
     if (!hasDiscriminating) return null
 
     // Candidats : tout serveur partageant au moins un signal discriminant.
     const candidates = await Server.query()
       .where((builder) => {
+        if (domain && domainTrusted) builder.orWhere('host_domain', domain)
         if (faviconHash) builder.orWhere('favicon_hash', faviconHash)
         if (resolvedEndpoint && endpointTrusted) {
           builder.orWhere('resolved_endpoint', resolvedEndpoint)
@@ -203,6 +275,10 @@ export default class DuplicateDetectionService {
       let score = 0
       const signals: string[] = []
 
+      if (domainTrusted && domain && candidate.hostDomain === domain) {
+        score += SIGNAL_WEIGHTS.domain
+        signals.push('domain')
+      }
       if (faviconHash && candidate.faviconHash === faviconHash) {
         score += SIGNAL_WEIGHTS.favicon
         signals.push('favicon')
@@ -215,8 +291,13 @@ export default class DuplicateDetectionService {
         score += SIGNAL_WEIGHTS.motd
         signals.push('motd')
       }
-      // La version n'est qu'un bonus : seule, elle ne place jamais un candidat
-      // dans la liste ci-dessus, donc elle ne peut pas déclencher un faux positif.
+      // players / version ne sont que des bonus : seuls, ils ne placent jamais un
+      // candidat dans la liste ci-dessus, donc ne peuvent pas déclencher de faux
+      // positif. On compare le compte live au dernier compte connu du candidat.
+      if (this.playerCountsClose(playerCount, candidate.lastPlayerCount)) {
+        score += SIGNAL_WEIGHTS.players
+        signals.push('players')
+      }
       if (version && candidate.version === version) {
         score += SIGNAL_WEIGHTS.version
         signals.push('version')

--- a/backend/database/migrations/1782358300000_add_host_domain_to_servers.ts
+++ b/backend/database/migrations/1782358300000_add_host_domain_to_servers.ts
@@ -1,0 +1,33 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+/**
+ * Signal "domaine racine" pour la détection de doublons.
+ *
+ * Le signal manquant le plus évident : `mc.hypixel.net` et `hypixel.net`
+ * partagent le même domaine enregistrable (eTLD+1 → `hypixel.net`). On stocke
+ * ce domaine, dérivé de l'adresse, dans une colonne indexée pour pouvoir
+ * retrouver d'un coup tous les serveurs d'un même domaine.
+ *
+ * La colonne est nullable et peuplée par le hook `@beforeSave` du modèle Server
+ * (cf. `normalizeWebsiteColumn`/`deriveHostDomainColumn`). Aucun backfill ici :
+ * les lignes existantes se remplissent d'elles-mêmes à leur prochain `save()`
+ * (le scheduler re-pingue chaque serveur en continu) — même logique d'auto-
+ * guérison que les autres empreintes (favicon_hash, motd_hash…).
+ */
+export default class extends BaseSchema {
+  protected tableName = 'servers'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.string('host_domain').nullable()
+      table.index(['host_domain'], 'servers_host_domain_idx')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropIndex(['host_domain'], 'servers_host_domain_idx')
+      table.dropColumn('host_domain')
+    })
+  }
+}

--- a/backend/tests/unit/duplicate_detection_service.spec.ts
+++ b/backend/tests/unit/duplicate_detection_service.spec.ts
@@ -1,0 +1,65 @@
+import { test } from '@japa/runner'
+import DuplicateDetectionService from '#services/duplicate_detection_service'
+
+test.group('DuplicateDetectionService.hostDomain', () => {
+  test('réduit un sous-domaine au domaine racine (eTLD+1)', ({ assert }) => {
+    assert.equal(DuplicateDetectionService.hostDomain('mc.hypixel.net'), 'hypixel.net')
+    assert.equal(DuplicateDetectionService.hostDomain('hypixel.net'), 'hypixel.net')
+    assert.equal(DuplicateDetectionService.hostDomain('play.hypixel.net'), 'hypixel.net')
+    assert.equal(DuplicateDetectionService.hostDomain('alpha.hypixel.net'), 'hypixel.net')
+  })
+
+  test('gère les suffixes publics à deux niveaux', ({ assert }) => {
+    assert.equal(DuplicateDetectionService.hostDomain('play.example.co.uk'), 'example.co.uk')
+  })
+
+  test('retourne null pour une IP ou un hôte sans TLD', ({ assert }) => {
+    assert.isNull(DuplicateDetectionService.hostDomain('192.168.1.1'))
+    assert.isNull(DuplicateDetectionService.hostDomain('localhost'))
+  })
+})
+
+test.group('DuplicateDetectionService.playerCountsClose', () => {
+  test('vrai quand les comptes sont à moins de 10 %', ({ assert }) => {
+    assert.isTrue(DuplicateDetectionService.playerCountsClose(40000, 41000))
+    assert.isTrue(DuplicateDetectionService.playerCountsClose(100, 100))
+  })
+
+  test('faux au-delà de 10 % d’écart', ({ assert }) => {
+    assert.isFalse(DuplicateDetectionService.playerCountsClose(100, 120))
+  })
+
+  test('faux sous le plancher de bruit (petits serveurs)', ({ assert }) => {
+    // Deux serveurs sans rapport peuvent tous deux stationner à ~10 joueurs.
+    assert.isFalse(DuplicateDetectionService.playerCountsClose(10, 10))
+  })
+
+  test('faux quand un compte est inconnu', ({ assert }) => {
+    assert.isFalse(DuplicateDetectionService.playerCountsClose(null, 5000))
+    assert.isFalse(DuplicateDetectionService.playerCountsClose(5000, null))
+  })
+})
+
+test.group('DuplicateDetectionService.hashMotd', () => {
+  test('le même squelette de MOTD donne le même hash malgré chiffres/couleurs', ({ assert }) => {
+    const a = DuplicateDetectionService.hashMotd('§aWelcome! §7Online: §e1234')
+    const b = DuplicateDetectionService.hashMotd('§aWelcome! §7Online: §e5678')
+    assert.isNotNull(a)
+    assert.equal(a, b)
+  })
+
+  test('null pour un MOTD trop court pour discriminer', ({ assert }) => {
+    assert.isNull(DuplicateDetectionService.hashMotd('hi'))
+  })
+})
+
+test.group('DuplicateDetectionService.hashFavicon', () => {
+  test('hash stable pour le même favicon, null sans favicon', ({ assert }) => {
+    const favicon = 'data:image/png;base64,AAAABBBBCCCC'
+    assert.equal(
+      DuplicateDetectionService.hashFavicon(favicon),
+      DuplicateDetectionService.hashFavicon(favicon)
+    )
+    assert.isNull(DuplicateDetectionService.hashFavicon(null))
+  })
+})


### PR DESCRIPTION
## Problème

Quelqu'un a pu ajouter `hypixel.net` alors que `mc.hypixel.net` (id 2) existait déjà.

Le moteur de détection (`DuplicateDetectionService`) ne comparait que **favicon / endpoint résolu / MOTD / version**. Pour un réseau comme Hypixel, ces signaux s'effondrent :
- **endpoint** : neutralisé (proxy anti-DDoS partagé) ;
- **MOTD** : ligne promo rotative → hash différent à chaque ping ;
- il ne reste que `favicon (50) + version (8) = 58`, **sous le seuil de 75** → non détecté.

Le signal le plus évident — le **domaine racine partagé** (`hypixel.net`) — n'était pas utilisé du tout.

## Refonte du moteur

**Nouveau signal « domaine racine » (eTLD+1)** — `mc.hypixel.net` et `hypixel.net` le partagent. Stocké dans une colonne indexée `host_domain`, dérivée de l'adresse via un hook `@beforeSave` (même pattern d'auto-guérison que les autres empreintes → **aucun backfill**). Neutralisé au-delà de 5 serveurs partageant le domaine (hébergeurs à sous-domaines type minehut.gg).

**Nouveau signal « joueurs connectés »** — deux serveurs à **±10 %** au même instant sont très probablement le même backend. Plancher à 50 joueurs pour éviter le bruit des petits serveurs ; jamais décisif seul.

**Poids rééquilibrés** (`domain 45, favicon 45, endpoint 40, motd 30, players 22, version 8`, seuil 75) : aucun signal ne franchit le seuil seul ; les combinaisons qui le franchissent exigent deux signaux indépendants concordants. Le cas hypixel.net marque désormais `domain + favicon + players ≈ 112` → bloqué nettement.

## Détails techniques

- `host_domain` se remplit sur **tous les chemins d'écriture** (création, édition propriétaire, ping du scheduler) ; les lignes existantes se réparent d'elles-mêmes au prochain ping (~10 min pour les serveurs actifs). Pas de migration de données.
- La migration ajoute uniquement la colonne nullable + son index.
- Aucune modification de données de prod incluse.

## Tests

Tests unitaires sur les helpers déterministes (extraction du domaine, proximité de joueurs, hash MOTD/favicon). `typecheck`, `lint` et `test unit` (10/10) passent.

## ⚠️ Nettoyage prod à faire à la main

Le doublon déjà en base n'est pas touché par ce PR :
- **id 615** (`test` = `hypixel.net`) → à supprimer (doublon de id 2).
- **id 280** (`Alpha Hypixel` = `alpha.hypixel.net`) → à arbitrer : même domaine, réseau de test distinct. Serait désormais détecté comme doublon à la création.

## Limites connues (hors scope)

- La détection ne tourne qu'à la **création** — l'`update()` du contrôleur ne fait toujours aucun contrôle de doublon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012c2eiwWGZnMXJkCVgnsAqu)_