### PR TITLE
fix(cost): réduire drastiquement le coût AWS S3 des favicons

### DIFF
--- a/backend/app/services/image_storage_service.ts
+++ b/backend/app/services/image_storage_service.ts
@@ -45,7 +45,12 @@ class ImageStorageService {
       .toFormat('webp')
       .toBuffer()
 
-    const cacheControl = 'public, max-age=3600'
+    // TTL 6h (navigateur + edge CDN). L'URL du favicon est stable (pas versionnée
+    // par un hash), donc un TTL long = image périmée jusqu'à expiration si le
+    // favicon change. 6h est un bon compromis : cosmétique et rarissime pour un
+    // favicon, mais suffisant pour effondrer l'egress derrière un CDN. On évite
+    // `immutable`/1 an ici, réservé aux assets à URL unique (blog, avatars).
+    const cacheControl = 'public, max-age=21600'
     await Promise.all([
       this.disk.put(`images/servers/${serverId}.png`, buffer, {
         contentType: 'image/png',

--- a/backend/start/scheduler.ts
+++ b/backend/start/scheduler.ts
@@ -117,14 +117,26 @@ async function updateServerInfo(server: Server, overwriteImage = false): Promise
   try {
     const data = await pingMinecraftServer(server.type, server.address, server.port)
     if (data) {
-      if (data.favicon && (overwriteImage || !server.imageUrl)) {
-        try {
-          server.imageUrl = await ImageStorageService.storeServerFavicon(server.id, data.favicon)
-        } catch (imgErr) {
-          logger.warn(
-            { serverId: server.id, err: (imgErr as Error).message },
-            'SCHEDULER: image processing failed'
-          )
+      // Empreinte du favicon : sert à la fois à la détection de doublon et à
+      // décider s'il faut réécrire l'image. On ne réuploade sur le stockage
+      // (S3 en prod) que si le favicon a réellement changé — ou s'il n'existe
+      // pas encore. Réécrire des octets identiques à chaque ping ne ferait que
+      // générer des PUT S3 inutiles (les favicons ne changent quasi jamais),
+      // ce qui a dominé la facture AWS. `overwriteImage` ne force donc plus la
+      // réécriture : le hash suffit à détecter les vrais changements.
+      if (data.favicon) {
+        const faviconHash = DuplicateDetectionService.hashFavicon(data.favicon)
+        if (!server.imageUrl || faviconHash !== server.faviconHash) {
+          try {
+            server.imageUrl = await ImageStorageService.storeServerFavicon(server.id, data.favicon)
+            server.faviconHash = faviconHash
+          } catch (imgErr) {
+            // On n'avance pas faviconHash : le prochain ping retentera l'upload.
+            logger.warn(
+              { serverId: server.id, err: (imgErr as Error).message },
+              'SCHEDULER: image processing failed'
+            )
+          }
         }
       }
 
@@ -143,12 +155,10 @@ async function updateServerInfo(server: Server, overwriteImage = false): Promise
         server.peakPlayerAt = DateTime.fromJSDate(createdAt)
       }
 
-      // Rafraîchit les empreintes de détection de doublon. favicon + MOTD sont
-      // recalculés à chaque ping (le MOTD bouge souvent) ; l'endpoint DNS, qui
-      // ne change quasi jamais, n'est re-résolu que lors du job 6h (overwriteImage).
-      if (data.favicon) {
-        server.faviconHash = DuplicateDetectionService.hashFavicon(data.favicon)
-      }
+      // Rafraîchit les empreintes de détection de doublon. Le favicon est déjà
+      // haché plus haut ; le MOTD est recalculé à chaque ping (il bouge souvent) ;
+      // l'endpoint DNS, qui ne change quasi jamais, n'est re-résolu que lors du
+      // job 6h (overwriteImage).
       server.motdHash = DuplicateDetectionService.hashMotd(data.description)
       if (overwriteImage) {
         server.resolvedEndpoint = await DuplicateDetectionService.resolveEndpoint(
@@ -260,8 +270,10 @@ scheduler
   })
   .everyFiveMinutes()
 
-// Force-refresh des favicons toutes les 6h sur TOUS les serveurs (pas seulement dus).
-// Utile pour rafraîchir les images qui auraient changé sans que le ping le détecte.
+// Balayage complet toutes les 6h sur TOUS les serveurs (pas seulement les dus).
+// Re-résout l'endpoint DNS (overwriteImage) et rattrape un favicon changé sur un
+// serveur "dead" rarement pingué. Les favicons ne sont réécrits que si leur hash
+// a changé (voir updateServerInfo), donc ce job ne génère plus de PUT S3 inutiles.
 scheduler
   .call(async () => {
     const start = Date.now()
@@ -280,7 +292,7 @@ scheduler
       `SCHEDULER: favicon refresh job done in ${Date.now() - start}ms — ${statsBatch.length}/${servers.length} pinged`
     )
   })
-  .everyTenMinutes()
+  .everySixHours()
 
 scheduler
   .call(async () => {


### PR DESCRIPTION
## Contexte

Depuis le passage du stockage des images en local → S3, la facture AWS est montée à ~30 $/mois. Après analyse, le stockage n'y est pour presque rien (favicons de quelques Ko) : **le coût est dominé par les requêtes PUT** et l'egress.

## Cause principale

Le job de refresh des favicons (`start/scheduler.ts`) tournait **toutes les 10 min** (au lieu des 6h indiquées par son propre commentaire) et réécrivait systématiquement les 2 objets S3 (`.png` + `.webp`) de **chaque** serveur, même quand le favicon n'avait pas changé.

Pour ~320 serveurs : `320 × 2 × 6/h × 24 × 30 ≈ 2,7 M PUT/mois` ≈ ~14 $/mois de PUT seuls, + l'egress associé aux réécritures qui invalident les caches.

## Changements

- **Upload conditionnel du favicon** : on ne réécrit sur le stockage (S3 en prod) que si le hash du favicon a changé (ou si l'image n'existe pas encore). Le hash est déjà calculé à chaque ping pour la détection de doublon, donc aucun coût supplémentaire. `overwriteImage` ne force plus la réécriture ; il ne sert plus qu'à re-résoudre l'endpoint DNS.
- **Cadence du balayage complet** : `everyTenMinutes()` → `everySixHours()`, conformément à l'intention d'origine. Les vrais changements de favicon restent détectés à la cadence de ping normale (5–10 min).
- **TTL des favicons** : `max-age` 1h → 6h. Derrière un CDN, moins de cache-miss donc moins d'egress origine. On garde un TTL borné (pas `immutable`) car l'URL du favicon est stable, non versionnée par un hash.

## Impact attendu

- PUT S3 : ~2,7 M/mois → quasi 0 (favicons quasi jamais modifiés).
- Egress : réduit, et prêt à s'effondrer une fois les images servies via le CDN Cloudflare.

## Tests

- Changements backend uniquement (`scheduler.ts`, `image_storage_service.ts`).
- Typecheck/lint non lançables en local (registry inaccessible dans l'environnement) — vérifiés par la CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013266qoftRXpnhbfhAaRrgk)_