### PR TITLE
fix(frontend): stop showing "server not found" for non-404 API errors

### DIFF
--- a/frontend/messages/en/servers.json
+++ b/frontend/messages/en/servers.json
@@ -51,6 +51,13 @@
       "title": "Server Not Found",
       "description": "The server you're looking for doesn't exist or has been removed.",
       "backHome": "Back to Home"
+    },
+    "error": {
+      "rateLimitTitle": "Too many requests",
+      "rateLimitDescription": "You've made too many requests in a short time. Please wait a moment, then try again.",
+      "genericTitle": "Unable to load the server",
+      "genericDescription": "Something went wrong while loading the server data. Please try again in a moment.",
+      "retry": "Try again"
     }
   },
   "faq": {

--- a/frontend/messages/es/servers.json
+++ b/frontend/messages/es/servers.json
@@ -51,6 +51,13 @@
       "title": "Servidor no encontrado",
       "description": "El servidor que buscas no existe o ha sido eliminado.",
       "backHome": "Volver al inicio"
+    },
+    "error": {
+      "rateLimitTitle": "Demasiadas solicitudes",
+      "rateLimitDescription": "Has realizado demasiadas solicitudes en poco tiempo. Espera un momento y vuelve a intentarlo.",
+      "genericTitle": "No se pudo cargar el servidor",
+      "genericDescription": "Se produjo un error al cargar los datos del servidor. Vuelve a intentarlo en un momento.",
+      "retry": "Reintentar"
     }
   },
   "faq": {

--- a/frontend/messages/fr/servers.json
+++ b/frontend/messages/fr/servers.json
@@ -51,6 +51,13 @@
       "title": "Serveur introuvable",
       "description": "Le serveur que vous recherchez n'existe pas ou a été supprimé.",
       "backHome": "Retour à l'accueil"
+    },
+    "error": {
+      "rateLimitTitle": "Trop de requêtes",
+      "rateLimitDescription": "Vous avez effectué trop de requêtes en peu de temps. Patientez un instant, puis réessayez.",
+      "genericTitle": "Impossible de charger le serveur",
+      "genericDescription": "Une erreur est survenue lors du chargement des données du serveur. Réessayez dans un instant.",
+      "retry": "Réessayer"
     }
   },
   "faq": {

--- a/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/layout.tsx
+++ b/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/layout.tsx
@@ -1,3 +1,4 @@
+import { HttpError } from "@/app/_cheatcode";
 import { getServer } from "@/http/server";
 import { getLastStat } from "@/utils/stats";
 import { Metadata } from "next";
@@ -100,6 +101,13 @@ export const generateMetadata = async (props: {
     };
   } catch (error) {
     console.error("Erreur", error);
+    // Seul un vrai 404 doit figer le titre « introuvable » + noindex dans le
+    // cache ISR (revalidate 600). Sur une erreur transitoire (429, 5xx,
+    // timeout), on hérite des metadata parentes pour ne pas désindexer un
+    // serveur valide pendant 10 minutes.
+    if (!(error instanceof HttpError && error.status === 404)) {
+      return {};
+    }
     return {
       title: t("meta.notFoundTitle"),
       description: t("meta.notFoundDescription"),

--- a/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { fetcher, getBaseUrl } from "@/app/_cheatcode";
+import { fetcher, getBaseUrl, HttpError } from "@/app/_cheatcode";
 import { generateTooltipHtml } from "@/components/serveur/card/tooltip-chart";
 import { getServerStats } from "@/http/server";
 import { ServerStat } from "@/types/server";
@@ -153,6 +153,43 @@ const ServerNotFound = () => {
   );
 };
 
+/**
+ * Erreur de chargement autre qu'un vrai 404 : rate-limit (429), erreur
+ * serveur (5xx), panne réseau… On l'annonce comme telle — surtout pas
+ * comme « serveur introuvable » — et on propose de réessayer.
+ */
+const ServerLoadError = ({ error, onRetry }: { error: Error; onRetry: () => void }) => {
+  const t = useTranslations("Servers");
+  const isRateLimited = error instanceof HttpError && error.status === 429;
+  return (
+    <main className="flex-1 space-y-4 py-4">
+      <div className="flex items-center justify-center min-h-[calc(100vh-200px)]">
+        <div className="bg-card text-card-foreground border border-border rounded-lg shadow-xs p-8 space-y-6 max-w-md w-full">
+          <div className="space-y-2 text-center">
+            <div className="w-16 h-16 mx-auto bg-secondary text-muted-foreground rounded-full flex items-center justify-center">
+              <Icon icon={isRateLimited ? "mdi:timer-sand" : "mdi:alert-circle-outline"} className="w-8 h-8" />
+            </div>
+            <h2 className="text-xl font-semibold text-foreground">
+              {isRateLimited ? t("detail.error.rateLimitTitle") : t("detail.error.genericTitle")}
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              {isRateLimited ? t("detail.error.rateLimitDescription") : t("detail.error.genericDescription")}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-accent-foreground bg-accent hover:bg-accent/90 rounded-md transition-colors"
+          >
+            <Icon icon="mdi:refresh" className="w-4 h-4" />
+            {t("detail.error.retry")}
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+};
+
 const ServerPage = () => {
   const { serverId } = useParams();
   const locale = useLocale();
@@ -161,6 +198,7 @@ const ServerPage = () => {
     data: serverData,
     error: serverError,
     isLoading: isServerLoading,
+    mutate: retryServer,
   } = useSWR<ServerData, Error>(`${getBaseUrl()}/servers/${serverId}`, fetcher, {
     // Aligné sur le TTL Redis backend (300s) — cf. P.2.1
     refreshInterval: 1000 * 60 * 5,
@@ -220,16 +258,13 @@ const ServerPage = () => {
   }
 
   if (serverError) {
-    if (serverError.message.includes("404")) {
+    if (serverError instanceof HttpError && serverError.status === 404) {
       return <ServerNotFound />;
     }
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-destructive">{serverError.message}</div>
-      </div>
-    );
+    return <ServerLoadError error={serverError} onRetry={() => retryServer()} />;
   }
 
+  // Filet de sécurité : réponse 200 sans payload exploitable.
   if (!serverData?.server) {
     return <ServerNotFound />;
   }

--- a/frontend/src/app/_cheatcode.tsx
+++ b/frontend/src/app/_cheatcode.tsx
@@ -16,8 +16,37 @@ export const localeHeaders = (): Record<string, string> => {
   return lang ? { "Accept-Language": lang } : {};
 };
 
-export const fetcher = (input: RequestInfo, init?: RequestInit) =>
-  fetch(input, { ...init, headers: { ...localeHeaders(), ...init?.headers } }).then((res) => res.json());
+/**
+ * Erreur HTTP porteuse du status, pour que les consommateurs (SWR, layouts)
+ * puissent distinguer un vrai 404 d'un 429/5xx transitoire. SWR s'appuie
+ * aussi sur `status` pour ne pas re-tenter les 404.
+ */
+export class HttpError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+  }
+}
+
+/** Extrait le message d'un corps d'erreur Adonis ({message} | {errors: [{message}]} | {error: {message}}). */
+const readErrorMessage = async (res: Response): Promise<string | undefined> => {
+  const body = (await res.json().catch(() => undefined)) as
+    | { error?: { message?: string }; errors?: { message?: string }[]; message?: string }
+    | undefined;
+  return body?.error?.message || body?.errors?.[0]?.message || body?.message;
+};
+
+export const fetcher = async (input: RequestInfo, init?: RequestInit) => {
+  const res = await fetch(input, { ...init, headers: { ...localeHeaders(), ...init?.headers } });
+  if (!res.ok) {
+    const message = await readErrorMessage(res);
+    throw new HttpError(message ?? `Request failed with status ${res.status}`, res.status);
+  }
+  return res.json();
+};
 
 /**
  * Returns the base URL for API calls

--- a/frontend/src/http/server.ts
+++ b/frontend/src/http/server.ts
@@ -1,4 +1,4 @@
-import { getBaseUrl } from "@/app/_cheatcode";
+import { getBaseUrl, HttpError } from "@/app/_cheatcode";
 import { Category, Server, ServerGrowthStat, ServerStat, ServerType } from "@/types/server";
 
 export interface ServerPayload {
@@ -102,7 +102,7 @@ export const getMyServers = async (token: string) => {
 export const getServer = async (serverId: number) => {
   const response = await fetch(`${getBaseUrl()}/servers/${serverId}`);
   if (!response.ok) {
-    throw new Error(`Failed to fetch server ${serverId}: ${response.status}`);
+    throw new HttpError(`Failed to fetch server ${serverId}`, response.status);
   }
   return response.json() as Promise<{ server: Server; stats: ServerStat[]; categories: Category[] }>;
 };


### PR DESCRIPTION
The SWR fetcher resolved every response with res.json() without checking
res.ok, so a 429 (rate limit), 500 or any other error body became "data"
with no `server` key and the server page fell through to its not-found
state — and SWR even cached that body, making the fake 404 render
instantly on revisit.

- fetcher now throws an HttpError carrying the HTTP status and the
  backend's error message
- the server page only shows "not found" on a real 404; 429 gets a
  dedicated "too many requests" card and other failures a generic error
  card, both with a retry button (en/fr/es translations added)
- generateMetadata only bakes the noindex "not found" metadata into the
  ISR cache on a real 404, so a transient backend error can no longer
  deindex a valid server for 10 minutes

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UnPtFcLX9b4JcWN9yiHfbQ