### PR TITLE
feat(blog): per-locale (fr/en) post translations with fallback

### DIFF
--- a/automation/seo-blog/PLAYBOOK.md
+++ b/automation/seo-blog/PLAYBOOK.md
@@ -19,10 +19,10 @@ concerns in the summary.
 The blog supports per-locale translations. **Produce the article in every supported content
 locale, every run.** The current locales are:
 
-| Locale | Language | Home domain          |
-| ------ | -------- | -------------------- |
-| `en`   | English  | minecraft-stats.com  |
-| `fr`   | French   | minecraft-stats.fr   |
+| Locale | Language | Home domain         |
+| ------ | -------- | ------------------- |
+| `en`   | English  | minecraft-stats.com |
+| `fr`   | French   | minecraft-stats.fr  |
 
 - **`en` is the primary language** (`defaultLocale`): write the article natively in English first,
   then translate it **faithfully and natively** (not word-for-word) into every other locale —
@@ -37,11 +37,11 @@ locale, every run.** The current locales are:
 `.fr` and `.com` share the same backend/database, so reading and writing both target the `.fr`
 API; published articles appear on both domains.
 
-| Variable          | Value                                     | Purpose                                          |
-| ----------------- | ----------------------------------------- | ------------------------------------------------ |
-| `MCSTATS_API_URL` | `https://api.minecraft-stats.fr/api/v1`   | REST API (used for the authed write + upload)    |
-| `MCSTATS_TOKEN`   | `oat_…` (env secret)                       | API token of a `writer`/`admin` account          |
-| `KIE_API_KEY`     | `…` (env secret)                           | kie.ai key for Nano Banana Pro cover generation  |
+| Variable          | Value                                   | Purpose                                         |
+| ----------------- | --------------------------------------- | ----------------------------------------------- |
+| `MCSTATS_API_URL` | `https://api.minecraft-stats.fr/api/v1` | REST API (used for the authed write + upload)   |
+| `MCSTATS_TOKEN`   | `oat_…` (env secret)                    | API token of a `writer`/`admin` account         |
+| `KIE_API_KEY`     | `…` (env secret)                        | kie.ai key for Nano Banana Pro cover generation |
 
 - **MCP (reads):** the Minecraft-Stats MCP is connected to this routine (read-only). Prefer its
   tools — `getPosts`, `getPostsBySlug`, `getServers`, `getServersPaginate`, `getServerStats`,
@@ -55,27 +55,31 @@ API; published articles appear on both domains.
 ## Step-by-step
 
 ### 1. Survey what already exists
+
 - Use MCP `getPosts` to list existing published articles (titles, slugs, angles).
 - Also fetch drafts via REST so you never duplicate a pending one:
   `GET {MCSTATS_API_URL}/admin/posts?status=all&limit=100` with `Authorization: Bearer {MCSTATS_TOKEN}`.
 - This combined list is the authoritative "already covered" set.
 
 ### 2. Find the topic (signal-driven ideation)
+
 Don't invent a topic from thin air — **discover** one from real signals, then frame it as an
-archetype. The archetype is how you *frame* the signal, not the starting point. Run this funnel:
+archetype. The archetype is how you _frame_ the signal, not the starting point. Run this funnel:
 
 **2a. Mine our own data first (the moat).** This is the unique angle no competitor can copy.
-Via MCP, scan for what's genuinely newsworthy *this run*:
+Via MCP, scan for what's genuinely newsworthy _this run_:
+
 - **Biggest mover** — the server with the largest weekly/monthly growth, or the sharpest drop
   (`getServers`/`getServersPaginate` + `getServerStats`, growth stats).
 - **Milestone / record just crossed** — a server passing a round number (10k/50k peak), a new
   all-time peak, or a category total crossing a threshold (`getGlobalStats`, `getCategories`).
 - **Fast-climbing newcomer**, or an unusual pattern (weekend vs weekday, month-over-month shift).
-Keep 3–5 candidate "data angles", each backed by a striking real number.
+  Keep 3–5 candidate "data angles", each backed by a striking real number.
 
 **2b. Pull external trend & demand signals.** Confirm a candidate matches real-world interest, or
 surface a fresher angle. These sources are **verified to work in this environment** (see tool
 notes below):
+
 - **New Minecraft versions/features — timely, high demand.** WebFetch
   `https://minecraft.wiki/w/Java_Edition` for the current release, then
   `https://minecraft.wiki/w/Java_Edition_<version>` for its changelog. New mobs/features drive
@@ -104,7 +108,9 @@ minecraft.net, and server-list sites are bot-blocked, so reach those **through W
 than fetching them directly.
 
 ### 3. Gather real data (our SEO moat)
+
 Original, factual data is what ranks. Via MCP:
+
 - `getServers` / `getServersPaginate` for real servers, names, rankings, player counts.
 - `getServerStats` for a server's history/growth; `getGlobalStats` for site-wide trends.
 - Available dynamic placeholders: `GET {MCSTATS_API_URL}/posts/placeholders/list`. Tokens like
@@ -116,6 +122,7 @@ Original, factual data is what ranks. Via MCP:
 ### 4. Write the article in every language (Markdown)
 
 **4a. Write the primary (English) version.**
+
 - **Title**: 50–60 chars, includes the primary keyword, compelling.
 - **Excerpt**: 140–160 chars — becomes the meta description; must stand alone and entice.
 - **Body**: 700–1500 words of genuinely useful Markdown. Logical H2/H3 structure, short
@@ -127,6 +134,7 @@ Original, factual data is what ranks. Via MCP:
   every translation).
 
 **4b. Translate into every other supported locale (see the Languages table).**
+
 - Produce a **native, idiomatic** translation of the title, excerpt and full body — not a literal
   word-for-word one. Keep the same structure, headings, data, tables and reading level. Localize
   the primary keyword to how people actually search in that language.
@@ -138,6 +146,7 @@ Original, factual data is what ranks. Via MCP:
   French translation gets a French URL). Only set one if you need a specific slug.
 
 ### 5. Generate the cover image (Nano Banana Pro → upload)
+
 Generate one original cover illustration for the article's topic with kie.ai's Nano Banana Pro,
 then upload it to our own storage and use the returned path as `coverImage`. Never put a raw
 kie.ai URL in `coverImage` — those expire; always re-host via our upload endpoint.
@@ -145,7 +154,7 @@ kie.ai URL in `coverImage` — those expire; always re-host via our upload endpo
 1. **Write the image prompt** from the article's topic. Every cover must read as part of the
    Minecraft-Stats brand, so the blog feels like one consistent visual family run after run.
    Build the prompt from this fixed **brand brief** plus a per-article subject:
-   - **Identity:** Minecraft-Stats is a *data/analytics* product, not a generic blocky-Minecraft
+   - **Identity:** Minecraft-Stats is a _data/analytics_ product, not a generic blocky-Minecraft
      skin. The hero motif is **server statistics**: ascending bar charts, glowing line/growth
      curves, dashboard panels, leaderboards — visualised with a tasteful Minecraft-world accent
      (a few voxel/cube elements, a blocky server silhouette), never a full pixel-art scene.
@@ -160,6 +169,7 @@ kie.ai URL in `coverImage` — those expire; always re-host via our upload endpo
      blocky server lit by a rising bar chart; a growth piece → an upward line graph over a voxel
      landscape; a ranking piece → a podium of chart bars). Keep the palette and style above fixed.
 2. **Create the task:**
+
    ```
    POST https://api.kie.ai/api/v1/jobs/createTask
    Authorization: Bearer {KIE_API_KEY}
@@ -175,7 +185,9 @@ kie.ai URL in `coverImage` — those expire; always re-host via our upload endpo
      }
    }
    ```
+
    Expect `code: 200`; read `data.taskId`.
+
 3. **Poll for the result:** `GET https://api.kie.ai/api/v1/jobs/recordInfo?taskId={taskId}` with
    `Authorization: Bearer {KIE_API_KEY}`. Wait a few seconds between polls (generation usually
    takes ~10–40 s). Read `data.state`:
@@ -193,6 +205,7 @@ kie.ai URL in `coverImage` — those expire; always re-host via our upload endpo
    relative `url` as `coverImage` in the next step.
 
 ### 6. Create the draft with all its translations (REST)
+
 One call creates the post and every translation at once. The text fields (`title`, `slug`,
 `content`, `excerpt`) live **inside each `translations[]` entry**; `coverImage` and `defaultLocale`
 are shared by the whole post.
@@ -221,6 +234,7 @@ Content-Type: application/json
   ]
 }
 ```
+
 - Include **one `translations` entry per supported locale** (Languages table) — at minimum the
   `defaultLocale` one; ideally all of them. `slug` is optional (auto-generated per locale); omit it.
 - `defaultLocale` must match a locale present in `translations` (it's the fallback language).
@@ -229,6 +243,7 @@ Content-Type: application/json
   entry is missing from `translations` — add it.
 
 ### 7. Report
+
 Output a short summary: chosen content type, title, primary keyword, **the languages generated**
 (e.g. `en`, `fr`), word count, whether a cover image was generated (and its stored path, or why it
 was skipped), the draft's id and per-locale slugs, and the review URL
@@ -236,6 +251,7 @@ was skipped), the draft's id and per-locale slugs, and the review URL
 were unsure about).
 
 ## Guardrails
+
 - One article per run. Never publish. Never edit or delete existing posts.
 - Never commit or print the tokens. Treat `MCSTATS_TOKEN` and `KIE_API_KEY` as secrets.
 - The cover image is best-effort: if `KIE_API_KEY` is missing or generation fails, create the

--- a/automation/seo-blog/PLAYBOOK.md
+++ b/automation/seo-blog/PLAYBOOK.md
@@ -1,18 +1,36 @@
 # SEO Blog Automation — Playbook
 
-This file is the single source of truth for the scheduled agent that writes English SEO blog
+This file is the single source of truth for the scheduled agent that writes multilingual SEO blog
 articles for Minecraft-Stats. The agent reads this file at the start of every run and follows
 it step by step. Edit this file to change the behaviour.
 
 ## Mission
 
-Once per run, produce **one** high-quality, original, English-language SEO article and create
-it as a **draft** via the API. **Do not publish** — Gabriel reviews drafts in the admin and
-publishes manually.
+Once per run, produce **one** high-quality, original SEO article **in every language the site
+supports** and create it as a single **draft** (with all its translations) via the API. **Do not
+publish** — Gabriel reviews drafts in the admin and publishes manually.
 
 Quality over quantity. One excellent, data-backed article beats three generic ones. If you
 cannot produce something genuinely useful this run, create the best draft you can and flag your
 concerns in the summary.
+
+### Languages — generate them all
+
+The blog supports per-locale translations. **Produce the article in every supported content
+locale, every run.** The current locales are:
+
+| Locale | Language | Home domain          |
+| ------ | -------- | -------------------- |
+| `en`   | English  | minecraft-stats.com  |
+| `fr`   | French   | minecraft-stats.fr   |
+
+- **`en` is the primary language** (`defaultLocale`): write the article natively in English first,
+  then translate it **faithfully and natively** (not word-for-word) into every other locale —
+  same structure, headings, data and placeholders, idiomatic in each language.
+- A reader on a domain whose translation is missing falls back to the primary language, so always
+  ship at least the `en` translation; ship the others too so French readers get French.
+- If the site adds a locale later, add its code to this table and the create payload — the agent
+  then covers it automatically. (The backend only accepts locales it supports and rejects others.)
 
 ## Configuration
 
@@ -30,7 +48,9 @@ API; published articles appear on both domains.
   `getGlobalStats`, `getCategories` — for discovery, dedup, and gathering live data.
 - **REST (write):** publishing/creating is NOT available via MCP. The single create call uses
   the REST API with `MCSTATS_TOKEN`.
-- Internal links in articles should point to `https://minecraft-stats.com` (English audience).
+- Internal links should point to the locale's home domain: the **English** translation links to
+  `https://minecraft-stats.com`, the **French** one to `https://minecraft-stats.fr` (each domain
+  serves both languages, so either resolves — matching the domain to the language is cleanest).
 
 ## Step-by-step
 
@@ -93,15 +113,29 @@ Original, factual data is what ranks. Via MCP:
 - You may use WebSearch for general Minecraft context, but never invent server names or numbers —
   every concrete figure must come from the API or a live placeholder.
 
-### 4. Write the article (Markdown)
-- **Title (`title`)**: 50–60 chars, includes the primary keyword, compelling.
-- **`excerpt`**: 140–160 chars — becomes the meta description; must stand alone and entice.
+### 4. Write the article in every language (Markdown)
+
+**4a. Write the primary (English) version.**
+- **Title**: 50–60 chars, includes the primary keyword, compelling.
+- **Excerpt**: 140–160 chars — becomes the meta description; must stand alone and entice.
 - **Body**: 700–1500 words of genuinely useful Markdown. Logical H2/H3 structure, short
   paragraphs, lists/tables where helpful. Natural keyword usage — no stuffing.
 - **Internal links**: at least 2 to relevant `https://minecraft-stats.com` pages (a server page,
   the blog, a category).
 - **Tone**: helpful, factual, English-native. Not promotional fluff, not obviously AI-generated.
-- Don't set `coverImage` here — it's produced in step 5 below from a generated image.
+- Don't set a cover image here — it's produced in step 5 below from a generated image (shared by
+  every translation).
+
+**4b. Translate into every other supported locale (see the Languages table).**
+- Produce a **native, idiomatic** translation of the title, excerpt and full body — not a literal
+  word-for-word one. Keep the same structure, headings, data, tables and reading level. Localize
+  the primary keyword to how people actually search in that language.
+- **Keep every placeholder token identical** (e.g. `%PLAYER_COUNT_REALTIME_2%`). They are resolved
+  server-side at render time and must stay byte-for-byte the same across languages.
+- **Internal links**: point each translation at its own home domain (English → `minecraft-stats.com`,
+  French → `minecraft-stats.fr`).
+- **Don't set a slug** — the backend generates a clean, unique slug per locale from each title (so the
+  French translation gets a French URL). Only set one if you need a specific slug.
 
 ### 5. Generate the cover image (Nano Banana Pro → upload)
 Generate one original cover illustration for the article's topic with kie.ai's Nano Banana Pro,
@@ -158,25 +192,48 @@ kie.ai URL in `coverImage` — those expire; always re-host via our upload endpo
    The response is `{ "url": "/images/blog/<uuid>.webp" }` (server converts to WebP). Use that
    relative `url` as `coverImage` in the next step.
 
-### 6. Create the draft (REST)
+### 6. Create the draft with all its translations (REST)
+One call creates the post and every translation at once. The text fields (`title`, `slug`,
+`content`, `excerpt`) live **inside each `translations[]` entry**; `coverImage` and `defaultLocale`
+are shared by the whole post.
+
 ```
 POST {MCSTATS_API_URL}/admin/posts
 Authorization: Bearer {MCSTATS_TOKEN}
 Content-Type: application/json
 
 {
-  "title":      "<title>",
-  "content":    "<markdown body>",
-  "excerpt":    "<meta description>",
-  "coverImage": "<url from step 5, omit if generation failed>"
+  "defaultLocale": "en",
+  "coverImage": "<url from step 5, omit if generation failed>",
+  "translations": [
+    {
+      "locale":  "en",
+      "title":   "<English title>",
+      "content": "<English markdown body>",
+      "excerpt": "<English meta description>"
+    },
+    {
+      "locale":  "fr",
+      "title":   "<French title>",
+      "content": "<French markdown body>",
+      "excerpt": "<French meta description>"
+    }
+  ]
 }
 ```
-Expect `201`. The post is created with `published: false`. **Do NOT call the publish endpoint.**
+- Include **one `translations` entry per supported locale** (Languages table) — at minimum the
+  `defaultLocale` one; ideally all of them. `slug` is optional (auto-generated per locale); omit it.
+- `defaultLocale` must match a locale present in `translations` (it's the fallback language).
+- Expect `201`. The post is created with `published: false`. **Do NOT call the publish endpoint.**
+- A `422` with `"A translation in the primary language is required."` means the `defaultLocale`
+  entry is missing from `translations` — add it.
 
 ### 7. Report
-Output a short summary: chosen content type, title, primary keyword, word count, whether a cover
-image was generated (and its stored path, or why it was skipped), the draft's slug/id, and the
-review URL `https://minecraft-stats.com/admin/posts`. Flag any quality concerns.
+Output a short summary: chosen content type, title, primary keyword, **the languages generated**
+(e.g. `en`, `fr`), word count, whether a cover image was generated (and its stored path, or why it
+was skipped), the draft's id and per-locale slugs, and the review URL
+`https://minecraft-stats.com/admin/posts`. Flag any quality concerns (including any translation you
+were unsure about).
 
 ## Guardrails
 - One article per run. Never publish. Never edit or delete existing posts.

--- a/automation/seo-blog/README.md
+++ b/automation/seo-blog/README.md
@@ -1,9 +1,10 @@
 # SEO Blog Automation
 
-A scheduled Claude agent that writes **one English SEO blog article per week** and creates it as
-a **draft** for review (it never auto-publishes). It picks topics itself: it looks at what's
-already on the blog (via the Minecraft-Stats MCP), chooses the least-covered content type, and
-generates a fresh, data-backed topic.
+A scheduled Claude agent that writes **one SEO blog article per week — in every language the site
+supports (English + French)** — and creates it as a single **draft** for review (it never
+auto-publishes). It picks topics itself: it looks at what's already on the blog (via the
+Minecraft-Stats MCP), chooses the least-covered content type, and generates a fresh, data-backed
+topic, written natively in English then translated to French.
 
 ## Files
 - `PLAYBOOK.md` — the instructions the agent follows every run. Edit this to change behaviour.
@@ -13,7 +14,8 @@ generates a fresh, data-backed topic.
 - **Reads** (existing posts, servers, live stats) → Minecraft-Stats **MCP** (read-only),
   connected to the routine.
 - **Writes** (create the draft) → REST `POST /admin/posts` with an **API token**, because the
-  MCP cannot publish.
+  MCP cannot publish. One call carries every translation (`translations[]` + `defaultLocale`); the
+  shared `coverImage` is reused across languages.
 - **Cover image** → generated with kie.ai **Nano Banana Pro** (`KIE_API_KEY`), then re-hosted via
   our own `POST /uploads/image` endpoint; the returned `/images/blog/…webp` path is stored as
   `coverImage`. Best-effort: a draft is still created if generation fails.

--- a/backend/.adonisjs/server/routes.d.ts
+++ b/backend/.adonisjs/server/routes.d.ts
@@ -47,6 +47,8 @@ export type ScannedRoutes = {
     'posts.show': { paramsTuple: [ParamValue]; params: {'slug': ParamValue} }
     'posts.get_placeholders': { paramsTuple?: []; params?: {} }
     'posts.resolve_placeholders': { paramsTuple?: []; params?: {} }
+    'posts.record_view': { paramsTuple: [ParamValue]; params: {'slug': ParamValue} }
+    'posts.submit_feedback': { paramsTuple: [ParamValue]; params: {'slug': ParamValue} }
     'advertisements.index': { paramsTuple?: []; params?: {} }
     'advertisements.record_impression': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'advertisements.click': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
@@ -59,9 +61,12 @@ export type ScannedRoutes = {
     'posts.destroy': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'posts.publish': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'posts.unpublish': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
+    'posts.admin_stats': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
+    'posts.admin_show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'posts.preview_placeholder': { paramsTuple?: []; params?: {} }
     'analytics.dashboard': { paramsTuple?: []; params?: {} }
     'users.admin_index': { paramsTuple?: []; params?: {} }
+    'users.admin_show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'users.update_role': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'advertisements.admin_index': { paramsTuple?: []; params?: {} }
     'advertisements.stats': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
@@ -97,8 +102,11 @@ export type ScannedRoutes = {
     'advertisements.index': { paramsTuple?: []; params?: {} }
     'advertisements.click': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'posts.admin_index': { paramsTuple?: []; params?: {} }
+    'posts.admin_stats': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
+    'posts.admin_show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'analytics.dashboard': { paramsTuple?: []; params?: {} }
     'users.admin_index': { paramsTuple?: []; params?: {} }
+    'users.admin_show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'advertisements.admin_index': { paramsTuple?: []; params?: {} }
     'advertisements.stats': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'advertisements.show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
@@ -129,8 +137,11 @@ export type ScannedRoutes = {
     'advertisements.index': { paramsTuple?: []; params?: {} }
     'advertisements.click': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'posts.admin_index': { paramsTuple?: []; params?: {} }
+    'posts.admin_stats': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
+    'posts.admin_show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'analytics.dashboard': { paramsTuple?: []; params?: {} }
     'users.admin_index': { paramsTuple?: []; params?: {} }
+    'users.admin_show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'advertisements.admin_index': { paramsTuple?: []; params?: {} }
     'advertisements.stats': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'advertisements.show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
@@ -149,6 +160,8 @@ export type ScannedRoutes = {
     'auth.logout_all': { paramsTuple?: []; params?: {} }
     'api_tokens.store': { paramsTuple?: []; params?: {} }
     'posts.resolve_placeholders': { paramsTuple?: []; params?: {} }
+    'posts.record_view': { paramsTuple: [ParamValue]; params: {'slug': ParamValue} }
+    'posts.submit_feedback': { paramsTuple: [ParamValue]; params: {'slug': ParamValue} }
     'advertisements.record_impression': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'analytics.hit': { paramsTuple?: []; params?: {} }
     'analytics.pageview': { paramsTuple?: []; params?: {} }

--- a/backend/app/controllers/posts_controller.ts
+++ b/backend/app/controllers/posts_controller.ts
@@ -1,6 +1,8 @@
 import Post from '#models/post'
+import PostTranslation from '#models/post_translation'
 import PostPolicy from '#policies/post_policy'
 import PlaceholderService from '#services/placeholder_service'
+import { SlugService } from '#services/slug_service'
 import {
   CreatePostValidator,
   PreviewPlaceholderValidator,
@@ -12,20 +14,73 @@ import type { HttpContext } from '@adonisjs/core/http'
 import db from '@adonisjs/lucid/services/db'
 import { DateTime } from 'luxon'
 
+const SUPPORTED_LOCALES = ['fr', 'en'] as const
+const DEFAULT_LOCALE = 'en'
+
+/** Locale demandée via `?locale=`, validée contre les locales supportées. */
+function resolveLocale(value: unknown): string {
+  return SUPPORTED_LOCALES.includes(value as never) ? (value as string) : DEFAULT_LOCALE
+}
+
+function serializeAuthor(post: Post) {
+  if (!post.author) return undefined
+  return { id: post.author.id, username: post.author.username, avatarUrl: post.author.avatarUrl }
+}
+
+/** Forme publique : champs article + traduction résolue (avec fallback) + slugs. */
+function serializePost(post: Post, locale: string) {
+  const resolved = post.forLocale(locale)
+  return {
+    id: post.id,
+    title: resolved.title,
+    slug: resolved.slug,
+    content: resolved.content,
+    excerpt: resolved.excerpt,
+    coverImage: post.coverImage,
+    published: post.published,
+    viewCount: post.viewCount,
+    publishedAt: post.publishedAt,
+    defaultLocale: post.defaultLocale,
+    localeUsed: resolved.localeUsed,
+    slugs: post.slugsByLocale(),
+    userId: post.userId,
+    createdAt: post.createdAt,
+    updatedAt: post.updatedAt,
+    author: serializeAuthor(post),
+  }
+}
+
+/** Forme admin : la forme publique (langue principale) + toutes les traductions brutes. */
+function serializeAdminPost(post: Post) {
+  return {
+    ...serializePost(post, post.defaultLocale),
+    availableLocales: post.translations.map((t) => t.locale),
+    translations: post.translations.map((t) => ({
+      locale: t.locale,
+      title: t.title,
+      slug: t.slug,
+      content: t.content,
+      excerpt: t.excerpt,
+    })),
+  }
+}
+
 export default class PostsController {
   /**
    * @listPosts
    * @operationId listPosts
    * @tag POSTS
    * @summary List published posts
-   * @description Returns a paginated list of published posts ordered by `published_at` descending. Each post includes its author (id, username, avatarUrl). Publicly accessible.
+   * @description Returns a paginated list of published posts ordered by `published_at` descending. Each post is resolved to the requested `?locale` (falling back to the post's primary language) and includes its author and per-locale `slugs`. Publicly accessible.
    * @paramQuery page - Page number (default 1) - @type(number) @example(1)
    * @paramQuery limit - Number of items per page (default 10) - @type(number) @example(10)
-   * @responseBody 200 - {"meta": {"total": 42, "perPage": 10, "currentPage": 1, "lastPage": 5}, "data": [{"id": 1, "title": "Welcome", "slug": "welcome", "content": "<p>Hello</p>", "excerpt": "Hello", "coverImage": "/images/blog/cover.webp", "published": true, "publishedAt": "2026-05-28T12:00:00.000Z", "userId": 1, "createdAt": "2026-05-20T12:00:00.000Z", "updatedAt": "2026-05-28T12:00:00.000Z", "author": {"id": 1, "username": "admin", "avatarUrl": ""}}]}
+   * @paramQuery locale - UI locale to resolve content for: `fr` or `en` (default `en`) - @type(string) @example(fr)
+   * @responseBody 200 - {"meta": {"total": 42, "perPage": 10, "currentPage": 1, "lastPage": 5}, "data": [{"id": 1, "title": "Welcome", "slug": "welcome", "content": "<p>Hello</p>", "excerpt": "Hello", "coverImage": "/images/blog/cover.webp", "published": true, "publishedAt": "2026-05-28T12:00:00.000Z", "defaultLocale": "en", "localeUsed": "en", "slugs": {"en": "welcome", "fr": "bienvenue"}, "userId": 1, "createdAt": "2026-05-20T12:00:00.000Z", "updatedAt": "2026-05-28T12:00:00.000Z", "author": {"id": 1, "username": "admin", "avatarUrl": ""}}]}
    */
   async index({ request, response }: HttpContext) {
     const page = Math.max(1, Number.parseInt(request.input('page', 1), 10) || 1)
     const limit = Math.min(100, Math.max(1, Number.parseInt(request.input('limit', 10), 10) || 10))
+    const locale = resolveLocale(request.input('locale'))
 
     const posts = await Post.query()
       .where('published', true)
@@ -33,10 +88,14 @@ export default class PostsController {
       .preload('author', (query) => {
         query.select('id', 'username', 'avatarUrl')
       })
+      .preload('translations')
       .orderBy('published_at', 'desc')
       .paginate(page, limit)
 
-    return response.ok(posts)
+    return response.ok({
+      meta: posts.toJSON().meta,
+      data: posts.all().map((post) => serializePost(post, locale)),
+    })
   }
 
   /**
@@ -44,21 +103,39 @@ export default class PostsController {
    * @operationId showPost
    * @tag POSTS
    * @summary Get a published post by slug
-   * @description Returns a single published post identified by its slug. Content is returned with its raw placeholder tokens (e.g. `%PLAYER_COUNT_REALTIME_125%`) intact — the client resolves them asynchronously via `POST /posts/placeholders/resolve` so the article renders immediately. Returns 404 if no published post matches the slug. Publicly accessible.
-   * @paramPath slug - Unique slug of the post - @type(string) @example(welcome-post) @required
+   * @description Returns a single published post matched by slug within the requested `?locale`. If no translation matches the slug in that locale, it resolves by slug across locales and falls back to the post's primary language. Content keeps its raw placeholder tokens (resolved client-side). Returns 404 if no published post matches. Publicly accessible.
+   * @paramPath slug - Slug of the post (per-locale) - @type(string) @example(welcome-post) @required
+   * @paramQuery locale - UI locale to resolve content for: `fr` or `en` (default `en`) - @type(string) @example(fr)
    * @responseBody 200 - <Post>
-   * @responseBody 404 - {"message": "Row not found", "code": "E_ROW_NOT_FOUND"}
+   * @responseBody 404 - {"message": "Post not found"}
    */
-  async show({ params, response }: HttpContext) {
-    const post = await Post.query()
-      .where('slug', params.slug)
-      .where('published', true)
-      .preload('author', (val) => {
-        val.select('id', 'username', 'avatarUrl')
-      })
-      .firstOrFail()
+  async show({ params, request, response, i18n }: HttpContext) {
+    const locale = resolveLocale(request.input('locale'))
 
-    return response.ok(post)
+    // 1. Slug exact dans la locale demandée ; 2. sinon n'importe quelle locale
+    // (cas fallback : on visite le slug de la langue principale sous une autre UI).
+    const translation =
+      (await PostTranslation.query().where('locale', locale).where('slug', params.slug).first()) ??
+      (await PostTranslation.query().where('slug', params.slug).first())
+
+    if (!translation) {
+      return response.notFound({ message: i18n.t('messages.posts.notFound') })
+    }
+
+    const post = await Post.query()
+      .where('id', translation.postId)
+      .where('published', true)
+      .preload('author', (query) => {
+        query.select('id', 'username', 'avatarUrl')
+      })
+      .preload('translations')
+      .first()
+
+    if (!post) {
+      return response.notFound({ message: i18n.t('messages.posts.notFound') })
+    }
+
+    return response.ok(serializePost(post, locale))
   }
 
   /**
@@ -66,15 +143,18 @@ export default class PostsController {
    * @operationId recordPostView
    * @tag POSTS
    * @summary Record a view for a published post
-   * @description Increments the raw view counter of a published post. Consent-exempt and best-effort: it stores only an aggregate counter (no visitor or account identifier), so it counts every reader — logged in or not, consent given or not — on the same privacy basis as the anonymous analytics hit. Detailed, consent-aware attribution (who viewed) is captured separately by the analytics page-view pipeline. Always responds `204 No Content`. Publicly accessible.
-   * @paramPath slug - Unique slug of the post - @type(string) @example(welcome-post) @required
+   * @description Increments the raw view counter of the post owning this slug. The counter is shared across all of a post's translations. Consent-exempt, best-effort, always `204`. Publicly accessible.
+   * @paramPath slug - Slug of the post (per-locale) - @type(string) @example(welcome-post) @required
    * @responseBody 204 - No content
    */
   async recordView({ params, response }: HttpContext) {
-    await Post.query()
-      .where('slug', params.slug)
-      .where('published', true)
-      .increment('view_count', 1)
+    const translation = await PostTranslation.query().where('slug', params.slug).first()
+    if (translation) {
+      await Post.query()
+        .where('id', translation.postId)
+        .where('published', true)
+        .increment('view_count', 1)
+    }
 
     return response.noContent()
   }
@@ -84,23 +164,25 @@ export default class PostsController {
    * @operationId submitPostFeedback
    * @tag POSTS
    * @summary Submit "was this article helpful?" feedback
-   * @description Records whether the reader found the article helpful. Deduplicated by the anonymous `visitorId` (one vote per device per post); re-submitting updates the existing vote. When the request carries a valid bearer token the vote is also attributed to the logged-in account. Aggregate results are visible to admins/writers only. Returns 404 if no published post matches the slug. Publicly accessible.
-   * @paramPath slug - Unique slug of the post - @type(string) @example(welcome-post) @required
+   * @description Records whether the reader found the article helpful, keyed at the post level (shared across translations) and deduplicated by the anonymous `visitorId`. Returns 404 if no published post matches the slug. Publicly accessible.
+   * @paramPath slug - Slug of the post (per-locale) - @type(string) @example(welcome-post) @required
    * @requestBody {"helpful": true, "visitorId": "f47ac10b-58cc-4372-a567-0e02b2c3d479"}
    * @responseBody 204 - No content
    * @responseBody 404 - {"error": "Post not found"}
    * @responseBody 422 - {"errors": [{"message": "The helpful field must be defined", "field": "helpful", "rule": "required"}]}
    */
   async submitFeedback({ params, request, response, auth, i18n }: HttpContext) {
-    const post = await Post.query().where('slug', params.slug).where('published', true).first()
+    const translation = await PostTranslation.query().where('slug', params.slug).first()
+    const post = translation
+      ? await Post.query().where('id', translation.postId).where('published', true).first()
+      : null
     if (!post) {
       return response.notFound({ error: i18n.t('messages.posts.notFound') })
     }
 
     const { helpful, visitorId } = await request.validateUsing(SubmitFeedbackValidator)
 
-    // L'endpoint est public : on lit l'utilisateur s'il est connecté sans l'imposer,
-    // pour qu'un visiteur anonyme puisse aussi voter.
+    // L'endpoint est public : on lit l'utilisateur s'il est connecté sans l'imposer.
     await auth.check()
 
     const now = DateTime.now().toSQL()
@@ -125,7 +207,7 @@ export default class PostsController {
    * @operationId resolvePlaceholders
    * @tag POSTS
    * @summary Resolve content placeholders to their current values
-   * @description Resolves a batch of placeholder tokens (e.g. `%PLAYER_COUNT_REALTIME_125%`) to their live values in a single request. Returns a map of token → value. Unknown servers resolve to a `[Server N not found]` marker. Used by the blog client to fill placeholders after the article has rendered. Publicly accessible.
+   * @description Resolves a batch of placeholder tokens to their live values. Returns a map of token → value. Publicly accessible.
    * @requestBody {"placeholders": ["%PLAYER_COUNT_REALTIME_125%", "%SERVER_VERSION_125%"]}
    * @responseBody 200 - {"%PLAYER_COUNT_REALTIME_125%": "42", "%SERVER_VERSION_125%": "1.21.4"}
    * @responseBody 422 - {"errors": [{"message": "The placeholders field must be defined", "field": "placeholders", "rule": "required"}]}
@@ -141,11 +223,11 @@ export default class PostsController {
    * @operationId adminListPosts
    * @tag POSTS_ADMIN
    * @summary List all posts (admin/writer)
-   * @description Returns a paginated list of posts including drafts. Writers only see their own posts, admins see every post. Each post includes its author (id, username, avatarUrl). Requires authentication and `manage` ability on the Post policy.
+   * @description Returns a paginated list of posts including drafts, shown in each post's primary language with the list of `availableLocales`. Writers only see their own posts. Requires `manage` ability.
    * @paramQuery page - Page number (default 1) - @type(number) @example(1)
    * @paramQuery limit - Number of items per page (default 20) - @type(number) @example(20)
    * @paramQuery status - Filter by status: `all`, `published`, or `draft` (default `all`) - @type(string) @example(all)
-   * @responseBody 200 - {"meta": {"total": 42, "perPage": 20, "currentPage": 1, "lastPage": 3}, "data": [{"id": 1, "title": "Draft", "slug": "draft", "content": "<p>WIP</p>", "excerpt": "", "coverImage": "", "published": false, "publishedAt": "", "userId": 1, "createdAt": "2026-05-20T12:00:00.000Z", "updatedAt": "2026-05-28T12:00:00.000Z", "author": {"id": 1, "username": "writer", "avatarUrl": ""}}]}
+   * @responseBody 200 - {"meta": {"total": 42, "perPage": 20, "currentPage": 1, "lastPage": 3}, "data": [{"id": 1, "title": "Draft", "slug": "draft", "defaultLocale": "en", "availableLocales": ["en"], "published": false, "author": {"id": 1, "username": "writer", "avatarUrl": ""}}]}
    * @responseBody 401 - {"error": "Unauthorized"}
    * @responseBody 403 - {"error": "Access denied. Writer privileges required."}
    */
@@ -161,13 +243,14 @@ export default class PostsController {
 
     const page = Math.max(1, Number.parseInt(request.input('page', 1), 10) || 1)
     const limit = Math.min(100, Math.max(1, Number.parseInt(request.input('limit', 20), 10) || 20))
-    const status = request.input('status', 'all') // all, published, draft
+    const status = request.input('status', 'all')
 
-    const query = Post.query().preload('author', (authorQuery) => {
-      authorQuery.select('id', 'username', 'avatarUrl')
-    })
+    const query = Post.query()
+      .preload('author', (authorQuery) => {
+        authorQuery.select('id', 'username', 'avatarUrl')
+      })
+      .preload('translations')
 
-    // Writers can only see their own posts, admins can see all
     if (user.role === 'writer') {
       query.where('user_id', user.id)
     }
@@ -180,7 +263,43 @@ export default class PostsController {
 
     const posts = await query.orderBy('created_at', 'desc').paginate(page, limit)
 
-    return response.ok(posts)
+    return response.ok({
+      meta: posts.toJSON().meta,
+      data: posts.all().map((post) => serializeAdminPost(post)),
+    })
+  }
+
+  /**
+   * @adminShowPost
+   * @operationId adminShowPost
+   * @tag POSTS_ADMIN
+   * @summary Get a single post with all its translations (admin/writer)
+   * @description Returns one post including every translation (title/slug/content/excerpt per locale), the shared cover image and `defaultLocale`. Used by the edit screen. Writers may only access their own posts. Requires `update` ability.
+   * @paramPath id - Post id - @type(number) @example(7) @required
+   * @responseBody 200 - <Post>
+   * @responseBody 401 - {"error": "Unauthorized"}
+   * @responseBody 403 - {"error": "Access denied. You can only update your own posts."}
+   * @responseBody 404 - {"message": "Row not found", "code": "E_ROW_NOT_FOUND"}
+   */
+  async adminShow({ params, response, auth, bouncer, i18n }: HttpContext) {
+    const user = auth.user
+    if (!user) {
+      return response.unauthorized({ error: i18n.t('messages.posts.unauthorized') })
+    }
+
+    const post = await Post.query()
+      .where('id', params.id)
+      .preload('author', (query) => {
+        query.select('id', 'username', 'avatarUrl')
+      })
+      .preload('translations')
+      .firstOrFail()
+
+    if (await bouncer.with(PostPolicy).denies('update', post)) {
+      return response.forbidden({ error: i18n.t('messages.posts.updateOwnOnly') })
+    }
+
+    return response.ok(serializeAdminPost(post))
   }
 
   /**
@@ -188,12 +307,12 @@ export default class PostsController {
    * @operationId createPost
    * @tag POSTS_ADMIN
    * @summary Create a new post
-   * @description Creates a new post owned by the authenticated user. The post is always created as an unpublished draft (`published: false`); use the publish endpoint to make it public. Requires authentication and `manage` ability on the Post policy.
+   * @description Creates an unpublished draft owned by the authenticated user, with one or more translations and a shared cover image. The translation in `defaultLocale` is required. Slugs are generated per locale. Requires `manage` ability.
    * @requestBody <CreatePostValidator>
    * @responseBody 201 - <Post>
    * @responseBody 401 - {"error": "Unauthorized"}
    * @responseBody 403 - {"error": "Access denied. Writer privileges required."}
-   * @responseBody 422 - {"errors": [{"message": "The title field must be defined", "field": "title", "rule": "required"}]}
+   * @responseBody 422 - {"errors": [{"message": "A translation in the primary language is required.", "field": "translations", "rule": "required"}]}
    */
   async store({ request, auth, response, bouncer, i18n }: HttpContext) {
     const user = auth.user
@@ -207,15 +326,50 @@ export default class PostsController {
 
     const data = await request.validateUsing(CreatePostValidator)
 
-    const post = await Post.create({
-      ...data,
-      userId: user.id,
-      published: false,
+    if (!data.translations.some((t) => t.locale === data.defaultLocale)) {
+      return response.unprocessableEntity({
+        errors: [
+          {
+            message: i18n.t('messages.posts.missingDefaultTranslation'),
+            field: 'translations',
+            rule: 'required',
+          },
+        ],
+      })
+    }
+
+    const post = await db.transaction(async (trx) => {
+      const created = await Post.create(
+        {
+          userId: user.id,
+          published: false,
+          coverImage: data.coverImage || null,
+          defaultLocale: data.defaultLocale,
+        },
+        { client: trx }
+      )
+
+      for (const translation of data.translations) {
+        const slug = await SlugService.uniqueSlug(
+          translation.locale,
+          translation.slug || translation.title
+        )
+        await created.related('translations').create({
+          locale: translation.locale,
+          title: translation.title,
+          slug,
+          content: translation.content,
+          excerpt: translation.excerpt || null,
+        })
+      }
+
+      return created
     })
 
     await post.load('author')
+    await post.load('translations')
 
-    return response.created(post)
+    return response.created(serializeAdminPost(post))
   }
 
   /**
@@ -223,14 +377,13 @@ export default class PostsController {
    * @operationId updatePost
    * @tag POSTS_ADMIN
    * @summary Update an existing post
-   * @description Updates fields of an existing post. Writers may only update their own posts, admins may update any. Requires authentication and `update` ability on the Post policy. Returns 404 if the post does not exist.
+   * @description Updates the shared fields (cover image, primary language) and upserts the provided translations. A translation's slug is only regenerated when a `slug` is supplied (URLs stay stable otherwise). New locales can be added. Requires `update` ability.
    * @paramPath id - Post id - @type(number) @example(7) @required
    * @requestBody <UpdatePostValidator>
    * @responseBody 200 - <Post>
    * @responseBody 401 - {"error": "Unauthorized"}
    * @responseBody 403 - {"error": "Access denied. You can only update your own posts."}
    * @responseBody 404 - {"message": "Row not found", "code": "E_ROW_NOT_FOUND"}
-   * @responseBody 422 - {"errors": [{"message": "The title field must have at least 3 characters", "field": "title", "rule": "minLength"}]}
    */
   async update({ params, request, response, auth, bouncer, i18n }: HttpContext) {
     const user = auth.user
@@ -246,12 +399,45 @@ export default class PostsController {
 
     const data = await request.validateUsing(UpdatePostValidator)
 
-    post.merge(data)
-    await post.save()
+    await db.transaction(async (trx) => {
+      post.useTransaction(trx)
+      if (data.defaultLocale !== undefined) post.defaultLocale = data.defaultLocale
+      if (data.coverImage !== undefined) post.coverImage = data.coverImage || null
+      await post.save()
+
+      for (const entry of data.translations ?? []) {
+        const existing = await PostTranslation.query({ client: trx })
+          .where('post_id', post.id)
+          .where('locale', entry.locale)
+          .first()
+
+        if (existing) {
+          if (entry.title !== undefined) existing.title = entry.title
+          if (entry.content !== undefined) existing.content = entry.content
+          if (entry.excerpt !== undefined) existing.excerpt = entry.excerpt || null
+          if (entry.slug !== undefined) {
+            existing.slug = await SlugService.uniqueSlug(entry.locale, entry.slug, existing.id)
+          }
+          existing.useTransaction(trx)
+          await existing.save()
+        } else if (entry.title && entry.content) {
+          // Nouvelle langue : nécessite au minimum titre + contenu.
+          const slug = await SlugService.uniqueSlug(entry.locale, entry.slug || entry.title)
+          await post.related('translations').create({
+            locale: entry.locale,
+            title: entry.title,
+            slug,
+            content: entry.content,
+            excerpt: entry.excerpt || null,
+          })
+        }
+      }
+    })
 
     await post.load('author')
+    await post.load('translations')
 
-    return response.ok(post)
+    return response.ok(serializeAdminPost(post))
   }
 
   /**
@@ -259,7 +445,7 @@ export default class PostsController {
    * @operationId deletePost
    * @tag POSTS_ADMIN
    * @summary Delete a post
-   * @description Permanently deletes a post. Writers may only delete their own posts, admins may delete any. Requires authentication and `destroy` ability on the Post policy. Returns 404 if the post does not exist.
+   * @description Permanently deletes a post and its translations (cascade). Writers may only delete their own posts. Requires `destroy` ability.
    * @paramPath id - Post id - @type(number) @example(7) @required
    * @responseBody 204 - {}
    * @responseBody 401 - {"error": "Unauthorized"}
@@ -288,7 +474,7 @@ export default class PostsController {
    * @operationId publishPost
    * @tag POSTS_ADMIN
    * @summary Publish a post
-   * @description Marks a post as published and sets `publishedAt` to the current timestamp. Writers may only publish their own posts, admins may publish any. Requires authentication and `publish` ability on the Post policy. Returns 404 if the post does not exist.
+   * @description Marks a post as published and sets `publishedAt`. Requires `publish` ability.
    * @paramPath id - Post id - @type(number) @example(7) @required
    * @responseBody 200 - <Post>
    * @responseBody 401 - {"error": "Unauthorized"}
@@ -312,8 +498,9 @@ export default class PostsController {
     await post.save()
 
     await post.load('author')
+    await post.load('translations')
 
-    return response.ok(post)
+    return response.ok(serializeAdminPost(post))
   }
 
   /**
@@ -321,7 +508,7 @@ export default class PostsController {
    * @operationId unpublishPost
    * @tag POSTS_ADMIN
    * @summary Unpublish a post
-   * @description Marks a post as unpublished and clears its `publishedAt` timestamp. Writers may only unpublish their own posts, admins may unpublish any. Requires authentication and `publish` ability on the Post policy. Returns 404 if the post does not exist.
+   * @description Marks a post as unpublished and clears `publishedAt`. Requires `publish` ability.
    * @paramPath id - Post id - @type(number) @example(7) @required
    * @responseBody 200 - <Post>
    * @responseBody 401 - {"error": "Unauthorized"}
@@ -345,8 +532,9 @@ export default class PostsController {
     await post.save()
 
     await post.load('author')
+    await post.load('translations')
 
-    return response.ok(post)
+    return response.ok(serializeAdminPost(post))
   }
 
   /**
@@ -354,8 +542,8 @@ export default class PostsController {
    * @operationId listPlaceholders
    * @tag POSTS
    * @summary List available content placeholders
-   * @description Returns the catalog of placeholder tokens that can be embedded in post content (e.g. `%PLAYER_COUNT_REALTIME_125%`). Each entry includes the placeholder name, a human-readable description, and an example string. Publicly accessible.
-   * @responseBody 200 - [{"name": "PLAYER_COUNT_REALTIME", "description": "Current number of online players", "example": "%PLAYER_COUNT_REALTIME_125%"}, {"name": "PLAYER_COUNT_PEAK_HIGH", "description": "Highest number of players ever recorded", "example": "%PLAYER_COUNT_PEAK_HIGH_125%"}]
+   * @description Returns the catalog of placeholder tokens that can be embedded in post content. Publicly accessible.
+   * @responseBody 200 - [{"name": "PLAYER_COUNT_REALTIME", "description": "Current number of online players", "example": "%PLAYER_COUNT_REALTIME_125%"}]
    */
   async getPlaceholders({ response }: HttpContext) {
     const placeholders = PlaceholderService.getAvailablePlaceholders()
@@ -367,7 +555,7 @@ export default class PostsController {
    * @operationId previewPlaceholder
    * @tag POSTS_ADMIN
    * @summary Preview a placeholder substitution
-   * @description Resolves a single placeholder for a given server and returns both the raw placeholder string and the computed value, so the editor UI can show writers what the token will render to. Requires authentication and `manage` ability on the Post policy.
+   * @description Resolves a single placeholder for a given server. Requires `manage` ability.
    * @requestBody {"placeholderName": "PLAYER_COUNT_REALTIME", "serverId": "125"}
    * @responseBody 200 - {"placeholder": "%PLAYER_COUNT_REALTIME_125%", "value": "42", "serverId": 125, "placeholderName": "PLAYER_COUNT_REALTIME"}
    * @responseBody 401 - {"error": "Unauthorized"}
@@ -402,9 +590,9 @@ export default class PostsController {
    * @operationId adminPostStats
    * @tag POSTS_ADMIN
    * @summary Post views & feedback statistics (admin/writer)
-   * @description Returns engagement statistics for a single post: the raw view total, the consent-aware analytics breakdown derived from the page-view pipeline for `/blog/{slug}` (consented views, logged-in views, unique visitors), the helpful/not-helpful feedback tallies, and the most recent logged-in viewers (who viewed). Writers may only access stats for their own posts, admins for any. Requires authentication and `update` ability on the Post policy. Returns 404 if the post does not exist.
+   * @description Returns engagement statistics for a post, aggregating analytics across every per-locale slug path (`/blog/{slug}`). Requires `update` ability.
    * @paramPath id - Post id - @type(number) @example(7) @required
-   * @responseBody 200 - {"post": {"id": 7, "title": "Welcome", "slug": "welcome", "viewCount": 1234}, "views": {"total": 1234, "consented": 800, "loggedIn": 120, "uniqueVisitors": 640}, "feedback": {"helpful": 42, "notHelpful": 3}, "recentViewers": [{"id": 1, "username": "gabriel", "avatarUrl": "", "lastViewedAt": "2026-06-26T12:00:00.000Z"}]}
+   * @responseBody 200 - {"post": {"id": 7, "title": "Welcome", "slugs": {"en": "welcome"}, "viewCount": 1234}, "views": {"total": 1234, "consented": 800, "loggedIn": 120, "uniqueVisitors": 640}, "feedback": {"helpful": 42, "notHelpful": 3}, "recentViewers": [{"id": 1, "username": "gabriel", "avatarUrl": "", "lastViewedAt": "2026-06-26T12:00:00.000Z"}]}
    * @responseBody 401 - {"error": "Unauthorized"}
    * @responseBody 403 - {"error": "Access denied. You can only view stats for your own posts."}
    * @responseBody 404 - {"message": "Row not found", "code": "E_ROW_NOT_FOUND"}
@@ -415,7 +603,7 @@ export default class PostsController {
       return response.unauthorized({ error: i18n.t('messages.posts.unauthorized') })
     }
 
-    const post = await Post.findOrFail(params.id)
+    const post = await Post.query().where('id', params.id).preload('translations').firstOrFail()
 
     if (await bouncer.with(PostPolicy).denies('update', post)) {
       return response.forbidden({
@@ -423,14 +611,15 @@ export default class PostsController {
       })
     }
 
-    // L'analytics enregistre les vues consenties par chemin exact (cf. AnalyticsService) :
-    // on retrouve donc les vues d'un article via son URL publique `/blog/{slug}`.
-    const path = `/blog/${post.slug}`
+    // L'analytics enregistre les vues par chemin exact ; un article a un chemin
+    // par langue (slug par locale), on agrège donc sur tous ses slugs.
+    const paths = post.translations.map((t) => `/blog/${t.slug}`)
+    const resolved = post.forLocale(post.defaultLocale)
 
     const [analyticsRow, feedbackRow, recentViewers] = await Promise.all([
       db
         .from('page_views')
-        .where('path', path)
+        .whereIn('path', paths)
         .select(db.raw('count(*) as consented_views'))
         .select(db.raw('count(*) filter (where user_id is not null) as logged_in_views'))
         .select(db.raw('count(distinct visitor_id) as unique_visitors'))
@@ -446,7 +635,7 @@ export default class PostsController {
       db
         .from('page_views')
         .join('users', 'users.id', 'page_views.user_id')
-        .where('page_views.path', path)
+        .whereIn('page_views.path', paths)
         .select('users.id as id', 'users.username as username', 'users.avatar_url as avatar_url')
         .select(db.raw('max(page_views.created_at) as last_viewed_at'))
         .groupBy('users.id', 'users.username', 'users.avatar_url')
@@ -455,7 +644,12 @@ export default class PostsController {
     ])
 
     return response.ok({
-      post: { id: post.id, title: post.title, slug: post.slug, viewCount: post.viewCount },
+      post: {
+        id: post.id,
+        title: resolved.title,
+        slugs: post.slugsByLocale(),
+        viewCount: post.viewCount,
+      },
       views: {
         total: post.viewCount,
         consented: Number(analyticsRow?.consented_views ?? 0),

--- a/backend/app/models/post.ts
+++ b/backend/app/models/post.ts
@@ -1,24 +1,12 @@
 import { DateTime } from 'luxon'
-import { BaseModel, beforeCreate, belongsTo, column } from '@adonisjs/lucid/orm'
-import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import { BaseModel, belongsTo, column, hasMany } from '@adonisjs/lucid/orm'
+import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
 import User from '#models/user'
-import string from '@adonisjs/core/helpers/string'
+import PostTranslation from '#models/post_translation'
 
 export default class Post extends BaseModel {
   @column({ isPrimary: true })
   declare id: number
-
-  @column()
-  declare title: string
-
-  @column()
-  declare slug: string
-
-  @column()
-  declare content: string
-
-  @column()
-  declare excerpt: string | null
 
   @column()
   declare coverImage: string | null
@@ -27,9 +15,14 @@ export default class Post extends BaseModel {
   declare published: boolean
 
   // Compteur de vues brut (cf. migration). Incrémenté pour chaque lecteur, sans
-  // donnée personnelle ; l'attribution détaillée passe par l'analytics (page_views).
+  // donnée personnelle ; partagé entre toutes les traductions de l'article.
   @column()
   declare viewCount: number
+
+  // Langue principale de l'article : sert de fallback quand la locale demandée
+  // n'a pas de traduction.
+  @column()
+  declare defaultLocale: string
 
   @column.dateTime()
   declare publishedAt: DateTime | null
@@ -40,28 +33,41 @@ export default class Post extends BaseModel {
   @belongsTo(() => User)
   declare author: BelongsTo<typeof User>
 
+  @hasMany(() => PostTranslation)
+  declare translations: HasMany<typeof PostTranslation>
+
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime
 
-  @beforeCreate()
-  static async generateSlug(post: Post) {
-    // Slugifie soit le slug fourni (admin), soit le titre. `strict` retire les
-    // caractères non URL-safe (apostrophes, deux-points, parenthèses, « ? »…)
-    // qui sinon finissent tels quels dans l'URL publique.
-    const source = post.slug || post.title
-    if (!source) return
+  /**
+   * Résout le contenu pour une locale : traduction demandée, sinon langue
+   * principale, sinon première disponible. `translations` doit être préchargé.
+   */
+  forLocale(locale: string) {
+    const translations = this.translations ?? []
+    const wanted =
+      translations.find((t) => t.locale === locale) ??
+      translations.find((t) => t.locale === this.defaultLocale) ??
+      translations[0]
 
-    let slug = string.slug(source, { lower: true, strict: true }) || `post-${Date.now()}`
-
-    // Vérifier si le slug existe déjà et ajouter un suffixe si nécessaire
-    const existingPost = await Post.query().where('slug', slug).first()
-    if (existingPost) {
-      slug = `${slug}-${Date.now()}`
+    return {
+      title: wanted?.title ?? '',
+      slug: wanted?.slug ?? '',
+      content: wanted?.content ?? '',
+      excerpt: wanted?.excerpt ?? null,
+      localeUsed: wanted?.locale ?? this.defaultLocale,
     }
+  }
 
-    post.slug = slug
+  /** Map locale → slug des traductions existantes (préchargées). */
+  slugsByLocale(): Record<string, string> {
+    const slugs: Record<string, string> = {}
+    for (const translation of this.translations ?? []) {
+      slugs[translation.locale] = translation.slug
+    }
+    return slugs
   }
 }

--- a/backend/app/models/post_translation.ts
+++ b/backend/app/models/post_translation.ts
@@ -1,0 +1,36 @@
+import { DateTime } from 'luxon'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import Post from '#models/post'
+
+export default class PostTranslation extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare postId: number
+
+  @column()
+  declare locale: string
+
+  @column()
+  declare title: string
+
+  @column()
+  declare slug: string
+
+  @column()
+  declare content: string
+
+  @column()
+  declare excerpt: string | null
+
+  @belongsTo(() => Post)
+  declare post: BelongsTo<typeof Post>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/backend/app/services/slug_service.ts
+++ b/backend/app/services/slug_service.ts
@@ -1,0 +1,24 @@
+import string from '@adonisjs/core/helpers/string'
+import PostTranslation from '#models/post_translation'
+
+export class SlugService {
+  /**
+   * Génère un slug URL-safe unique pour une locale. Déduplique contre les
+   * traductions de la même langue (les collisions entre langues sont permises),
+   * en ignorant optionnellement une traduction (utile en mise à jour).
+   */
+  static async uniqueSlug(locale: string, source: string, ignoreId?: number): Promise<string> {
+    let slug = string.slug(source, { lower: true, strict: true }) || `post-${Date.now()}`
+
+    const query = PostTranslation.query().where('locale', locale).where('slug', slug)
+    if (ignoreId) {
+      query.whereNot('id', ignoreId)
+    }
+    const existing = await query.first()
+    if (existing) {
+      slug = `${slug}-${Date.now()}`
+    }
+
+    return slug
+  }
+}

--- a/backend/app/validators/post.ts
+++ b/backend/app/validators/post.ts
@@ -1,22 +1,38 @@
 import vine from '@vinejs/vine'
 
+const localeEnum = vine.enum(['fr', 'en'])
+
+// Une traduction à la création : titre et contenu requis, slug/excerpt optionnels.
+const translationCreate = vine.object({
+  locale: localeEnum,
+  title: vine.string().minLength(3).maxLength(255),
+  slug: vine.string().minLength(3).maxLength(255).optional(),
+  content: vine.string().minLength(10),
+  excerpt: vine.string().maxLength(500).optional(),
+})
+
+// À la mise à jour, chaque entrée est un upsert partiel ; seule `locale` est requise.
+const translationUpdate = vine.object({
+  locale: localeEnum,
+  title: vine.string().minLength(3).maxLength(255).optional(),
+  slug: vine.string().minLength(3).maxLength(255).optional(),
+  content: vine.string().minLength(10).optional(),
+  excerpt: vine.string().maxLength(500).optional(),
+})
+
 export const CreatePostValidator = vine.compile(
   vine.object({
-    title: vine.string().minLength(3).maxLength(255),
-    slug: vine.string().minLength(3).maxLength(255).optional(),
-    content: vine.string().minLength(10),
-    excerpt: vine.string().maxLength(500).optional(),
+    defaultLocale: localeEnum,
     coverImage: vine.string().maxLength(500).optional(),
+    translations: vine.array(translationCreate).minLength(1),
   })
 )
 
 export const UpdatePostValidator = vine.compile(
   vine.object({
-    title: vine.string().minLength(3).maxLength(255).optional(),
-    slug: vine.string().minLength(3).maxLength(255).optional(),
-    content: vine.string().minLength(10).optional(),
-    excerpt: vine.string().maxLength(500).optional(),
+    defaultLocale: localeEnum.optional(),
     coverImage: vine.string().maxLength(500).optional(),
+    translations: vine.array(translationUpdate).optional(),
   })
 )
 

--- a/backend/database/migrations/1782508569959_add_post_translations_and_default_locale.ts
+++ b/backend/database/migrations/1782508569959_add_post_translations_and_default_locale.ts
@@ -1,0 +1,81 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'post_translations'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table
+        .integer('post_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('posts')
+        .onDelete('CASCADE')
+      table.string('locale', 5).notNullable()
+      table.string('title', 255).notNullable()
+      table.string('slug', 255).notNullable()
+      table.text('content', 'longtext').notNullable()
+      table.text('excerpt').nullable()
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+
+      // Une seule traduction par (article, langue) ; slug unique par langue.
+      // L'unique (locale, slug) sert aussi d'index pour le lookup public.
+      table.unique(['post_id', 'locale'])
+      table.unique(['locale', 'slug'])
+    })
+
+    // Langue principale de l'article, utilisée en fallback quand la traduction
+    // demandée n'existe pas. Tous les articles existants sont en anglais.
+    this.schema.alterTable('posts', (table) => {
+      table.string('default_locale', 5).notNullable().defaultTo('en')
+    })
+
+    // Recopier le contenu existant en traduction 'en' AVANT de supprimer les
+    // colonnes sources (l'ordre des deferred suit celui de déclaration).
+    this.defer(async (db) => {
+      await db.rawQuery(
+        `insert into post_translations (post_id, locale, title, slug, content, excerpt, created_at, updated_at)
+         select id, 'en', title, slug, content, excerpt, created_at, updated_at from posts`
+      )
+    })
+
+    // Le texte vit désormais dans post_translations. Sous PostgreSQL, supprimer
+    // la colonne `slug` retire automatiquement sa contrainte unique
+    // (`posts_slug_unique`), pas besoin d'un dropUnique explicite.
+    this.schema.alterTable('posts', (table) => {
+      table.dropColumn('title')
+      table.dropColumn('slug')
+      table.dropColumn('content')
+      table.dropColumn('excerpt')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable('posts', (table) => {
+      table.string('title', 255).nullable()
+      table.string('slug', 255).nullable()
+      table.text('content', 'longtext').nullable()
+      table.text('excerpt').nullable()
+    })
+
+    // Restaurer le texte depuis la traduction de la langue principale.
+    this.defer(async (db) => {
+      await db.rawQuery(
+        `update posts p
+         set title = t.title, slug = t.slug, content = t.content, excerpt = t.excerpt
+         from post_translations t
+         where t.post_id = p.id and t.locale = p.default_locale`
+      )
+    })
+
+    this.schema.alterTable('posts', (table) => {
+      table.dropColumn('default_locale')
+    })
+
+    this.schema.dropTable('post_translations')
+  }
+}

--- a/backend/database/schema.ts
+++ b/backend/database/schema.ts
@@ -202,25 +202,48 @@ export class PageViewSchema extends BaseModel {
   declare visitorId: number
 }
 
-export class PostSchema extends BaseModel {
+export class PostFeedbackSchema extends BaseModel {
+  static $columns = [
+    'createdAt',
+    'helpful',
+    'id',
+    'postId',
+    'updatedAt',
+    'userId',
+    'visitorId',
+  ] as const
+  $columns = PostFeedbackSchema.$columns
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime | null
+  @column()
+  declare helpful: boolean
+  @column({ isPrimary: true })
+  declare id: number
+  @column()
+  declare postId: number
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime | null
+  @column()
+  declare userId: number | null
+  @column()
+  declare visitorId: string
+}
+
+export class PostTranslationSchema extends BaseModel {
   static $columns = [
     'content',
-    'coverImage',
     'createdAt',
     'excerpt',
     'id',
-    'published',
-    'publishedAt',
+    'locale',
+    'postId',
     'slug',
     'title',
     'updatedAt',
-    'userId',
   ] as const
-  $columns = PostSchema.$columns
+  $columns = PostTranslationSchema.$columns
   @column()
   declare content: string
-  @column()
-  declare coverImage: string | null
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime | null
   @column()
@@ -228,17 +251,48 @@ export class PostSchema extends BaseModel {
   @column({ isPrimary: true })
   declare id: number
   @column()
-  declare published: boolean | null
-  @column.dateTime()
-  declare publishedAt: DateTime | null
+  declare locale: string
+  @column()
+  declare postId: number
   @column()
   declare slug: string
   @column()
   declare title: string
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime | null
+}
+
+export class PostSchema extends BaseModel {
+  static $columns = [
+    'coverImage',
+    'createdAt',
+    'defaultLocale',
+    'id',
+    'published',
+    'publishedAt',
+    'updatedAt',
+    'userId',
+    'viewCount',
+  ] as const
+  $columns = PostSchema.$columns
+  @column()
+  declare coverImage: string | null
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime | null
+  @column()
+  declare defaultLocale: string
+  @column({ isPrimary: true })
+  declare id: number
+  @column()
+  declare published: boolean | null
+  @column.dateTime()
+  declare publishedAt: DateTime | null
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime | null
   @column()
   declare userId: number
+  @column()
+  declare viewCount: number
 }
 
 export class RateLimitSchema extends BaseModel {
@@ -351,6 +405,7 @@ export class ServerSchema extends BaseModel {
     'categoryId',
     'createdAt',
     'faviconHash',
+    'hostDomain',
     'id',
     'imageUrl',
     'lastMaxCount',
@@ -380,6 +435,8 @@ export class ServerSchema extends BaseModel {
   declare createdAt: DateTime | null
   @column()
   declare faviconHash: string | null
+  @column()
+  declare hostDomain: string | null
   @column({ isPrimary: true })
   declare id: number
   @column()
@@ -418,6 +475,36 @@ export class ServerSchema extends BaseModel {
   declare version: string | null
   @column()
   declare website: string | null
+}
+
+export class TrafficDailySchema extends BaseModel {
+  static $columns = [
+    'countries',
+    'createdAt',
+    'date',
+    'httpErrors',
+    'httpRequests',
+    'id',
+    'uniqueVisitors',
+    'updatedAt',
+  ] as const
+  $columns = TrafficDailySchema.$columns
+  @column()
+  declare countries: any
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+  @column.date()
+  declare date: DateTime
+  @column()
+  declare httpErrors: bigint | number
+  @column()
+  declare httpRequests: bigint | number
+  @column({ isPrimary: true })
+  declare id: number
+  @column()
+  declare uniqueVisitors: number
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
 }
 
 export class UserSchema extends BaseModel {

--- a/backend/resources/lang/en/messages.json
+++ b/backend/resources/lang/en/messages.json
@@ -32,6 +32,7 @@
     "unauthorized": "Unauthorized",
     "writerRequired": "Access denied. Writer privileges required.",
     "notFound": "Post not found",
+    "missingDefaultTranslation": "A translation in the primary language is required.",
     "updateOwnOnly": "Access denied. You can only update your own posts.",
     "deleteOwnOnly": "Access denied. You can only delete your own posts.",
     "publishOwnOnly": "Access denied. You can only publish your own posts.",

--- a/backend/resources/lang/fr/messages.json
+++ b/backend/resources/lang/fr/messages.json
@@ -32,6 +32,7 @@
     "unauthorized": "Non autorisé",
     "writerRequired": "Accès refusé. Privilèges de rédacteur requis.",
     "notFound": "Article introuvable",
+    "missingDefaultTranslation": "Une traduction dans la langue principale est requise.",
     "updateOwnOnly": "Accès refusé. Vous ne pouvez modifier que vos propres articles.",
     "deleteOwnOnly": "Accès refusé. Vous ne pouvez supprimer que vos propres articles.",
     "publishOwnOnly": "Accès refusé. Vous ne pouvez publier que vos propres articles.",

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -216,6 +216,9 @@ router
         router
           .get('posts/:id/stats', '#controllers/posts_controller.adminStats')
           .use([throttleLight('admin.posts.stats', 30), NO_STORE])
+        router
+          .get('posts/:id', '#controllers/posts_controller.adminShow')
+          .use(throttleLight('admin.posts.show', 30))
 
         // Placeholders preview (writers and admins)
         router

--- a/frontend/messages/en/admin.json
+++ b/frontend/messages/en/admin.json
@@ -118,6 +118,9 @@
     "slugInputPlaceholder": "auto-from-title",
     "summary": "Summary (optional)",
     "summaryPlaceholder": "A short description for the article card...",
+    "primaryLanguage": "Primary language",
+    "primaryLanguageHint": "The language readers fall back to when a translation is missing.",
+    "primaryRequired": "Please fill in the title and content of the primary language.",
     "cancel": "Cancel"
   },
   "posts": {

--- a/frontend/messages/fr/admin.json
+++ b/frontend/messages/fr/admin.json
@@ -118,6 +118,9 @@
     "slugInputPlaceholder": "auto-depuis-le-titre",
     "summary": "Résumé (optionnel)",
     "summaryPlaceholder": "Une courte description pour la carte de l'article...",
+    "primaryLanguage": "Langue principale",
+    "primaryLanguageHint": "La langue affichée en secours lorsqu'une traduction est absente.",
+    "primaryRequired": "Veuillez renseigner le titre et le contenu de la langue principale.",
     "cancel": "Annuler"
   },
   "posts": {

--- a/frontend/src/app/[locale]/(pages)/admin/posts/[id]/edit/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/admin/posts/[id]/edit/page.tsx
@@ -2,10 +2,11 @@
 
 import { AdminBackLink } from "@/components/admin/admin-back-link";
 import { AdminLoadingState, AdminMessageState } from "@/components/admin/admin-states";
-import { PostForm, PostFormValues } from "@/components/admin/post-form";
+import { LocaleFields, PostForm, PostFormValues } from "@/components/admin/post-form";
 import { useAuth } from "@/contexts/auth";
-import { getAdminPosts, updatePost } from "@/http/post";
-import { Post } from "@/types/post";
+import { getAdminPost, updatePost } from "@/http/post";
+import { emptyPostFormValues, hasPrimaryContent, postFormValuesFromAdmin, slugify, toUpdateInput } from "@/lib/post-form";
+import { AdminPost, PostLocale } from "@/types/post";
 import { useParams } from "next/navigation";
 import { useRouter } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
@@ -20,12 +21,8 @@ const EditPostPage = () => {
   const idParam = Array.isArray(params.id) ? params.id[0] : params.id;
   const postId = Number.parseInt(idParam ?? "");
 
-  const [post, setPost] = useState<Post | null>(null);
-  const [title, setTitle] = useState("");
-  const [slug, setSlug] = useState("");
-  const [content, setContent] = useState("");
-  const [excerpt, setExcerpt] = useState("");
-  const [coverImage, setCoverImage] = useState("");
+  const [post, setPost] = useState<AdminPost | null>(null);
+  const [values, setValues] = useState<PostFormValues>(() => emptyPostFormValues("en"));
   const [loading, setLoading] = useState(false);
   const [fetching, setFetching] = useState(true);
 
@@ -35,16 +32,9 @@ const EditPostPage = () => {
     const fetchPost = async () => {
       try {
         setFetching(true);
-        const response = await getAdminPosts(token, 1, 100);
-        const foundPost = response.data.find((p) => p.id === postId);
-        if (foundPost) {
-          setPost(foundPost);
-          setTitle(foundPost.title);
-          setSlug(foundPost.slug);
-          setContent(foundPost.content);
-          setExcerpt(foundPost.excerpt || "");
-          setCoverImage(foundPost.coverImage || "");
-        }
+        const found = await getAdminPost(postId, token);
+        setPost(found);
+        setValues(postFormValuesFromAdmin(found));
       } catch (error) {
         console.error("Failed to fetch post:", error);
       } finally {
@@ -75,43 +65,45 @@ const EditPostPage = () => {
 
   if (!post) {
     return (
-      <AdminMessageState
-        title={t("posts.notFoundTitle")}
-        description={t("posts.notFoundDescription")}
-      >
+      <AdminMessageState title={t("posts.notFoundTitle")} description={t("posts.notFoundDescription")}>
         <AdminBackLink href="/admin/posts" label={t("posts.backToArticles")} />
       </AdminMessageState>
     );
   }
 
-  const handleField = <K extends keyof PostFormValues>(field: K, value: PostFormValues[K]) => {
-    const setters: Record<keyof PostFormValues, (v: string) => void> = {
-      title: setTitle,
-      slug: setSlug,
-      excerpt: setExcerpt,
-      coverImage: setCoverImage,
-      content: setContent,
-    };
-    setters[field](value);
+  const onLocaleField = <K extends keyof LocaleFields>(locale: PostLocale, field: K, value: LocaleFields[K]) => {
+    setValues((prev) => ({
+      ...prev,
+      translations: { ...prev.translations, [locale]: { ...prev.translations[locale], [field]: value } },
+    }));
+  };
+
+  const onSharedField = (field: "defaultLocale" | "coverImage", value: string) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const onTitleBlur = (locale: PostLocale) => {
+    setValues((prev) => {
+      const fields = prev.translations[locale];
+      if (!fields.title || fields.slug) return prev;
+      return {
+        ...prev,
+        translations: { ...prev.translations, [locale]: { ...fields, slug: slugify(fields.title) } },
+      };
+    });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!token) return;
+    if (!hasPrimaryContent(values)) {
+      alert(t("postForm.primaryRequired"));
+      return;
+    }
 
     try {
       setLoading(true);
-      await updatePost(
-        postId,
-        {
-          title,
-          slug,
-          content,
-          excerpt: excerpt || undefined,
-          coverImage: coverImage || undefined,
-        },
-        token
-      );
+      await updatePost(postId, toUpdateInput(values), token);
       router.push("/admin/posts");
     } catch (error) {
       console.error("Failed to update post:", error);
@@ -131,8 +123,10 @@ const EditPostPage = () => {
       </div>
 
       <PostForm
-        values={{ title, slug, excerpt, coverImage, content }}
-        onField={handleField}
+        values={values}
+        onLocaleField={onLocaleField}
+        onSharedField={onSharedField}
+        onTitleBlur={onTitleBlur}
         onSubmit={handleSubmit}
         submitting={loading}
         submitLabel={loading ? t("posts.updating") : t("posts.updateSubmit")}

--- a/frontend/src/app/[locale]/(pages)/admin/posts/new/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/admin/posts/new/page.tsx
@@ -2,10 +2,12 @@
 
 import { AdminBackLink } from "@/components/admin/admin-back-link";
 import { AdminLoadingState, AdminMessageState } from "@/components/admin/admin-states";
-import { PostForm, PostFormValues } from "@/components/admin/post-form";
+import { LocaleFields, PostForm, PostFormValues } from "@/components/admin/post-form";
 import { useAuth } from "@/contexts/auth";
 import { createPost } from "@/http/post";
 import { useRouter } from "@/i18n/navigation";
+import { emptyPostFormValues, hasPrimaryContent, slugify, toCreateInput } from "@/lib/post-form";
+import { PostLocale } from "@/types/post";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
@@ -14,11 +16,7 @@ const NewPostPage = () => {
   const t = useTranslations("Admin");
   const token = getToken();
   const router = useRouter();
-  const [title, setTitle] = useState("");
-  const [slug, setSlug] = useState("");
-  const [content, setContent] = useState("");
-  const [excerpt, setExcerpt] = useState("");
-  const [coverImage, setCoverImage] = useState("");
+  const [values, setValues] = useState<PostFormValues>(() => emptyPostFormValues("en"));
   const [loading, setLoading] = useState(false);
 
   if (!user) {
@@ -35,43 +33,40 @@ const NewPostPage = () => {
     );
   }
 
-  const generateSlug = () => {
-    if (title) {
-      const newSlug = title
-        .toLowerCase()
-        .replaceAll(/[^a-z0-9]+/g, "-")
-        .replaceAll(/(^-|-$)+/g, "");
-      setSlug(newSlug);
-    }
+  const onLocaleField = <K extends keyof LocaleFields>(locale: PostLocale, field: K, value: LocaleFields[K]) => {
+    setValues((prev) => ({
+      ...prev,
+      translations: { ...prev.translations, [locale]: { ...prev.translations[locale], [field]: value } },
+    }));
   };
 
-  const handleField = <K extends keyof PostFormValues>(field: K, value: PostFormValues[K]) => {
-    const setters: Record<keyof PostFormValues, (v: string) => void> = {
-      title: setTitle,
-      slug: setSlug,
-      excerpt: setExcerpt,
-      coverImage: setCoverImage,
-      content: setContent,
-    };
-    setters[field](value);
+  const onSharedField = (field: "defaultLocale" | "coverImage", value: string) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+  };
+
+  // Auto-fill the slug from the title, but never clobber a manually edited one.
+  const onTitleBlur = (locale: PostLocale) => {
+    setValues((prev) => {
+      const fields = prev.translations[locale];
+      if (!fields.title || fields.slug) return prev;
+      return {
+        ...prev,
+        translations: { ...prev.translations, [locale]: { ...fields, slug: slugify(fields.title) } },
+      };
+    });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!token) return;
+    if (!hasPrimaryContent(values)) {
+      alert(t("postForm.primaryRequired"));
+      return;
+    }
 
     try {
       setLoading(true);
-      await createPost(
-        {
-          title,
-          slug: slug || undefined,
-          content,
-          excerpt: excerpt || undefined,
-          coverImage: coverImage || undefined,
-        },
-        token
-      );
+      await createPost(toCreateInput(values), token);
       router.push("/admin/posts");
     } catch (error) {
       console.error("Failed to create post:", error);
@@ -91,9 +86,10 @@ const NewPostPage = () => {
       </div>
 
       <PostForm
-        values={{ title, slug, excerpt, coverImage, content }}
-        onField={handleField}
-        onTitleBlur={generateSlug}
+        values={values}
+        onLocaleField={onLocaleField}
+        onSharedField={onSharedField}
+        onTitleBlur={onTitleBlur}
         onSubmit={handleSubmit}
         submitting={loading}
         submitLabel={loading ? t("posts.publishing") : t("posts.publishSubmit")}

--- a/frontend/src/app/[locale]/(pages)/blog/[slug]/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/blog/[slug]/page.tsx
@@ -13,15 +13,17 @@ import ArticleBody from "@/components/blog/article-body";
 import ArticleFeedback from "@/components/blog/article-feedback";
 import ArticleViewTracker from "@/components/blog/article-view-tracker";
 import { resolveAssetUrl } from "@/lib/domain";
-import { buildAlternates, getDomainConfig } from "@/lib/domain-server";
+import { buildAlternatesForSlugs, getDomainConfig, getOpenGraphLocales } from "@/lib/domain-server";
 import { renderMarkdown } from "@/lib/markdown";
+import { PostLocale } from "@/types/post";
 
 // ISR — chaque page d'article est rebuild en arrière-plan toutes les 10 minutes (P.4.3)
 export const revalidate = 600;
 
 // generateMetadata et le composant de page demandent le même article : on
-// mémoïse l'appel sur la durée de la requête pour ne taper le backend qu'une fois.
-const loadPost = cache(getPostBySlug);
+// mémoïse l'appel sur la durée de la requête. La locale fait partie de la clé de
+// cache, sinon le contenu fallback d'une locale fuiterait sur une autre.
+const loadPost = cache((slug: string, locale: PostLocale) => getPostBySlug(slug, locale));
 
 type Props = {
   params: Promise<{ locale: string; slug: string }>;
@@ -33,9 +35,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const t = await getTranslations({ locale, namespace: "Blog" });
 
   try {
-    const post = await loadPost(slug);
+    const post = await loadPost(slug, locale as PostLocale);
 
-    const { canonical, languages } = buildAlternates(locale, `/blog/${post.slug}`);
+    const { canonical, languages } = buildAlternatesForSlugs(locale, post.slugs);
     // Fall back to the site OG image so cover-less posts still get a social card.
     const image = post.coverImage
       ? resolveAssetUrl(post.coverImage)
@@ -56,6 +58,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         description: post.excerpt || post.title,
         type: "article",
         url: canonical,
+        // Reflects the language actually rendered (fallback-aware).
+        locale: getOpenGraphLocales(post.localeUsed).locale,
         publishedTime: post.publishedAt?.toString(),
         modifiedTime: post.updatedAt?.toString(),
         authors: [post.author.username],
@@ -82,16 +86,16 @@ export default async function BlogPostPage({ params }: Readonly<Props>) {
   const t = await getTranslations({ locale, namespace: "Blog" });
 
   try {
-    const post = await loadPost(slug);
+    const post = await loadPost(slug, locale as PostLocale);
 
     return (
       <div className="min-h-screen animate-in fade-in slide-in-from-bottom-4 duration-500 pb-20">
         {/* Records a best-effort, consent-exempt view once per session. */}
         <ArticleViewTracker slug={post.slug} />
 
-        {/* Structured Data for SEO */}
+        {/* Structured Data for SEO — inLanguage reflects the rendered language. */}
         <BlogPostStructuredData
-          locale={locale}
+          locale={post.localeUsed}
           post={{
             id: post.id,
             title: post.title,

--- a/frontend/src/app/[locale]/(pages)/blog/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/blog/page.tsx
@@ -1,6 +1,7 @@
 import PostCard from "@/components/blog/post-card";
 import { Button } from "@/components/ui/button";
 import { getPosts } from "@/http/post";
+import { PostLocale } from "@/types/post";
 import { buildAlternates, getDomainConfig } from "@/lib/domain-server";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Metadata } from "next";
@@ -45,7 +46,7 @@ export default async function BlogPage({ params, searchParams }: Readonly<Props>
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "Blog" });
   const page = parsePage((await searchParams).page);
-  const posts = await getPosts(page, PAGE_SIZE);
+  const posts = await getPosts(page, PAGE_SIZE, locale as PostLocale);
   const articles = posts.data;
   const { currentPage, lastPage } = posts.meta;
 

--- a/frontend/src/app/feed.xml/route.ts
+++ b/frontend/src/app/feed.xml/route.ts
@@ -25,9 +25,9 @@ function escapeXml(value: string): string {
     .replace(/'/g, "&apos;");
 }
 
-async function getRecentPosts(apiUrl: string): Promise<FeedPost[]> {
+async function getRecentPosts(apiUrl: string, locale: string): Promise<FeedPost[]> {
   try {
-    const response = await fetch(`${apiUrl}/posts?page=1&limit=50`, {
+    const response = await fetch(`${apiUrl}/posts?page=1&limit=50&locale=${locale}`, {
       next: { revalidate: 3600 },
     });
 
@@ -43,7 +43,9 @@ async function getRecentPosts(apiUrl: string): Promise<FeedPost[]> {
 
 export async function GET() {
   const { baseUrl, apiUrl } = await getDomainConfig();
-  const posts = await getRecentPosts(apiUrl);
+  // .fr serves the French feed, .com the English one.
+  const domainLocale = baseUrl.includes("minecraft-stats.fr") ? "fr" : "en";
+  const posts = await getRecentPosts(apiUrl, domainLocale);
 
   const items = posts
     .map((post) => {
@@ -65,7 +67,7 @@ export async function GET() {
     <title>Minecraft Stats Blog</title>
     <link>${baseUrl}/blog</link>
     <description>Latest news, server spotlights, and development updates.</description>
-    <language>en</language>
+    <language>${domainLocale}</language>
     <atom:link href="${baseUrl}/feed.xml" rel="self" type="application/rss+xml" />
 ${items}
   </channel>

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import { MetadataRoute } from 'next';
-import { alternateLanguages, getDomainConfig } from '@/lib/domain-server';
+import { alternateLanguages, getDomainConfig, sitemapLanguagesForSlugs } from '@/lib/domain-server';
 
 interface Server {
   id: number;
@@ -13,6 +13,7 @@ interface ServerListItem {
 
 interface Post {
   slug: string;
+  slugs: Record<string, string>;
   publishedAt: string | null;
   updatedAt: string;
 }
@@ -45,15 +46,16 @@ async function getAllServers(apiUrl: string): Promise<Server[]> {
   }
 }
 
-async function getAllPosts(apiUrl: string): Promise<Post[]> {
+async function getAllPosts(apiUrl: string, locale: string): Promise<Post[]> {
   try {
     const posts: Post[] = [];
     let page = 1;
     let lastPage = 1;
 
-    // `/posts` only returns published posts; paginate through every page.
+    // `/posts` only returns published posts; paginate through every page. The
+    // locale resolves each post's primary slug for this domain's URLs.
     do {
-      const response = await fetch(`${apiUrl}/posts?page=${page}&limit=100`, {
+      const response = await fetch(`${apiUrl}/posts?page=${page}&limit=100&locale=${locale}`, {
         next: { revalidate: 3600 },
       });
 
@@ -77,7 +79,12 @@ async function getAllPosts(apiUrl: string): Promise<Post[]> {
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const { baseUrl, apiUrl } = await getDomainConfig();
-  const [servers, posts] = await Promise.all([getAllServers(apiUrl), getAllPosts(apiUrl)]);
+  // Per-domain sitemap: .fr lists French URLs, .com English ones.
+  const domainLocale = baseUrl.includes('minecraft-stats.fr') ? 'fr' : 'en';
+  const [servers, posts] = await Promise.all([
+    getAllServers(apiUrl),
+    getAllPosts(apiUrl, domainLocale),
+  ]);
 
   // Static routes (path is locale-free; alternates point at each locale's home domain)
   const routes: MetadataRoute.Sitemap = [
@@ -117,7 +124,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     lastModified: new Date(post.updatedAt || post.publishedAt || Date.now()),
     changeFrequency: 'weekly' as const,
     priority: 0.6,
-    alternates: { languages: alternateLanguages(`/blog/${post.slug}`) },
+    // Per-locale slugs: advertise only the translations that exist.
+    alternates: { languages: sitemapLanguagesForSlugs(post.slugs) },
   }));
 
   // Dynamic server routes

--- a/frontend/src/components/admin/post-form.tsx
+++ b/frontend/src/components/admin/post-form.tsx
@@ -6,105 +6,163 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Link } from "@/i18n/navigation";
+import { cn } from "@/lib/utils";
+import { PostLocale } from "@/types/post";
 import { useTranslations } from "next-intl";
+import { useState } from "react";
 
-export interface PostFormValues {
+export interface LocaleFields {
   title: string;
   slug: string;
   excerpt: string;
-  coverImage: string;
   content: string;
 }
 
+export interface PostFormValues {
+  defaultLocale: PostLocale;
+  /** Shared across every translation. */
+  coverImage: string;
+  translations: Record<PostLocale, LocaleFields>;
+}
+
+const LOCALES: PostLocale[] = ["en", "fr"];
+
 interface PostFormProps {
   values: PostFormValues;
-  onField: <K extends keyof PostFormValues>(field: K, value: PostFormValues[K]) => void;
-  onTitleBlur?: () => void;
+  onLocaleField: <K extends keyof LocaleFields>(locale: PostLocale, field: K, value: LocaleFields[K]) => void;
+  onSharedField: (field: "defaultLocale" | "coverImage", value: string) => void;
+  onTitleBlur?: (locale: PostLocale) => void;
   onSubmit: (e: React.FormEvent) => void;
   submitLabel: string;
   submitting: boolean;
 }
 
-/** Shared blog post create/edit form (title, slug, excerpt, cover, content editor). */
+/**
+ * Blog post create/edit form. Title/slug/excerpt/content are edited per locale
+ * via tabs; the cover image and primary language are shared. Only the primary
+ * language is required — secondary translations are optional.
+ */
 export const PostForm = ({
   values,
-  onField,
+  onLocaleField,
+  onSharedField,
   onTitleBlur,
   onSubmit,
   submitLabel,
   submitting,
 }: PostFormProps) => {
   const t = useTranslations("Admin");
+  const tCommon = useTranslations("Common");
+  const [active, setActive] = useState<PostLocale>(values.defaultLocale);
+
+  const fields = values.translations[active];
+  const isPrimary = active === values.defaultLocale;
 
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-5">
-    {/* Editor card: title, slug preview, Tiptap toolbar + body */}
-    <div className="overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-xs">
-      <div className="space-y-2 border-b border-border p-5">
-        <Input
-          type="text"
-          value={values.title}
-          onChange={(e) => onField("title", e.target.value)}
-          onBlur={onTitleBlur}
-          placeholder={t("postForm.titlePlaceholder")}
-          required
-          aria-label={t("postForm.titlePlaceholder")}
-          className="h-auto border-0 bg-transparent px-0 py-0 text-2xl font-extrabold tracking-tight focus-visible:ring-0 focus-visible:ring-offset-0 sm:text-3xl"
-        />
-        <div className="flex min-w-0 items-center gap-1 text-sm text-muted-foreground">
-          <span className="shrink-0">/blog/</span>
-          <span className="truncate font-mono text-accent">
-            {values.slug || t("postForm.slugPlaceholder")}
-          </span>
-        </div>
+      {/* Locale tabs (★ marks the primary/fallback language) */}
+      <div className="flex w-fit items-center gap-1 rounded-lg border border-border bg-card p-1">
+        {LOCALES.map((loc) => (
+          <button
+            key={loc}
+            type="button"
+            onClick={() => setActive(loc)}
+            className={cn(
+              "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+              active === loc
+                ? "bg-accent text-accent-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {tCommon(`languageName.${loc}`)}
+            {loc === values.defaultLocale && <span className="ml-1 text-xs opacity-70">★</span>}
+          </button>
+        ))}
       </div>
 
-      <TiptapEditor content={values.content} onChange={(content) => onField("content", content)} />
-    </div>
-
-    {/* Settings card: article details */}
-    <div className="rounded-xl border border-border bg-card text-card-foreground shadow-xs">
-      <div className="border-b border-border px-5 py-4">
-        <h2 className="text-base font-bold text-foreground">{t("postForm.details")}</h2>
-      </div>
-      <div className="grid grid-cols-1 gap-5 p-5">
-        <div className="space-y-2">
-          <Label>{t("postForm.slug")}</Label>
+      {/* Editor card: title, slug preview, content — for the active locale */}
+      <div className="overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-xs">
+        <div className="space-y-2 border-b border-border p-5">
           <Input
             type="text"
-            value={values.slug}
-            onChange={(e) => onField("slug", e.target.value)}
-            placeholder={t("postForm.slugInputPlaceholder")}
-            className="font-mono text-sm"
+            value={fields.title}
+            onChange={(e) => onLocaleField(active, "title", e.target.value)}
+            onBlur={() => onTitleBlur?.(active)}
+            placeholder={t("postForm.titlePlaceholder")}
+            required={isPrimary}
+            aria-label={t("postForm.titlePlaceholder")}
+            className="h-auto border-0 bg-transparent px-0 py-0 text-2xl font-extrabold tracking-tight focus-visible:ring-0 focus-visible:ring-offset-0 sm:text-3xl"
           />
+          <div className="flex min-w-0 items-center gap-1 text-sm text-muted-foreground">
+            <span className="shrink-0">/blog/</span>
+            <span className="truncate font-mono text-accent">
+              {fields.slug || t("postForm.slugPlaceholder")}
+            </span>
+          </div>
         </div>
 
-        <CoverImageField
-          value={values.coverImage}
-          onChange={(value) => onField("coverImage", value)}
-        />
+        <TiptapEditor content={fields.content} onChange={(content) => onLocaleField(active, "content", content)} />
+      </div>
 
-        <div className="space-y-2">
-          <Label>{t("postForm.summary")}</Label>
-          <textarea
-            value={values.excerpt}
-            onChange={(e) => onField("excerpt", e.target.value)}
-            rows={3}
-            className="flex w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-            placeholder={t("postForm.summaryPlaceholder")}
+      {/* Settings card: primary language, slug, cover, excerpt */}
+      <div className="rounded-xl border border-border bg-card text-card-foreground shadow-xs">
+        <div className="border-b border-border px-5 py-4">
+          <h2 className="text-base font-bold text-foreground">{t("postForm.details")}</h2>
+        </div>
+        <div className="grid grid-cols-1 gap-5 p-5">
+          <div className="space-y-2">
+            <Label>{t("postForm.primaryLanguage")}</Label>
+            <select
+              value={values.defaultLocale}
+              onChange={(e) => onSharedField("defaultLocale", e.target.value)}
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              {LOCALES.map((loc) => (
+                <option key={loc} value={loc}>
+                  {tCommon(`languageName.${loc}`)}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-muted-foreground">{t("postForm.primaryLanguageHint")}</p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t("postForm.slug")}</Label>
+            <Input
+              type="text"
+              value={fields.slug}
+              onChange={(e) => onLocaleField(active, "slug", e.target.value)}
+              placeholder={t("postForm.slugInputPlaceholder")}
+              className="font-mono text-sm"
+            />
+          </div>
+
+          <CoverImageField
+            value={values.coverImage}
+            onChange={(value) => onSharedField("coverImage", value)}
           />
+
+          <div className="space-y-2">
+            <Label>{t("postForm.summary")}</Label>
+            <textarea
+              value={fields.excerpt}
+              onChange={(e) => onLocaleField(active, "excerpt", e.target.value)}
+              rows={3}
+              className="flex w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              placeholder={t("postForm.summaryPlaceholder")}
+            />
+          </div>
         </div>
       </div>
-    </div>
 
-    <div className="flex items-center gap-3">
-      <Button type="submit" variant="accent" disabled={submitting}>
-        {submitLabel}
-      </Button>
-      <Button asChild variant="secondary">
-        <Link href="/admin/posts">{t("postForm.cancel")}</Link>
-      </Button>
-    </div>
-  </form>
+      <div className="flex items-center gap-3">
+        <Button type="submit" variant="accent" disabled={submitting}>
+          {submitLabel}
+        </Button>
+        <Button asChild variant="secondary">
+          <Link href="/admin/posts">{t("postForm.cancel")}</Link>
+        </Button>
+      </div>
+    </form>
   );
 };

--- a/frontend/src/http/post.ts
+++ b/frontend/src/http/post.ts
@@ -1,11 +1,20 @@
 import { getBaseUrl } from '@/app/_cheatcode'
-import { CreatePostInput, Post, PostStats, PostsListResponse, UpdatePostInput } from '@/types/post'
+import {
+  AdminPost,
+  AdminPostsListResponse,
+  CreatePostInput,
+  Post,
+  PostLocale,
+  PostStats,
+  PostsListResponse,
+  UpdatePostInput,
+} from '@/types/post'
 import { getErrorMessage } from './auth'
 
 // Public endpoints
 
-export const getPosts = async (page: number = 1, limit: number = 10) => {
-  const response = await fetch(`${getBaseUrl()}/posts?page=${page}&limit=${limit}`, {
+export const getPosts = async (page: number = 1, limit: number = 10, locale: PostLocale = 'en') => {
+  const response = await fetch(`${getBaseUrl()}/posts?page=${page}&limit=${limit}&locale=${locale}`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -37,8 +46,8 @@ export const resolvePlaceholders = async (placeholders: string[]) => {
   return response.json() as Promise<Record<string, string>>
 }
 
-export const getPostBySlug = async (slug: string) => {
-  const response = await fetch(`${getBaseUrl()}/posts/${slug}`, {
+export const getPostBySlug = async (slug: string, locale: PostLocale = 'en') => {
+  const response = await fetch(`${getBaseUrl()}/posts/${slug}?locale=${locale}`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -119,7 +128,24 @@ export const getAdminPosts = async (
     throw new Error(errorMessage)
   }
 
-  return response.json() as Promise<PostsListResponse>
+  return response.json() as Promise<AdminPostsListResponse>
+}
+
+/** Single post with all its translations, for the edit screen. */
+export const getAdminPost = async (postId: number, token: string) => {
+  const response = await fetch(`${getBaseUrl()}/admin/posts/${postId}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  })
+
+  if (!response.ok) {
+    const errorMessage = await getErrorMessage(response)
+    throw new Error(errorMessage)
+  }
+
+  return response.json() as Promise<AdminPost>
 }
 
 export const getAdminPostStats = async (postId: number, token: string) => {
@@ -153,7 +179,7 @@ export const createPost = async (data: CreatePostInput, token: string) => {
     throw new Error(errorMessage)
   }
 
-  return response.json() as Promise<Post>
+  return response.json() as Promise<AdminPost>
 }
 
 export const updatePost = async (postId: number, data: UpdatePostInput, token: string) => {
@@ -171,7 +197,7 @@ export const updatePost = async (postId: number, data: UpdatePostInput, token: s
     throw new Error(errorMessage)
   }
 
-  return response.json() as Promise<Post>
+  return response.json() as Promise<AdminPost>
 }
 
 export const deletePost = async (postId: number, token: string) => {

--- a/frontend/src/lib/domain-server.ts
+++ b/frontend/src/lib/domain-server.ts
@@ -121,6 +121,43 @@ export function buildAlternates(locale: string, path: string = ""): { canonical:
   };
 }
 
+/**
+ * hreflang map for a resource with a DIFFERENT slug per locale (blog posts).
+ * Only includes locales that actually have a translation, so we never advertise
+ * a phantom URL. `slugs` is the locale→slug map returned by the API.
+ */
+export function sitemapLanguagesForSlugs(
+  slugs: Record<string, string | undefined>,
+  prefix: string = "/blog"
+): Record<string, string> {
+  const languages: Record<string, string> = {};
+  for (const [locale, slug] of Object.entries(slugs)) {
+    if (slug) {
+      languages[locale] = `${LOCALE_HOME[locale] ?? LOCALE_HOME.en}${prefix}/${slug}`;
+    }
+  }
+  return languages;
+}
+
+/**
+ * Per-locale-slug variant of buildAlternates for blog posts. Advertises only the
+ * existing translations; x-default points at the English URL when present; the
+ * canonical is the current locale's URL, or the English/first one for a fallback
+ * render (locale without its own translation).
+ */
+export function buildAlternatesForSlugs(
+  locale: string,
+  slugs: Record<string, string | undefined>,
+  prefix: string = "/blog"
+): { canonical: string; languages: Record<string, string> } {
+  const languages = sitemapLanguagesForSlugs(slugs, prefix);
+  if (languages.en) {
+    languages["x-default"] = languages.en;
+  }
+  const canonical = languages[locale] ?? languages.en ?? Object.values(languages)[0] ?? LOCALE_HOME.en;
+  return { canonical, languages };
+}
+
 // OpenGraph wants the underscore form; our locale tokens are the short fr/en.
 const OG_LOCALE: Record<string, string> = { fr: "fr_FR", en: "en_US" };
 

--- a/frontend/src/lib/domain-server.ts
+++ b/frontend/src/lib/domain-server.ts
@@ -127,11 +127,12 @@ export function buildAlternates(locale: string, path: string = ""): { canonical:
  * a phantom URL. `slugs` is the locale→slug map returned by the API.
  */
 export function sitemapLanguagesForSlugs(
-  slugs: Record<string, string | undefined>,
+  slugs: Record<string, string | undefined> | undefined | null,
   prefix: string = "/blog"
 ): Record<string, string> {
   const languages: Record<string, string> = {};
-  for (const [locale, slug] of Object.entries(slugs)) {
+  // `slugs` can be absent (an API without translations yet, or a malformed post).
+  for (const [locale, slug] of Object.entries(slugs ?? {})) {
     if (slug) {
       languages[locale] = `${LOCALE_HOME[locale] ?? LOCALE_HOME.en}${prefix}/${slug}`;
     }

--- a/frontend/src/lib/post-form.ts
+++ b/frontend/src/lib/post-form.ts
@@ -1,0 +1,80 @@
+import type { LocaleFields, PostFormValues } from "@/components/admin/post-form";
+import type { AdminPost, CreatePostInput, PostLocale, PostTranslationInput } from "@/types/post";
+
+export const POST_LOCALES: PostLocale[] = ["en", "fr"];
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function emptyLocaleFields(): LocaleFields {
+  return { title: "", slug: "", excerpt: "", content: "" };
+}
+
+export function emptyPostFormValues(defaultLocale: PostLocale = "en"): PostFormValues {
+  return {
+    defaultLocale,
+    coverImage: "",
+    translations: { en: emptyLocaleFields(), fr: emptyLocaleFields() },
+  };
+}
+
+/** Hydrate the form from an admin post (edit screen). */
+export function postFormValuesFromAdmin(post: AdminPost): PostFormValues {
+  const translations = { en: emptyLocaleFields(), fr: emptyLocaleFields() };
+  for (const translation of post.translations) {
+    translations[translation.locale] = {
+      title: translation.title,
+      slug: translation.slug,
+      excerpt: translation.excerpt ?? "",
+      content: translation.content,
+    };
+  }
+  return { defaultLocale: post.defaultLocale, coverImage: post.coverImage ?? "", translations };
+}
+
+/**
+ * Builds the translation payload, keeping the primary language plus any secondary
+ * locale the editor actually filled in (title + content). Empty secondary tabs are
+ * dropped so we don't create blank translations.
+ */
+function buildTranslations(values: PostFormValues): PostTranslationInput[] {
+  return POST_LOCALES.flatMap((locale) => {
+    const fields = values.translations[locale];
+    const isPrimary = locale === values.defaultLocale;
+    if (!isPrimary && !(fields.title.trim() && fields.content.trim())) {
+      return [];
+    }
+    return [
+      {
+        locale,
+        title: fields.title,
+        slug: fields.slug || undefined,
+        content: fields.content,
+        excerpt: fields.excerpt || undefined,
+      },
+    ];
+  });
+}
+
+export function toCreateInput(values: PostFormValues): CreatePostInput {
+  return {
+    defaultLocale: values.defaultLocale,
+    coverImage: values.coverImage || undefined,
+    translations: buildTranslations(values),
+  };
+}
+
+/** The update payload mirrors create (translations are upserted server-side). */
+export function toUpdateInput(values: PostFormValues): CreatePostInput {
+  return toCreateInput(values);
+}
+
+/** Whether the primary-language translation has the required title + content. */
+export function hasPrimaryContent(values: PostFormValues): boolean {
+  const primary = values.translations[values.defaultLocale];
+  return Boolean(primary.title.trim() && primary.content.trim());
+}

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -1,7 +1,10 @@
 import { User } from './auth'
 
+export type PostLocale = 'fr' | 'en'
+
 export interface Post {
   id: number
+  /** Resolved for the requested locale (falls back to the post's primary language). */
   title: string
   slug: string
   content: string
@@ -10,10 +13,31 @@ export interface Post {
   published: boolean
   viewCount: number
   publishedAt: Date | null
+  /** Primary language of the post, used as fallback. */
+  defaultLocale: PostLocale
+  /** Language actually rendered after fallback resolution. */
+  localeUsed: PostLocale
+  /** Slug of each existing translation, keyed by locale (for hreflang/canonical). */
+  slugs: Partial<Record<PostLocale, string>>
   userId: number
   author: User
   createdAt: Date
   updatedAt: Date
+}
+
+/** Raw per-locale content, as edited in the admin form. */
+export interface PostTranslationContent {
+  locale: PostLocale
+  title: string
+  slug: string
+  content: string
+  excerpt: string | null
+}
+
+/** Admin view of a post: every translation + the locales it exists in. */
+export interface AdminPost extends Post {
+  availableLocales: PostLocale[]
+  translations: PostTranslationContent[]
 }
 
 /** A logged-in reader of an article, surfaced in the admin post-stats view. */
@@ -29,7 +53,7 @@ export interface PostStats {
   post: {
     id: number
     title: string
-    slug: string
+    slugs: Partial<Record<PostLocale, string>>
     viewCount: number
   }
   views: {
@@ -48,33 +72,44 @@ export interface PostStats {
   recentViewers: PostViewer[]
 }
 
-export interface CreatePostInput {
+export interface PostTranslationInput {
+  locale: PostLocale
   title: string
   slug?: string
   content: string
   excerpt?: string
+}
+
+export interface CreatePostInput {
+  defaultLocale: PostLocale
   coverImage?: string
+  translations: PostTranslationInput[]
 }
 
 export interface UpdatePostInput {
-  title?: string
-  slug?: string
-  content?: string
-  excerpt?: string
+  defaultLocale?: PostLocale
   coverImage?: string
+  translations?: PostTranslationInput[]
+}
+
+interface PaginationMeta {
+  total: number
+  perPage: number
+  currentPage: number
+  lastPage: number
+  firstPage: number
+  firstPageUrl: string
+  lastPageUrl: string
+  nextPageUrl: string | null
+  previousPageUrl: string | null
 }
 
 export interface PostsListResponse {
-  meta: {
-    total: number
-    perPage: number
-    currentPage: number
-    lastPage: number
-    firstPage: number
-    firstPageUrl: string
-    lastPageUrl: string
-    nextPageUrl: string | null
-    previousPageUrl: string | null
-  }
+  meta: PaginationMeta
   data: Post[]
+}
+
+export interface AdminPostsListResponse {
+  meta: PaginationMeta
+  data: AdminPost[]
 }


### PR DESCRIPTION
## Summary
Lets a blog post exist in several languages. Readers see the post in the active locale and fall back to its **primary language** when a translation is missing. Admins author translations from EN/FR tabs, and the SEO blog automation now generates every language. All existing posts are treated as English.

> ⚠️ Stacked on #209 (i18n routing) — this branch builds on it, so the diff against `staging` includes the i18n commits until #209 merges. Review the blog-specific commits (`feat(blog)…`, `docs(automation)…`, `fix(seo)…`).

## Changes
**Backend**
- Migration: normalized `post_translations` (title/slug/content/excerpt per locale, unique `(post_id, locale)` and `(locale, slug)`); `posts.default_locale`; backfills every existing post as `en`, then drops the text columns.
- `PostTranslation` model + `Post.forLocale()`/`slugsByLocale()`; `SlugService.uniqueSlug` dedupes per locale and runs on create **and** update.
- Controller resolves `?locale` with fallback and serializes resolved fields + `localeUsed` + per-locale `slugs`; `store`/`update` are transactional and upsert translations; new `GET /admin/posts/:id`; stats aggregate every per-locale slug path. Validators reshaped to a `translations[]` payload (primary-language translation required).

**Frontend**
- Types + http client carry the locale; `getAdminPost` for the editor; `AdminPost` exposes `translations` + `availableLocales`.
- Blog list/detail pass the locale; the detail `cache()` key includes it so fallback content never leaks across locales.
- `buildAlternatesForSlugs` builds hreflang/canonical from the per-locale slug map (only existing translations); sitemap + RSS go per domain locale; JSON-LD `inLanguage` uses the rendered language.
- `post-form` becomes EN/FR tabs with a shared cover image and a primary-language selector; new/edit pages driven by a small `lib/post-form` helper; new admin i18n keys.

**Automation**
- `automation/seo-blog` playbook updated to write natively in English, translate to French, and submit all translations in one draft via the new `translations[]` + `defaultLocale` payload.

## Testing
- Migration run + rollback on dev; 7 existing posts backfilled to `en`, columns dropped.
- API verified against the real DB: `/posts?locale=en|fr` (shape incl. `slugs`/`localeUsed`/`defaultLocale`), `show` by slug, **fallback** (`?locale=fr` → en content), 404.
- `next build` + `yarn lint` (frontend), `yarn typecheck` + `yarn lint` (backend) all green. Sitemap build hardened against an API without `slugs`.
- Not yet exercised at runtime: creating a bilingual post + serving a real FR page (needs admin OAuth login) — same code path as the verified EN case.

## Notes
- **Destructive migration** (drops the post text columns + the slug unique index): back up the DB before prod, and deploy backend + frontend together (all old code read `posts.slug`).
- DB-stored content stays single-language elsewhere; category names are not translated.
🤖 Generated with [Claude Code](https://claude.com/claude-code)