### PR TITLE
Add /rankings page with 4 server leaderboards

### DIFF
--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -303,6 +303,7 @@ export default class ServersController {
    * @paramQuery languageIds - CSV of language ids to filter on (e.g. "1,2,3") - @type(string) @example(1,2)
    * @paramQuery search - Case-insensitive substring matched against name and address - @type(string) @example(hypixel)
    * @paramQuery type - Filter by server edition. Any other value is ignored. - @type(string) @enum(java, bedrock)
+   * @paramQuery sort - Ranking order. "players" (default) = most current players online (stale servers demoted); "trending" = highest weekly player growth; "peak" = highest all-time peak player count; "newest" = most recently added. Any other value falls back to "players". Powers the /rankings leaderboards. - @type(string) @enum(players, trending, peak, newest)
    * @paramQuery ids - Restrict to specific server ids. Accepts CSV ("1,2,3") OR repeated param ("ids=1&ids=2"). Positive integers only, deduplicated, max 20 ids (extras dropped). Used for the favorites section. - @type(string) @example(12,34,56)
    * @paramQuery nocache - Set to "1" to bypass the response cache. Only honored in non-production environments or for admin users. - @type(string) @enum(1)
    * @responseBody 200 - {"data": [{"server": "<Server>", "stats": [{"serverId": 1, "createdAt": "2026-05-28T12:00:00.000Z", "playerCount": 1200, "maxCount": 5000}], "categories": ["<Category>"], "growthStat": "<ServerGrowthStat>"}], "meta": {"total": 100, "perPage": 10, "currentPage": 1, "lastPage": 10, "firstPage": 1}}
@@ -318,6 +319,14 @@ export default class ServersController {
     // Édition (java/bedrock). Toute autre valeur est ignorée (pas de filtre).
     const typeParam = request.input('type')
     const type = typeParam === 'java' || typeParam === 'bedrock' ? typeParam : undefined
+
+    // Tri du classement (page /rankings). Whitelist stricte, fallback 'players'
+    // = ordre historique par joueurs actuels. Même logique inline que `type`.
+    const sortParam = request.input('sort')
+    const sort =
+      sortParam === 'trending' || sortParam === 'peak' || sortParam === 'newest'
+        ? sortParam
+        : 'players'
 
     // `ids` restreint la requête à une liste explicite de serveurs — utilisé par
     // la section "favoris", qui affiche les favoris de l'utilisateur dans leur
@@ -342,6 +351,7 @@ export default class ServersController {
       languageIds,
       search,
       type,
+      sort,
       ids: ids.join(','),
     })
 
@@ -364,6 +374,7 @@ export default class ServersController {
           languageIds,
           search,
           type,
+          sort,
           ids,
         })
         return result

--- a/backend/app/services/server_listing_service.ts
+++ b/backend/app/services/server_listing_service.ts
@@ -14,9 +14,11 @@ export default class ServerListingService {
     languageIds?: string
     search: string
     type?: 'java' | 'bedrock'
+    sort?: 'players' | 'trending' | 'peak' | 'newest'
     ids: number[]
   }) {
     const { page, limit, categoryIds, languageIds, search, type, ids } = opts
+    const sort = opts.sort ?? 'players'
 
     // Ordering : on ne classe par `last_player_count` que si le dernier ping
     // réussi est récent (< 30 min, soit ~3 cycles de 10 min). Sinon le serveur
@@ -35,15 +37,42 @@ export default class ServerListingService {
       query = query.whereIn('id', ids)
     }
 
-    query = query
-      .orderByRaw(
-        `CASE
-          WHEN last_stats_at > now() - interval '30 minutes'
-            THEN COALESCE(last_player_count, -1)
-          ELSE -1
-         END DESC`
-      )
-      .orderBy('last_stats_at', 'desc')
+    // Tri du classement selon `sort`. Par défaut ('players'), l'ordre historique
+    // stale-aware : on ne classe par `last_player_count` que si le dernier ping
+    // réussi est récent (< 30 min). Les autres tris alimentent la page /rankings.
+    if (sort === 'trending') {
+      // Serveurs qui montent : croissance hebdo la plus forte. On JOIN la table
+      // de croissance (relation hasOne, 1:1 → pas de multiplication de lignes) et
+      // on ne garde que les croissances strictement positives. `select('servers.*')`
+      // est indispensable : Server.query() émet un `select *` non qualifié, sans
+      // ça les colonnes de server_growth_stats "bleedent" sur le modèle.
+      query = query
+        .select('servers.*')
+        .leftJoin('server_growth_stats', 'server_growth_stats.server_id', 'servers.id')
+        .whereNotNull('server_growth_stats.weekly_growth')
+        .where('server_growth_stats.weekly_growth', '>', 0)
+        .orderBy('server_growth_stats.weekly_growth', 'desc')
+    } else if (sort === 'peak') {
+      // Records all-time. Postgres trie NULLS-first en DESC → NULLS LAST explicite
+      // pour reléguer les serveurs sans pic connu en bas.
+      query = query.orderByRaw('peak_player_count DESC NULLS LAST')
+    } else if (sort === 'newest') {
+      query = query.orderBy('created_at', 'desc')
+    } else {
+      query = query
+        .orderByRaw(
+          `CASE
+            WHEN last_stats_at > now() - interval '30 minutes'
+              THEN COALESCE(last_player_count, -1)
+            ELSE -1
+           END DESC`
+        )
+        .orderBy('last_stats_at', 'desc')
+    }
+
+    // Départage stable : évite qu'un serveur "saute" d'une page à l'autre quand
+    // plusieurs partagent la même valeur de tri (fréquent sur peak/newest).
+    query = query.orderBy('servers.id', 'asc')
 
     if (search) {
       query = query.where((builder) => {

--- a/frontend/messages/en/footer.json
+++ b/frontend/messages/en/footer.json
@@ -7,6 +7,7 @@
   },
   "links": {
     "allServers": "All servers",
+    "rankings": "Rankings",
     "addServer": "Add a server",
     "blog": "Blog",
     "apiDocs": "API documentation",

--- a/frontend/messages/en/header.json
+++ b/frontend/messages/en/header.json
@@ -1,6 +1,7 @@
 {
   "nav": {
     "servers": "Servers",
+    "rankings": "Rankings",
     "blog": "Blog",
     "api": "API"
   },

--- a/frontend/messages/en/rankings.json
+++ b/frontend/messages/en/rankings.json
@@ -1,0 +1,44 @@
+{
+  "eyebrow": "Rankings",
+  "title": "Minecraft server rankings",
+  "description": "Discover the best Minecraft servers: the most played right now, the fastest growing, the all-time attendance records, and the newest servers added. Rankings continuously updated from real player data.",
+  "meta": {
+    "title": "Minecraft Server Rankings — Top, Trending & Records",
+    "description": "The Minecraft server rankings: top players online, trending servers, all-time peak records, and newest servers. Real-time data, updated every 10 minutes.",
+    "keywords": "minecraft server rankings, best minecraft servers, top minecraft servers, popular minecraft servers, trending minecraft servers",
+    "ogTitle": "Minecraft Server Rankings",
+    "ogDescription": "Top players online, trending servers, peak records, and newest Minecraft servers — in real time."
+  },
+  "sections": {
+    "players": {
+      "nav": "Top players",
+      "title": "Top servers by players online",
+      "description": "The Minecraft servers with the most players connected right now. The reference leaderboard, in real time.",
+      "empty": "No player data available yet."
+    },
+    "trending": {
+      "nav": "Trending",
+      "title": "Trending servers",
+      "description": "The fastest growing servers, ranked by player-count growth over the past week.",
+      "empty": "Not enough growth data yet to build this ranking."
+    },
+    "peak": {
+      "nav": "Records",
+      "title": "All-time attendance records",
+      "description": "The highest player peaks ever recorded. The servers that made history with their attendance.",
+      "empty": "No attendance records available yet."
+    },
+    "newest": {
+      "nav": "Newest",
+      "title": "Newest servers",
+      "description": "The latest servers added to Minecraft Stats. Discover them before everyone else.",
+      "empty": "No recent servers to show yet."
+    }
+  },
+  "metrics": {
+    "playersOnline": "online",
+    "weeklyGrowth": "this week",
+    "allTimePeak": "all-time peak",
+    "added": "added on"
+  }
+}

--- a/frontend/messages/es/footer.json
+++ b/frontend/messages/es/footer.json
@@ -7,6 +7,7 @@
   },
   "links": {
     "allServers": "Todos los servidores",
+    "rankings": "Clasificaciones",
     "addServer": "Añadir un servidor",
     "blog": "Blog",
     "apiDocs": "Documentación de la API",

--- a/frontend/messages/es/header.json
+++ b/frontend/messages/es/header.json
@@ -1,6 +1,7 @@
 {
   "nav": {
     "servers": "Servidores",
+    "rankings": "Clasificaciones",
     "blog": "Blog",
     "api": "API"
   },

--- a/frontend/messages/es/rankings.json
+++ b/frontend/messages/es/rankings.json
@@ -1,0 +1,44 @@
+{
+  "eyebrow": "Clasificaciones",
+  "title": "Clasificaciones de servidores de Minecraft",
+  "description": "Descubre los mejores servidores de Minecraft: los más jugados ahora mismo, los que más rápido crecen, los récords históricos de afluencia y los últimos servidores añadidos. Clasificaciones actualizadas continuamente con datos reales de jugadores.",
+  "meta": {
+    "title": "Clasificaciones de servidores de Minecraft — Top, tendencias y récords",
+    "description": "Las clasificaciones de servidores de Minecraft: top de jugadores en línea, servidores en tendencia, récords de pico histórico y servidores nuevos. Datos en tiempo real, actualizados cada 10 minutos.",
+    "keywords": "clasificación servidor minecraft, mejor servidor minecraft, top servidor minecraft, servidor minecraft popular, servidor minecraft tendencia",
+    "ogTitle": "Clasificaciones de servidores de Minecraft",
+    "ogDescription": "Top de jugadores en línea, servidores en tendencia, récords de pico y servidores nuevos de Minecraft — en tiempo real."
+  },
+  "sections": {
+    "players": {
+      "nav": "Top jugadores",
+      "title": "Top de servidores por jugadores en línea",
+      "description": "Los servidores de Minecraft con más jugadores conectados ahora mismo. La clasificación de referencia, en tiempo real.",
+      "empty": "Todavía no hay datos de jugadores disponibles."
+    },
+    "trending": {
+      "nav": "Tendencias",
+      "title": "Servidores en tendencia",
+      "description": "Los servidores que más rápido crecen, clasificados por el aumento de jugadores durante la última semana.",
+      "empty": "Aún no hay suficientes datos de crecimiento para esta clasificación."
+    },
+    "peak": {
+      "nav": "Récords",
+      "title": "Récords de afluencia histórica",
+      "description": "Los picos de jugadores más altos jamás registrados. Los servidores que hicieron historia por su afluencia.",
+      "empty": "Todavía no hay récords de afluencia disponibles."
+    },
+    "newest": {
+      "nav": "Nuevos",
+      "title": "Servidores nuevos",
+      "description": "Los últimos servidores añadidos a Minecraft Stats. Descúbrelos antes que nadie.",
+      "empty": "Todavía no hay servidores recientes que mostrar."
+    }
+  },
+  "metrics": {
+    "playersOnline": "en línea",
+    "weeklyGrowth": "esta semana",
+    "allTimePeak": "pico histórico",
+    "added": "añadido el"
+  }
+}

--- a/frontend/messages/fr/footer.json
+++ b/frontend/messages/fr/footer.json
@@ -7,6 +7,7 @@
   },
   "links": {
     "allServers": "Tous les serveurs",
+    "rankings": "Classements",
     "addServer": "Ajouter un serveur",
     "blog": "Blog",
     "apiDocs": "Documentation de l'API",

--- a/frontend/messages/fr/header.json
+++ b/frontend/messages/fr/header.json
@@ -1,6 +1,7 @@
 {
   "nav": {
     "servers": "Serveurs",
+    "rankings": "Classements",
     "blog": "Blog",
     "api": "API"
   },

--- a/frontend/messages/fr/rankings.json
+++ b/frontend/messages/fr/rankings.json
@@ -1,0 +1,44 @@
+{
+  "eyebrow": "Classements",
+  "title": "Classements des serveurs Minecraft",
+  "description": "Découvrez les meilleurs serveurs Minecraft : les plus joués en ce moment, ceux qui montent le plus vite, les records historiques de fréquentation et les derniers serveurs ajoutés. Classements mis à jour en continu à partir de données de joueurs réelles.",
+  "meta": {
+    "title": "Classements des serveurs Minecraft — Top, tendances et records",
+    "description": "Les classements des serveurs Minecraft : top des joueurs en ligne, serveurs en tendance, records de pic all-time et nouveaux serveurs. Données en temps réel, mises à jour toutes les 10 minutes.",
+    "keywords": "classement serveur minecraft, meilleur serveur minecraft, top serveur minecraft, serveur minecraft populaire, serveur minecraft tendance",
+    "ogTitle": "Classements des serveurs Minecraft",
+    "ogDescription": "Top des joueurs en ligne, serveurs en tendance, records de pic et nouveaux serveurs Minecraft — en temps réel."
+  },
+  "sections": {
+    "players": {
+      "nav": "Top joueurs",
+      "title": "Top serveurs par joueurs en ligne",
+      "description": "Les serveurs Minecraft avec le plus de joueurs connectés en ce moment. Le classement de référence, en temps réel.",
+      "empty": "Aucune donnée de joueurs disponible pour l'instant."
+    },
+    "trending": {
+      "nav": "Tendances",
+      "title": "Serveurs en tendance",
+      "description": "Les serveurs qui montent le plus vite, classés par croissance du nombre de joueurs sur la dernière semaine.",
+      "empty": "Pas encore assez de données de croissance pour établir ce classement."
+    },
+    "peak": {
+      "nav": "Records",
+      "title": "Records de fréquentation all-time",
+      "description": "Les plus gros pics de joueurs jamais enregistrés. Les serveurs qui ont marqué l'histoire par leur affluence.",
+      "empty": "Aucun record de fréquentation disponible pour l'instant."
+    },
+    "newest": {
+      "nav": "Nouveaux",
+      "title": "Nouveaux serveurs",
+      "description": "Les derniers serveurs ajoutés à Minecraft Stats. À découvrir avant tout le monde.",
+      "empty": "Aucun serveur récent à afficher pour l'instant."
+    }
+  },
+  "metrics": {
+    "playersOnline": "en ligne",
+    "weeklyGrowth": "cette semaine",
+    "allTimePeak": "pic all-time",
+    "added": "ajouté le"
+  }
+}

--- a/frontend/src/app/[locale]/(pages)/rankings/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/rankings/page.tsx
@@ -1,0 +1,105 @@
+import { Metadata } from "next";
+import { getFormatter, getLocale, getTranslations } from "next-intl/server";
+import { Crown, Sparkles, TrendingUp, Trophy, Users } from "lucide-react";
+import { buildAlternates } from "@/lib/domain-server";
+import { getRanking, RankingSort } from "@/http/rankings";
+import { buildMetric } from "@/components/rankings/metric";
+import RankingSection from "@/components/rankings/ranking-section";
+import RankingsNav from "@/components/rankings/rankings-nav";
+import { PodiumRow } from "@/components/rankings/podium";
+
+// ISR : la page est régénérée au plus toutes les 10 min, aligné sur le cache backend.
+export const revalidate = 600;
+
+// Nombre de serveurs par classement (podium 3 + liste 12).
+const RANKING_LIMIT = 15;
+
+// Les 4 classements de la page. `id` sert d'ancre ; `icon` alimente en-tête + nav.
+const SECTIONS: { sort: RankingSort; id: string; icon: React.ReactNode }[] = [
+  { sort: "players", id: "top", icon: <Users className="h-5 w-5" /> },
+  { sort: "trending", id: "trending", icon: <TrendingUp className="h-5 w-5" /> },
+  { sort: "peak", id: "peak", icon: <Crown className="h-5 w-5" /> },
+  { sort: "newest", id: "new", icon: <Sparkles className="h-5 w-5" /> },
+];
+
+export const generateMetadata = async ({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> => {
+  const { locale } = await params;
+  const { canonical, languages } = buildAlternates(locale, "/rankings");
+  const t = await getTranslations({ locale, namespace: "Rankings" });
+
+  return {
+    title: t("meta.title"),
+    description: t("meta.description"),
+    keywords: t("meta.keywords"),
+    openGraph: {
+      title: t("meta.ogTitle"),
+      description: t("meta.ogDescription"),
+      type: "website",
+      url: canonical,
+    },
+    alternates: { canonical, languages },
+    robots: { index: true, follow: true },
+  };
+};
+
+const Rankings = async () => {
+  const locale = await getLocale();
+  const t = await getTranslations("Rankings");
+  const format = await getFormatter();
+
+  // Un fetch par classement, en parallèle. Un classement qui échoue ne fait pas
+  // tomber la page entière : il rend une section vide avec son message.
+  const responses = await Promise.all(
+    SECTIONS.map((section) => getRanking(section.sort, RANKING_LIMIT).catch(() => null)),
+  );
+
+  const sections = SECTIONS.map((section, index) => {
+    const rows: PodiumRow[] = (responses[index]?.data ?? []).map((entry, i) => ({
+      rank: i + 1,
+      entry,
+      metric: buildMetric(section.sort, entry, format, t),
+    }));
+    return { ...section, rows };
+  });
+
+  const navItems = SECTIONS.map((section) => ({
+    id: section.id,
+    label: t(`sections.${section.sort}.nav`),
+    icon: section.icon,
+  }));
+
+  return (
+    <main className="mx-auto w-full max-w-4xl space-y-12 py-8">
+      <header className="space-y-4">
+        <div>
+          <div className="mb-1 flex items-center gap-2 text-xs font-bold uppercase tracking-[0.12em] text-accent">
+            <Trophy className="h-4 w-4" />
+            {t("eyebrow")}
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">{t("title")}</h1>
+          <p className="mt-2 max-w-2xl text-muted-foreground">{t("description")}</p>
+        </div>
+        <RankingsNav items={navItems} />
+      </header>
+
+      {sections.map((section) => (
+        <RankingSection
+          key={section.id}
+          id={section.id}
+          icon={section.icon}
+          title={t(`sections.${section.sort}.title`)}
+          description={t(`sections.${section.sort}.description`)}
+          rows={section.rows}
+          emptyLabel={t(`sections.${section.sort}.empty`)}
+          locale={locale}
+        />
+      ))}
+    </main>
+  );
+};
+
+export default Rankings;

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -105,6 +105,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       alternates: { languages: buildAlternates(domainLocale, "").languages },
     },
     {
+      url: `${baseUrl}/rankings`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.8,
+      alternates: { languages: buildAlternates(domainLocale, "/rankings").languages },
+    },
+    {
       url: `${baseUrl}/blog`,
       lastModified: new Date(),
       changeFrequency: 'daily',

--- a/frontend/src/components/footer/index.tsx
+++ b/frontend/src/components/footer/index.tsx
@@ -59,6 +59,11 @@ const Footer = () => {
                 </Link>
               </li>
               <li>
+                <Link href="/rankings" className={linkClass}>
+                  {t("links.rankings")}
+                </Link>
+              </li>
+              <li>
                 <Link href="/account/add-server" className={linkClass}>
                   {t("links.addServer")}
                 </Link>

--- a/frontend/src/components/header/index.tsx
+++ b/frontend/src/components/header/index.tsx
@@ -26,6 +26,7 @@ import {
 
 const NAV_LINKS = [
   { href: "/", key: "servers", icon: "material-symbols:list", matchPrefixes: ["/servers"] },
+  { href: "/rankings", key: "rankings", icon: "material-symbols:trophy-outline", matchPrefixes: ["/rankings"] },
   { href: "/blog", key: "blog", icon: "material-symbols:article-outline", matchPrefixes: ["/blog"] },
 ] as const;
 

--- a/frontend/src/components/rankings/metric.ts
+++ b/frontend/src/components/rankings/metric.ts
@@ -1,0 +1,70 @@
+import { RankingEntry, RankingSort } from "@/http/rankings";
+
+export type MetricTone = "up" | "down" | "neutral";
+
+export interface RankingMetric {
+  /** Valeur mise en avant (déjà formatée selon la locale). */
+  value: string;
+  /** Libellé court sous la valeur (traduit). */
+  label: string;
+  tone: MetricTone;
+}
+
+/** Fonction de traduction minimale (compatible next-intl `getTranslations`). */
+type Translate = (key: string) => string;
+/**
+ * Formatteur minimal (compatible next-intl `getFormatter`). Les options de
+ * `dateTime` sont volontairement restreintes au sous-ensemble qu'on utilise :
+ * le type complet de next-intl (use-intl) est plus étroit que
+ * `Intl.DateTimeFormatOptions`, donc on reste sur ce qui est assignable.
+ */
+interface Formatter {
+  number: (value: number) => string;
+  dateTime: (value: Date, options?: { dateStyle?: "full" | "long" | "medium" | "short" }) => string;
+}
+
+const formatGrowth = (growth: number) => `${growth >= 0 ? "+" : ""}${Math.round(growth * 100)}%`;
+
+/**
+ * Métrique mise en avant pour une entrée de classement, selon le tri. Centralise
+ * le choix du champ (joueurs actuels / croissance / pic / date) et son formatage
+ * localisé, pour que podium et liste affichent exactement la même chose.
+ */
+export function buildMetric(
+  sort: RankingSort,
+  entry: RankingEntry,
+  format: Formatter,
+  t: Translate,
+): RankingMetric {
+  const { server, growthStat } = entry;
+
+  switch (sort) {
+    case "trending": {
+      const growth = growthStat?.weeklyGrowth ?? 0;
+      return {
+        value: formatGrowth(growth),
+        label: t("metrics.weeklyGrowth"),
+        tone: growth >= 0 ? "up" : "down",
+      };
+    }
+    case "peak":
+      return {
+        value: format.number(server.peakPlayerCount ?? 0),
+        label: t("metrics.allTimePeak"),
+        tone: "neutral",
+      };
+    case "newest":
+      return {
+        value: format.dateTime(new Date(server.createdAt), { dateStyle: "medium" }),
+        label: t("metrics.added"),
+        tone: "neutral",
+      };
+    case "players":
+    default:
+      return {
+        value: format.number(server.lastPlayerCount ?? 0),
+        label: t("metrics.playersOnline"),
+        tone: "neutral",
+      };
+  }
+}

--- a/frontend/src/components/rankings/podium.tsx
+++ b/frontend/src/components/rankings/podium.tsx
@@ -1,0 +1,113 @@
+import { Crown, Medal } from "lucide-react";
+import { Link } from "@/i18n/navigation";
+import { serverPath } from "@/lib/server-url";
+import { cn } from "@/lib/utils";
+import { RankingEntry } from "@/http/rankings";
+import ServerImage from "@/components/serveur/card/server-image";
+import ServerLanguages from "@/components/serveur/card/server-languages";
+import { RankingMetric } from "./metric";
+
+export interface PodiumRow {
+  rank: number;
+  entry: RankingEntry;
+  metric: RankingMetric;
+}
+
+interface PodiumProps {
+  rows: PodiumRow[];
+}
+
+const toneClass: Record<RankingMetric["tone"], string> = {
+  up: "text-success",
+  down: "text-destructive",
+  neutral: "text-foreground",
+};
+
+// Habillage or / argent / bronze par rang. Les couleurs amber/slate/orange
+// rendent correctement en clair comme en sombre.
+const podiumStyle: Record<number, { ring: string; badge: string; Icon: typeof Crown; order: string; raised: string }> = {
+  1: {
+    ring: "ring-amber-400/50",
+    badge: "bg-amber-400/15 text-amber-500 ring-amber-400/40",
+    Icon: Crown,
+    order: "sm:order-2",
+    raised: "sm:pt-8",
+  },
+  2: {
+    ring: "ring-slate-300/50",
+    badge: "bg-slate-300/15 text-slate-400 ring-slate-300/40",
+    Icon: Medal,
+    order: "sm:order-1",
+    raised: "",
+  },
+  3: {
+    ring: "ring-orange-500/40",
+    badge: "bg-orange-500/15 text-orange-600 ring-orange-500/40 dark:text-orange-400",
+    Icon: Medal,
+    order: "sm:order-3",
+    raised: "",
+  },
+};
+
+/**
+ * Podium des 3 premiers d'un classement. Le n°1 est mis en avant (centré et
+ * surélevé en desktop). Rendu entièrement côté serveur.
+ */
+const Podium = ({ rows }: PodiumProps) => {
+  return (
+    <ol className="grid grid-cols-1 gap-4 sm:grid-cols-3 sm:items-end">
+      {rows.map(({ rank, entry, metric }) => {
+        const { server } = entry;
+        const style = podiumStyle[rank] ?? podiumStyle[3];
+
+        return (
+          <li key={server.id} className={cn("flex", style.order)}>
+            <Link
+              href={serverPath(server.id, server.name)}
+              className={cn(
+                "group flex w-full flex-col items-center gap-2 rounded-xl border border-border bg-card px-4 pb-5 pt-5 text-center text-card-foreground shadow-xs ring-1 transition-all duration-150 ease-in-out hover:-translate-y-0.5 hover:shadow-md",
+                style.ring,
+                style.raised,
+              )}
+            >
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-bold ring-1",
+                  style.badge,
+                )}
+              >
+                <style.Icon className="h-4 w-4" />
+                {rank}
+              </span>
+
+              <ServerImage imageUrl={server.imageUrl} name={server.name} className="h-16 w-16" />
+
+              <div className="flex min-w-0 max-w-full flex-col items-center gap-1">
+                <div className="flex min-w-0 max-w-full items-center gap-2">
+                  <span className="truncate text-lg font-bold leading-tight text-foreground group-hover:text-accent">
+                    {server.name}
+                  </span>
+                  {server.languages?.length > 0 && (
+                    <ServerLanguages languages={server.languages} className="shrink-0" />
+                  )}
+                </div>
+                <span className="max-w-full truncate font-mono text-xs text-muted-foreground">
+                  {server.address.toLowerCase()}
+                </span>
+              </div>
+
+              <div className="mt-1 flex flex-col items-center">
+                <span className={cn("text-2xl font-extrabold tabular-nums", toneClass[metric.tone])}>
+                  {metric.value}
+                </span>
+                <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{metric.label}</span>
+              </div>
+            </Link>
+          </li>
+        );
+      })}
+    </ol>
+  );
+};
+
+export default Podium;

--- a/frontend/src/components/rankings/rank-row.tsx
+++ b/frontend/src/components/rankings/rank-row.tsx
@@ -1,0 +1,64 @@
+import { Link } from "@/i18n/navigation";
+import { serverPath } from "@/lib/server-url";
+import { cn } from "@/lib/utils";
+import { RankingEntry } from "@/http/rankings";
+import ServerImage from "@/components/serveur/card/server-image";
+import ServerLanguages from "@/components/serveur/card/server-languages";
+import { RankingMetric } from "./metric";
+
+interface RankRowProps {
+  rank: number;
+  entry: RankingEntry;
+  metric: RankingMetric;
+}
+
+const toneClass: Record<RankingMetric["tone"], string> = {
+  up: "text-success",
+  down: "text-destructive",
+  neutral: "text-foreground",
+};
+
+/**
+ * Ligne d'un classement (rangs 4+). Volontairement server-rendered et sobre
+ * (pas de sparkline ni de boutons interactifs) : tout le contenu part dans le
+ * HTML, bon pour le SEO et les agents qui lisent la page. Toute la ligne est un
+ * lien vers la fiche serveur.
+ */
+const RankRow = ({ rank, entry, metric }: RankRowProps) => {
+  const { server } = entry;
+
+  return (
+    <li>
+      <Link
+        href={serverPath(server.id, server.name)}
+        className="group flex items-center gap-3 rounded-lg border border-border bg-card p-3 text-card-foreground shadow-xs transition-all duration-150 ease-in-out hover:-translate-y-0.5 hover:border-accent/50 hover:shadow-md"
+      >
+        <span className="w-8 shrink-0 text-center text-base font-bold tabular-nums text-muted-foreground">
+          {rank}
+        </span>
+        <ServerImage imageUrl={server.imageUrl} name={server.name} className="h-10 w-10" />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate font-semibold leading-tight text-foreground group-hover:text-accent">
+              {server.name}
+            </span>
+            {server.languages?.length > 0 && (
+              <ServerLanguages languages={server.languages} className="shrink-0" />
+            )}
+          </div>
+          <span className="block truncate font-mono text-[13px] text-muted-foreground">
+            {server.address.toLowerCase()}
+          </span>
+        </div>
+        <div className="flex shrink-0 flex-col items-end">
+          <span className={cn("text-base font-bold tabular-nums", toneClass[metric.tone])}>
+            {metric.value}
+          </span>
+          <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{metric.label}</span>
+        </div>
+      </Link>
+    </li>
+  );
+};
+
+export default RankRow;

--- a/frontend/src/components/rankings/ranking-section.tsx
+++ b/frontend/src/components/rankings/ranking-section.tsx
@@ -1,0 +1,61 @@
+import { ReactNode } from "react";
+import Podium, { PodiumRow } from "./podium";
+import RankRow from "./rank-row";
+import { RankingsStructuredData } from "@/components/seo/structured-data";
+
+interface RankingSectionProps {
+  /** Ancre de section (navigation par onglets). */
+  id: string;
+  icon: ReactNode;
+  title: string;
+  description: string;
+  rows: PodiumRow[];
+  emptyLabel: string;
+  locale: string;
+}
+
+/**
+ * Une section de classement : en-tête (icône + titre + description), podium des
+ * 3 premiers, puis la liste des suivants. Émet aussi un JSON-LD `ItemList` pour
+ * les moteurs et les agents IA. Entièrement server-rendered.
+ */
+const RankingSection = ({ id, icon, title, description, rows, emptyLabel, locale }: RankingSectionProps) => {
+  const podium = rows.slice(0, 3);
+  const rest = rows.slice(3);
+
+  return (
+    <section id={id} aria-labelledby={`${id}-title`} className="scroll-mt-24">
+      <div className="mb-5 flex items-start gap-3">
+        <span className="mt-0.5 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-accent/10 text-accent">
+          {icon}
+        </span>
+        <div>
+          <h2 id={`${id}-title`} className="text-2xl font-bold tracking-tight text-foreground">
+            {title}
+          </h2>
+          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{description}</p>
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border bg-card p-6 text-center text-sm text-muted-foreground">
+          {emptyLabel}
+        </p>
+      ) : (
+        <>
+          <RankingsStructuredData name={title} rows={rows} locale={locale} />
+          {podium.length > 0 && <Podium rows={podium} />}
+          {rest.length > 0 && (
+            <ol className="mt-4 flex flex-col gap-2">
+              {rest.map((row) => (
+                <RankRow key={row.entry.server.id} rank={row.rank} entry={row.entry} metric={row.metric} />
+              ))}
+            </ol>
+          )}
+        </>
+      )}
+    </section>
+  );
+};
+
+export default RankingSection;

--- a/frontend/src/components/rankings/rankings-nav.tsx
+++ b/frontend/src/components/rankings/rankings-nav.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from "react";
+
+interface RankingsNavProps {
+  items: { id: string; label: string; icon: ReactNode }[];
+}
+
+/**
+ * Onglets d'ancrage vers chaque section de classement. Simples liens `#hash`
+ * (aucun JS) : fonctionnent sans hydratation et restent crawlables.
+ */
+const RankingsNav = ({ items }: RankingsNavProps) => {
+  return (
+    <nav aria-label="Rankings" className="flex flex-wrap gap-2">
+      {items.map((item) => (
+        <a
+          key={item.id}
+          href={`#${item.id}`}
+          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1.5 text-sm font-medium text-muted-foreground shadow-xs transition-colors hover:border-accent/50 hover:text-accent"
+        >
+          {item.icon}
+          {item.label}
+        </a>
+      ))}
+    </nav>
+  );
+};
+
+export default RankingsNav;

--- a/frontend/src/components/seo/structured-data.tsx
+++ b/frontend/src/components/seo/structured-data.tsx
@@ -1,5 +1,6 @@
 import { getClientDomainConfig, resolveAssetUrl } from "@/lib/domain";
 import { Category, Server } from "@/types/server";
+import { serverPath } from "@/lib/server-url";
 import Script from "next/script";
 
 /**
@@ -266,6 +267,50 @@ export function BlogPostStructuredData({ post, locale }: Readonly<BlogPostStruct
   return (
     <Script
       id={`blog-post-structured-data-${post.id}`}
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: toJsonLd(structuredData) }}
+    />
+  );
+}
+
+interface RankingsStructuredDataProps {
+  /** Titre du classement (ex. "Top serveurs par joueurs en ligne"). */
+  name: string;
+  rows: { rank: number; entry: { server: Pick<Server, "id" | "name"> } }[];
+  locale?: string;
+}
+
+/**
+ * JSON-LD `ItemList` pour un classement. Donne aux moteurs et aux agents IA
+ * l'ordre exact et l'URL de chaque serveur classé — un signal fort et lisible
+ * par machine, en complément du HTML sémantique de la page.
+ */
+export function RankingsStructuredData({ name, rows, locale }: Readonly<RankingsStructuredDataProps>) {
+  const { baseUrl } = getClientDomainConfig();
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name,
+    inLanguage: bcp47(locale),
+    numberOfItems: rows.length,
+    itemListOrder: "https://schema.org/ItemListOrderDescending",
+    itemListElement: rows.map(({ rank, entry }) => ({
+      "@type": "ListItem",
+      position: rank,
+      name: entry.server.name,
+      url: `${baseUrl}${serverPath(entry.server.id, entry.server.name)}`,
+    })),
+  };
+
+  const id = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+
+  return (
+    <Script
+      id={`rankings-structured-data-${id}`}
       type="application/ld+json"
       dangerouslySetInnerHTML={{ __html: toJsonLd(structuredData) }}
     />

--- a/frontend/src/http/rankings.ts
+++ b/frontend/src/http/rankings.ts
@@ -1,0 +1,45 @@
+import { getBaseUrl } from "@/app/_cheatcode";
+import { Category, Server, ServerGrowthStat, ServerStat } from "@/types/server";
+
+/**
+ * Classements de la page /rankings. Chaque tri est servi par le même endpoint
+ * `/servers/paginate` (avec `?sort=`), donc chaque entrée a la forme d'une ligne
+ * de classement standard : le serveur + ses stats 24h + ses relations.
+ */
+export type RankingSort = "players" | "trending" | "peak" | "newest";
+
+export interface RankingEntry {
+  server: Server;
+  stats: ServerStat[];
+  categories: Category[];
+  growthStat: ServerGrowthStat | null;
+}
+
+export interface RankingResponse {
+  data: RankingEntry[];
+  meta: {
+    total: number;
+    perPage: number;
+    currentPage: number;
+    lastPage: number;
+    firstPage: number;
+  };
+}
+
+/**
+ * Récupère un classement côté serveur (RSC) pour un rendu SEO-friendly. On passe
+ * par `getBaseUrl()` (INTERNAL_API_URL en Docker) et non par le domaine public,
+ * pour éviter les problèmes de loopback NAT. ISR : revalidation toutes les 10 min,
+ * alignée sur le TTL du cache backend.
+ */
+export const getRanking = async (sort: RankingSort, limit = 15): Promise<RankingResponse> => {
+  const response = await fetch(`${getBaseUrl()}/servers/paginate?sort=${sort}&limit=${limit}`, {
+    next: { revalidate: 600 },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${sort} ranking: ${response.status}`);
+  }
+
+  return response.json() as Promise<RankingResponse>;
+};


### PR DESCRIPTION
## Summary

Introduces a new `/rankings` page featuring four distinct Minecraft server leaderboards: top players online, trending (weekly growth), all-time peak records, and newest servers. The page is fully server-rendered for SEO, with a visual podium for the top 3 and a list view for remaining entries. Includes JSON-LD structured data and multi-language support (EN/ES/FR).

## Key Changes

**Backend (`backend/`)**
- Extended `ServerListingService.list()` to support four ranking sorts via new `sort` parameter:
  - `"players"` (default): current online players, stale-aware (servers inactive >30 min demoted)
  - `"trending"`: highest weekly growth (LEFT JOIN `server_growth_stats`, filter positive growth)
  - `"peak"`: highest all-time peak player count (NULLS LAST for unknowns)
  - `"newest"`: most recently added (by `created_at`)
- Added stable tiebreaker ordering by `servers.id ASC` to prevent pagination drift
- Updated `ServersController.paginate()` JSDoc to document the new `sort` query parameter

**Frontend (`frontend/`)**
- New page `app/[locale]/(pages)/rankings/page.tsx`: fetches 4 rankings in parallel (ISR 600s), renders 4 sections with podium + list
- New components:
  - `components/rankings/podium.tsx`: visual top-3 display with Crown/Medal icons, color-coded (gold/silver/bronze), desktop elevation
  - `components/rankings/rank-row.tsx`: list rows for ranks 4+, compact server card with metric
  - `components/rankings/ranking-section.tsx`: section wrapper with icon, title, description, podium, list, and JSON-LD emission
  - `components/rankings/metric.ts`: centralized metric formatting (players, growth %, peak, date) with locale-aware formatting
  - `components/rankings/rankings-nav.tsx`: hash-based anchor tabs (no JS, SEO-friendly)
- New HTTP client `http/rankings.ts`: `getRanking(sort, limit)` RSC fetcher using `INTERNAL_API_URL`
- New structured data `RankingsStructuredData`: emits `schema.org/ItemList` JSON-LD for each ranking
- Translation files (EN/ES/FR) with section titles, descriptions, metrics, and metadata
- Updated navigation (header, footer) to link to `/rankings`
- Updated sitemap to include `/rankings` with daily changeFrequency and 0.8 priority

## Notable Implementation Details

- **Metric abstraction**: `buildMetric()` centralizes formatting logic so podium and list always display identical values, regardless of sort type
- **Tone system**: metrics carry a "tone" (up/down/neutral) for color coding (green for growth, red for decline)
- **Server-rendered**: entire page is RSC with no client-side hydration; all content in HTML for crawlers and AI agents
- **Parallel fetches**: all 4 rankings fetched concurrently; one failure doesn't block the page (renders empty section with fallback message)
- **Stable ordering**: tiebreaker by ID prevents servers from jumping positions when multiple share the same metric value (common on peak/newest)
- **Responsive podium**: desktop layout elevates rank #1 (centered, raised) via Tailwind `sm:order-*` and `sm:pt-*`

https://claude.ai/code/session_01JkJRTiWPBdzZfvMrK4AMuc