### PR TITLE
fix(seo): consolidate server URLs and drop dead pages from the index

### DIFF
--- a/frontend/src/app/[locale]/(pages)/account/my-servers/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/account/my-servers/page.tsx
@@ -7,6 +7,7 @@ import { Link } from "@/i18n/navigation";
 import { Icon } from "@iconify/react/dist/iconify.js";
 import { useAuth } from "@/contexts/auth";
 import { deleteServer, getMyServers, MyServerItem } from "@/http/server";
+import { serverPath } from "@/lib/server-url";
 import DashboardLayout from "@/components/account/dashboard-layout";
 import DashboardHero from "@/components/account/dashboard-hero";
 import DashboardStatTile from "@/components/account/dashboard-stat-tile";
@@ -136,7 +137,7 @@ const MyServersPage = () => {
                   <ServerImage imageUrl={server.imageUrl} name={server.name} className="h-10 w-10" />
                   <div className="min-w-0 flex-1">
                     <Link
-                      href={`/servers/${server.id}/${server.name}`}
+                      href={serverPath(server.id, server.name)}
                       className="block truncate text-sm font-semibold text-foreground transition-colors hover:text-accent"
                     >
                       {server.name}
@@ -155,7 +156,7 @@ const MyServersPage = () => {
                   </div>
                   <div className="flex items-center gap-1">
                     <Link
-                      href={`/servers/${server.id}/${server.name}`}
+                      href={serverPath(server.id, server.name)}
                       aria-label={t("myServers.view")}
                       title={t("myServers.viewTitle")}
                       className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"

--- a/frontend/src/app/[locale]/(pages)/admin/users/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/admin/users/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Badge, BadgeProps } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAuth } from "@/contexts/auth";
 import { AdminUserDetailResponse, getAdminUserDetail } from "@/http/user";
+import { serverPath } from "@/lib/server-url";
 import { RegistrationProvider } from "@/types/auth";
 import { Icon } from "@iconify/react/dist/iconify.js";
 import { Link } from "@/i18n/navigation";
@@ -274,7 +275,7 @@ const AdminUserDetailPage = () => {
                       <ServerImage imageUrl={server.imageUrl ?? ""} name={server.name} className="h-10 w-10" />
                       <div className="min-w-0 flex-1">
                         <Link
-                          href={`/servers/${server.id}/${server.name}`}
+                          href={serverPath(server.id, server.name)}
                           className="block truncate text-sm font-semibold text-foreground transition-colors hover:text-accent"
                         >
                           {server.name}
@@ -306,7 +307,7 @@ const AdminUserDetailPage = () => {
                         {formatDate(server.createdAt)}
                       </div>
                       <Link
-                        href={`/servers/${server.id}/${server.name}`}
+                        href={serverPath(server.id, server.name)}
                         aria-label={t("users.detail.viewServer")}
                         title={t("users.detail.view")}
                         className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"

--- a/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/layout.tsx
+++ b/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/layout.tsx
@@ -3,6 +3,8 @@ import { getLastStat } from "@/utils/stats";
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { buildAlternates, getDomainConfig, getOpenGraphLocales } from "@/lib/domain-server";
+import { isServerIndexable, serverPath } from "@/lib/server-url";
+import { redirect } from "@/i18n/navigation";
 
 // ISR — la metadata (OG, title, description) est rebuild toutes les 10 minutes
 // au lieu d'être re-fetched à chaque requête (P.4.3 ; remplace force-dynamic).
@@ -23,11 +25,9 @@ export const generateMetadata = async (props: {
     const languages = server.server.languages.map((l) => l.name).join(", ");
     const imageUrl = `${assetsBase}${server.server.imageUrl}.webp`;
 
-    // Create a clean slug for the canonical URL
-    const slug = server.server.name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/(^-|-$)/g, '');
+    // Dead servers (no successful ping for a month) are thin pages Google drops as
+    // "crawled, currently not indexed". Tell it explicitly rather than letting it guess.
+    const indexable = isServerIndexable(server.server.lastStatsAt);
 
     const title = t("meta.title", { name: server.server.name });
     const description = t("meta.description", {
@@ -39,7 +39,7 @@ export const generateMetadata = async (props: {
 
     const { canonical, languages: alternateLanguages } = buildAlternates(
       params.locale,
-      `/servers/${server.server.id}/${slug}`,
+      serverPath(server.server.id, server.server.name),
     );
     const og = getOpenGraphLocales(params.locale);
 
@@ -86,10 +86,10 @@ export const generateMetadata = async (props: {
         languages: alternateLanguages,
       },
       robots: {
-        index: true,
+        index: indexable,
         follow: true,
         googleBot: {
-          index: true,
+          index: indexable,
           follow: true,
           'max-video-preview': -1,
           'max-image-preview': 'large',
@@ -116,7 +116,33 @@ export const generateMetadata = async (props: {
   }
 };
 
-const Layout = ({ children }: { children: React.ReactNode }) => {
+const Layout = async ({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string; serverId: string; serverName?: string[] }>;
+}) => {
+  const { locale, serverId, serverName } = await params;
+
+  // Collapse every non-canonical spelling of a server URL (raw display name, wrong
+  // slug, missing slug) onto the canonical slug with a redirect, so Google stops
+  // bucketing the variants as "duplicate without user-selected canonical".
+  let canonicalPath: string | null = null;
+  try {
+    const { server } = await getServer(Number(serverId));
+    canonicalPath = serverPath(server.id, server.name);
+  } catch {
+    // Unknown/unreachable server — let the client page render its not-found state.
+  }
+
+  if (canonicalPath) {
+    const requestedPath = `/servers/${serverId}${serverName?.length ? `/${serverName.join("/")}` : ""}`;
+    if (requestedPath !== canonicalPath) {
+      redirect({ href: canonicalPath, locale });
+    }
+  }
+
   return <>{children}</>;
 };
 

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,14 +1,21 @@
 import { MetadataRoute } from 'next';
 import { buildAlternates, buildAlternatesForSlugs, getDomainConfig } from '@/lib/domain-server';
+import { isServerIndexable, serverPath } from '@/lib/server-url';
 
 interface Server {
   id: number;
   name: string;
   updatedAt: string;
+  lastStatsAt: string | null;
 }
 
 interface ServerListItem {
-  server: Server;
+  server: {
+    id: number;
+    name: string;
+    updatedAt: string;
+    lastStatsAt: string | null;
+  };
 }
 
 interface Post {
@@ -39,6 +46,7 @@ async function getAllServers(apiUrl: string): Promise<Server[]> {
       id: item.server.id,
       name: item.server.name,
       updatedAt: item.server.updatedAt,
+      lastStatsAt: item.server.lastStatsAt,
     }));
   } catch (error) {
     console.error('Error fetching servers for sitemap:', error);
@@ -143,21 +151,22 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     alternates: { languages: buildAlternatesForSlugs(domainLocale, post.slugs).languages },
   }));
 
-  // Dynamic server routes
-  const serverRoutes: MetadataRoute.Sitemap = servers.map((server) => {
-    const slug = server.name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/(^-|-$)/g, '');
+  // Dynamic server routes. Dead servers (no successful ping for SERVER_STALE_DAYS)
+  // are thin pages Google reports as "crawled, currently not indexed"; keeping them
+  // out of the sitemap concentrates crawl budget on live servers.
+  const serverRoutes: MetadataRoute.Sitemap = servers
+    .filter((server) => isServerIndexable(server.lastStatsAt))
+    .map((server) => {
+      const path = serverPath(server.id, server.name);
 
-    return {
-      url: `${baseUrl}/servers/${server.id}/${slug}`,
-      lastModified: new Date(server.updatedAt),
-      changeFrequency: 'daily' as const,
-      priority: 0.8,
-      alternates: { languages: buildAlternates(domainLocale, `/servers/${server.id}/${slug}`).languages },
-    };
-  });
+      return {
+        url: `${baseUrl}${path}`,
+        lastModified: new Date(server.updatedAt),
+        changeFrequency: 'daily' as const,
+        priority: 0.8,
+        alternates: { languages: buildAlternates(domainLocale, path).languages },
+      };
+    });
 
   return [...routes, ...postRoutes, ...serverRoutes];
 }

--- a/frontend/src/components/serveur/card/index.tsx
+++ b/frontend/src/components/serveur/card/index.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@/i18n/navigation";
+import { serverPath } from "@/lib/server-url";
 import { Category, Server, ServerGrowthStat, ServerStat } from "@/types/server";
 import ServerImage from "./server-image";
 import ServerInfo from "./server-info";
@@ -20,7 +21,7 @@ interface ServerCardProps {
 const ServerCard = ({ server, stats, categories, growthStat, isFull, showChart = true }: ServerCardProps) => {
   return (
     <Link
-      href={`/servers/${server.id}/${server.name}`}
+      href={serverPath(server.id, server.name)}
       className="group relative flex h-full w-full flex-col gap-3 rounded-lg border border-border bg-card p-4 text-card-foreground shadow-xs transition-all duration-150 ease-in-out hover:-translate-y-0.5 hover:border-accent/50 hover:shadow-md"
     >
       <ServerActions server={server} />

--- a/frontend/src/lib/server-url.ts
+++ b/frontend/src/lib/server-url.ts
@@ -1,0 +1,50 @@
+/**
+ * Canonical URL + indexing helpers for server pages.
+ *
+ * Every server must resolve to a single URL. Internal links used to point at
+ * `/servers/12/My Server` (the raw display name) while the canonical tag and the
+ * sitemap advertised `/servers/12/my-server` (a slug). Google treated the two as
+ * separate pages and dropped them as "duplicate without user-selected canonical".
+ * These helpers give links, the sitemap, the canonical tag and the slug redirect
+ * one shared definition so they always agree.
+ */
+
+/** Lowercase, hyphenated slug derived from a server's display name. */
+export function serverSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+/**
+ * Locale-free canonical path for a server. The slug segment is omitted when it
+ * would be empty (a name with no a-z0-9 characters), keeping a single valid URL.
+ */
+export function serverPath(id: number, name: string): string {
+  const slug = serverSlug(name);
+  return slug ? `/servers/${id}/${slug}` : `/servers/${id}`;
+}
+
+/**
+ * Days without a successful ping after which a server counts as dead. `lastStatsAt`
+ * only advances when a ping succeeds (failed pings record a null-count stat without
+ * moving it), so it is the truthful "last alive" signal.
+ */
+export const SERVER_STALE_DAYS = 30;
+
+/**
+ * Whether a server page is worth indexing. Dead servers — never pinged
+ * successfully, or silent for {@link SERVER_STALE_DAYS} — are thin pages Google
+ * reports as "crawled, currently not indexed". We keep them out of the sitemap and
+ * mark them noindex so crawl budget goes to live servers.
+ */
+export function isServerIndexable(
+  lastStatsAt: string | Date | null | undefined,
+  now: number = Date.now(),
+): boolean {
+  if (!lastStatsAt) return false;
+  const last = new Date(lastStatsAt).getTime();
+  if (Number.isNaN(last)) return false;
+  return now - last <= SERVER_STALE_DAYS * 24 * 60 * 60 * 1000;
+}

--- a/frontend/src/types/server.ts
+++ b/frontend/src/types/server.ts
@@ -23,6 +23,7 @@ export interface Server {
   user: User;
   createdAt: Date;
   lastOnlineAt: Date | null;
+  lastStatsAt: Date | null;
   lastPlayerCount: number | null;
   lastMaxCount: number | null;
   peakPlayerCount: number | null;


### PR DESCRIPTION
## Contexte

Le rapport Google Search Console de `minecraft-stats.fr` montre une **désindexation continue** sur 3 mois : les pages indexées passent de ~370 (30 mars) à ~95 (11 juin), pendant que les impressions chutent de ~170 à ~30/jour.

Deux postes critiques écrasent tout le reste :
- **338** pages « Explorées, actuellement non indexées » (contenu mince / faible valeur)
- **129** pages « En double sans URL canonique sélectionnée par l'utilisateur »

## Causes racines

**1. Les liens internes fabriquent des doublons.** Les cartes serveur (accueil, compte, admin) pointaient vers `/servers/<id>/<nom brut>` (ex. `/servers/610/Blitzmc`) alors que le sitemap et la balise canonical annoncent le slug `/servers/610/blitzmc`. Pour Google, deux URLs distinctes → doublons sans canonique honorée.

**2. Le sitemap annonce des serveurs morts.** L'API live renvoie 517 serveurs, dont ~95 sans ping réussi depuis +30 jours et ~28 jamais en ligne. Ces pages quasi vides sont exactement ce que Google classe « explorées, non indexées », et gaspillent le crawl budget.

## Changements

- **`src/lib/server-url.ts`** (nouveau) : helpers partagés `serverSlug` / `serverPath` / `isServerIndexable` pour que liens, sitemap, canonical et redirection s'accordent sur **une seule URL par serveur**.
- **Liens internes** (carte serveur, mes-serveurs, admin/users) : pointent désormais vers le slug canonique via `serverPath()`.
- **Redirection serveur-side** dans le layout serveur : toute URL non-canonique (nom brut, slug erroné ou absent) redirige vers le slug canonique, consolidant les doublons au niveau HTTP.
- **Sitemap** : les serveurs morts (>30 j sans ping réussi) sont exclus → le budget d'exploration se concentre sur les serveurs vivants.
- **`noindex`** sur les pages de serveurs morts : signal explicite à Google plutôt que de le laisser deviner. Auto-réparateur via l'ISR si un serveur revient en ligne.

Le critère « mort » repose sur `lastStatsAt` (>30 j), qui n'avance que sur un ping réussi : un serveur vide mais joignable reste indexable.

## Tests

⚠️ `tsc` / `lint` n'ont **pas** pu être exécutés localement : l'environnement de sandbox interrompt le téléchargement de gros binaires (sharp, next-swc) via le proxy, empêchant `yarn install` d'aboutir. Les changements sont calqués sur les patterns existants ; **merci de laisser la CI valider le typecheck/lint**.

## Effet attendu

- Disparition progressive des 129 doublons (consolidés par redirect + liens corrigés).
- Arrêt de l'hémorragie « explorées non indexées » après re-crawl du sitemap allégé.
- À faire après déploiement : **resoumettre le sitemap** dans Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017wgR6v8iBmYgtXKVLPE9Mz)_