### PR TITLE
Fix OpenAPI spec serialization for placeholder tokens

### DIFF
--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -20,7 +20,11 @@ const PUBLIC_LONG = cacheHeaders({ maxAge: 3600 })
 const NO_STORE = cacheHeaders({ noStore: true })
 
 router.get('/swagger', async () => {
-  return AutoSwagger.default.docs(router.toJSON(), swagger)
+  // On sert le spec en JSON plutôt qu'en YAML : le sérialiseur YAML d'AutoSwagger ne met
+  // pas entre guillemets les clés de mapping commençant par `%` (ex. les jetons de
+  // placeholder `%PLAYER_COUNT_REALTIME_125%`), ce qui produit un YAML invalide et empêche
+  // Scalar (/docs) comme le serveur MCP de charger la doc. JSON gère ces clés nativement.
+  return AutoSwagger.default.json(router.toJSON(), swagger)
 })
 
 router.get('/docs', async () => {


### PR DESCRIPTION
## Summary
Changed the `/swagger` endpoint to return the OpenAPI spec as JSON instead of YAML to ensure compatibility with tools that consume the spec (Scalar UI and MCP server).

## Key Changes
- Modified `backend/start/routes.ts`: switched from `AutoSwagger.default.docs()` (YAML output) to `AutoSwagger.default.json()` (JSON output)

## Implementation Details
The AutoSwagger YAML serializer does not properly quote mapping keys that begin with `%` (e.g., placeholder tokens like `%PLAYER_COUNT_REALTIME_125%`), producing invalid YAML that prevents both the Scalar documentation UI (`/docs`) and the MCP server from loading the spec. JSON natively handles these keys without issues, making it a more robust serialization format for this use case.

The spec content remains identical—only the serialization format changes, ensuring all downstream consumers can reliably parse the OpenAPI specification.

https://claude.ai/code/session_014aDw2ThV3tkaoHyvpSQydV