### PR TITLE
fix(admin): show real user avatars in the admin users list

### DIFF
--- a/frontend/src/app/[locale]/(pages)/admin/users/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/admin/users/page.tsx
@@ -6,8 +6,8 @@ import DashboardStatTile from "@/components/account/dashboard-stat-tile";
 import { AdminFilterTabs } from "@/components/admin/admin-filter-tabs";
 import { AdminLoadingState, AdminMessageState } from "@/components/admin/admin-states";
 import { Badge, BadgeProps } from "@/components/ui/badge";
+import { AvatarTile } from "@/components/ui/avatar-tile";
 import { Input } from "@/components/ui/input";
-import { LetterTile } from "@/components/ui/letter-tile";
 import { Pagination } from "@/components/ui/pagination";
 import {
   Select,
@@ -225,7 +225,11 @@ const AdminUsersPage = () => {
                   href={`/admin/users/${u.id}`}
                   className="group flex min-w-0 flex-1 items-center gap-3"
                 >
-                  <LetterTile name={u.username} className="h-10 w-10 rounded-md text-sm" />
+                  <AvatarTile
+                    name={u.username}
+                    src={u.avatarUrl}
+                    className="h-10 w-10 rounded-md text-sm"
+                  />
                   <div className="min-w-0">
                     <p className="truncate font-medium text-foreground transition-colors group-hover:text-accent">
                       {u.username}


### PR DESCRIPTION
Promotes the admin avatar fix from `staging` to `main`.

## Problem

In the admin Dashboard, the users list showed a name-initial placeholder tile for every user instead of their real profile photo. The user's `avatarUrl` was already returned by the backend (`/admin/users`) and used on the user detail page, but the list view ignored it.

## Change

- Replace the `LetterTile` in the admin users list rows with the shared `AvatarTile` component, passing `u.avatarUrl`.
- `AvatarTile` renders the real photo when available and falls back to the name-hashed `LetterTile` when there is no avatar or the image fails to load — matching the user detail page header.

## Notes

- Frontend-only change; no API or type changes required.
- Already merged to `staging` (#219) with all CI checks green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAehvJzDfFhgZEbA7a8vu4)_