### PR TITLE
fix(seo): redirect dotted-name server URLs and make slug redirects permanent

### DIFF
--- a/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/layout.tsx
+++ b/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/layout.tsx
@@ -4,7 +4,8 @@ import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { buildAlternates, getDomainConfig, getOpenGraphLocales } from "@/lib/domain-server";
 import { isServerIndexable, serverPath } from "@/lib/server-url";
-import { redirect } from "@/i18n/navigation";
+import { getPathname } from "@/i18n/navigation";
+import { permanentRedirect } from "next/navigation";
 
 // ISR — la metadata (OG, title, description) est rebuild toutes les 10 minutes
 // au lieu d'être re-fetched à chaque requête (P.4.3 ; remplace force-dynamic).
@@ -125,9 +126,11 @@ const Layout = async ({
 }) => {
   const { locale, serverId, serverName } = await params;
 
-  // Collapse every non-canonical spelling of a server URL (raw display name, wrong
-  // slug, missing slug) onto the canonical slug with a redirect, so Google stops
-  // bucketing the variants as "duplicate without user-selected canonical".
+  // The slug after the id is purely cosmetic — the page only reads serverId — so
+  // every spelling (raw display name, wrong slug, missing slug) serves identical
+  // content. Collapse them onto the canonical slug with a permanent (308) redirect
+  // so Google transfers signals and stops bucketing the variants as
+  // "duplicate without user-selected canonical".
   let canonicalPath: string | null = null;
   try {
     const { server } = await getServer(Number(serverId));
@@ -139,7 +142,8 @@ const Layout = async ({
   if (canonicalPath) {
     const requestedPath = `/servers/${serverId}${serverName?.length ? `/${serverName.join("/")}` : ""}`;
     if (requestedPath !== canonicalPath) {
-      redirect({ href: canonicalPath, locale });
+      // getPathname re-adds the locale prefix (as-needed) that permanentRedirect needs.
+      permanentRedirect(getPathname({ href: canonicalPath, locale }));
     }
   }
 

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -13,9 +13,13 @@ export default function proxy(request: NextRequest) {
 }
 
 export const config = {
-  // Skip API routes, Next internals, and anything with a file extension. The
-  // `.*\\..*` clause keeps the locale-agnostic metadata routes (sitemap.xml,
-  // robots.txt, feed.xml, manifest.webmanifest, favicon.ico) and /images/* out
-  // of the locale rewrite.
-  matcher: ["/((?!api|_next|_vercel|.*\\..*).*)"],
+  // Skip API routes, Next internals, and real asset files. We exclude only known
+  // asset extensions (not any dot) so the locale-agnostic metadata routes
+  // (sitemap.xml, robots.txt, feed.xml, manifest.webmanifest, favicon.ico) and
+  // /images/* stay out of the locale rewrite — while server URLs whose slug looks
+  // like a domain (e.g. /servers/12/penguin.gg) still reach the locale handling
+  // and the canonical-slug redirect instead of 404ing.
+  matcher: [
+    "/((?!api|_next|_vercel|.*\\.(?:xml|txt|webmanifest|ico|png|jpe?g|svg|webp|gif|json|js|css|woff2?|ttf|eot|map|pdf)$).*)",
+  ],
 };


### PR DESCRIPTION
## Contexte

Finition de la PR #216 (consolidation des URLs serveur). En vérifiant le résultat sur staging, deux trous sont apparus.

## Changements

**1. Noms de serveur contenant un point (~4% — « Herobrine.fr », « PENGUIN.GG »…)**
Leurs anciennes URLs en nom brut renvoyaient **404** au lieu de rediriger : le matcher du middleware i18n (`proxy.ts`) ignorait tout chemin contenant un `.`. On le restreint aux **vraies extensions d'asset** (`xml|txt|webmanifest|ico|png|...`), de sorte que `/servers/12/penguin.gg` atteigne le routing de locale et la redirection vers le slug canonique. Les routes métadonnées (`sitemap.xml`, `robots.txt`, `feed.xml`, `manifest.webmanifest`, `favicon.ico`) et `/images/*` restent exclues comme avant.

**2. Redirection permanente (308) au lieu de temporaire (307)**
Le suffixe après l'`id` étant purement cosmétique (la page ne lit que `serverId`), toutes les variantes sont de vrais doublons. On passe à `permanentRedirect` (308) pour que Google transfère le jus de lien et remplace l'URL dans son index, au lieu de laisser coexister les deux.

## Vérifié sur staging (après merge de #216, serveur réel id 385)

| URL | Avant | Après (attendu) |
|---|---|---|
| `/servers/385` | 307 | 308 → `/servers/385/herobrine-fr` |
| `/servers/385/mauvais-slug` | 307 | 308 → slug canonique |
| `/servers/385/Herobrine.fr` (nom à point) | **404** | 308 → slug canonique |

## Tests

⚠️ `tsc` / `lint` non exécutables localement (le proxy de sandbox interrompt le téléchargement des binaires natifs, `yarn install` n'aboutit pas). **Laisser la CI valider** — le job Frontend couvre build + typecheck + lint. Je re-vérifierai les redirects sur staging une fois cette PR mergée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017wgR6v8iBmYgtXKVLPE9Mz)_