### PR TITLE
refactor: deepen modules across API client, stats, posts, servers &amp; auth

### DIFF
--- a/backend/app/constants/intervals.ts
+++ b/backend/app/constants/intervals.ts
@@ -1,0 +1,18 @@
+/**
+ * Intervalles d'agrégation autorisés pour les stats — source unique de vérité.
+ *
+ * Auparavant l'ensemble était recopié dans deux validators (`stat.ts`,
+ * `global_stat.ts`) ; ajouter une taille de bucket demandait d'éditer les deux et
+ * de penser au switch `StatsService.intervalToSeconds`. On centralise l'ensemble
+ * ici ; `intervalToSeconds` reste l'autorité pour la conversion en secondes.
+ */
+export const STAT_INTERVALS = [
+  '30 minutes',
+  '1 hour',
+  '2 hours',
+  '6 hours',
+  '1 day',
+  '1 week',
+] as const
+
+export type StatInterval = (typeof STAT_INTERVALS)[number]

--- a/backend/app/constants/locales.ts
+++ b/backend/app/constants/locales.ts
@@ -1,0 +1,23 @@
+/**
+ * Locales de contenu supportées par la plateforme — source unique de vérité,
+ * alignée sur le routing i18n du frontend (`frontend/src/i18n/routing.ts`).
+ *
+ * Historique : la liste était dupliquée et divergente (le back ne connaissait que
+ * `fr`/`en` alors que le front autorisait `es`). Résultat : un article espagnol
+ * pouvait être créé — le validator accepte `es` — mais jamais servi, car la
+ * résolution de lecture rabattait silencieusement `es` sur `en`. Un seul endroit
+ * désormais, pour que création et lecture ne puissent plus diverger.
+ */
+export const SUPPORTED_LOCALES = ['fr', 'en', 'es'] as const
+
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number]
+
+/** Langue de repli quand aucune locale valide n'est demandée. */
+export const DEFAULT_LOCALE: SupportedLocale = 'en'
+
+/** Locale demandée (ex: `?locale=`), validée contre les locales supportées. */
+export function resolveLocale(value: unknown): SupportedLocale {
+  return SUPPORTED_LOCALES.includes(value as SupportedLocale)
+    ? (value as SupportedLocale)
+    : DEFAULT_LOCALE
+}

--- a/backend/app/controllers/advertisements_controller.ts
+++ b/backend/app/controllers/advertisements_controller.ts
@@ -2,6 +2,7 @@ import Advertisement from '#models/advertisement'
 import AdvertisementEvent from '#models/advertisement_event'
 import AdvertisementPolicy from '#policies/advertisement_policy'
 import AdvertisementStatsService from '#services/advertisement_stats_service'
+import AdRedirectService from '#services/ad_redirect_service'
 import {
   CreateAdvertisementValidator,
   UpdateAdvertisementValidator,
@@ -19,42 +20,6 @@ function parseDate(value: string | null | undefined): DateTime | null {
   if (!value) return null
   const parsed = DateTime.fromISO(value)
   return parsed.isValid ? parsed : null
-}
-
-/**
- * Décode les entités HTML les plus courantes (le navigateur les décode côté client,
- * il faut donc comparer sur la même base).
- */
-function decodeHtmlEntities(value: string): string {
-  // Décodage en une seule passe : la sortie n'est jamais re-traitée, donc
-  // aucun risque de double-décodage (ex. "&amp;#38;" reste "&#38;").
-  return value.replace(/&(?:amp|#38|#x26);/gi, '&')
-}
-
-/**
- * Retire les caractères de contrôle (saut de ligne, tabulation, etc.) d'une URL.
- * Les navigateurs les retirent des URLs ; ils sont surtout interdits dans un
- * en-tête HTTP et provoqueraient un crash s'ils étaient renvoyés tels quels.
- */
-function sanitizeUrl(value: string): string {
-  // eslint-disable-next-line no-control-regex
-  return value.replace(/[\x00-\x1F\x7F]/g, '').trim()
-}
-
-/**
- * Extrait les URLs des attributs href présents dans le HTML d'une publicité.
- * Sert de liste blanche pour la redirection de clic (anti open-redirect).
- */
-function extractHrefs(html: string): Set<string> {
-  const urls = new Set<string>()
-  const regex = /href\s*=\s*["']([^"']+)["']/gi
-  let match: RegExpExecArray | null
-  while ((match = regex.exec(html)) !== null) {
-    const href = sanitizeUrl(match[1])
-    urls.add(href)
-    urls.add(sanitizeUrl(decodeHtmlEntities(href)))
-  }
-  return urls
 }
 
 /**
@@ -175,21 +140,9 @@ export default class AdvertisementsController {
       return response.redirect('/')
     }
 
-    const to = sanitizeUrl(String(request.input('to', '')))
-
-    let target: string | null = null
-    if (to && extractHrefs(ad.htmlContent).has(to)) {
-      try {
-        const parsed = new URL(to)
-        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-          // parsed.href est normalisé : garanti sûr pour un en-tête HTTP Location.
-          target = parsed.href
-        }
-      } catch {
-        target = null
-      }
-    }
-
+    // Allow-list anti open-redirect : la cible doit être un http(s) présent dans
+    // les href du HTML de la pub (cf. AdRedirectService, testé unitairement).
+    const target = AdRedirectService.resolveTarget(ad.htmlContent, String(request.input('to', '')))
     if (!target) {
       return response.redirect('/')
     }

--- a/backend/app/controllers/auth_controller.ts
+++ b/backend/app/controllers/auth_controller.ts
@@ -18,7 +18,7 @@ import mail from '@adonisjs/mail/services/main'
 import jwt from 'jsonwebtoken'
 import { DateTime } from 'luxon'
 import { createHash, randomBytes } from 'node:crypto'
-import fs from 'node:fs/promises'
+import { readUploadedImage } from '#utils/uploaded_image'
 
 export default class AuthController {
   /**
@@ -292,13 +292,19 @@ export default class AuthController {
       extnames: ['jpg', 'jpeg', 'png', 'webp', 'gif'],
     })
 
-    if (!image) return response.badRequest({ error: i18n.t('messages.auth.noImageProvided') })
-    if (!image.isValid) return response.badRequest({ error: image.errors })
-    if (!image.tmpPath) return response.badRequest({ error: i18n.t('messages.auth.invalidUpload') })
+    const upload = await readUploadedImage(image)
+    if (!upload.ok) {
+      if (upload.reason === 'missing') {
+        return response.badRequest({ error: i18n.t('messages.auth.noImageProvided') })
+      }
+      if (upload.reason === 'invalid') {
+        return response.badRequest({ error: upload.errors })
+      }
+      return response.badRequest({ error: i18n.t('messages.auth.invalidUpload') })
+    }
 
-    const buffer = await fs.readFile(image.tmpPath)
     const previousAvatar = user.avatarUrl
-    user.avatarUrl = await ImageStorageService.storeUserAvatar(user.id, buffer)
+    user.avatarUrl = await ImageStorageService.storeUserAvatar(user.id, upload.buffer)
     await user.save()
 
     // Remove the previous avatar (only our own uploads — never an OAuth URL).

--- a/backend/app/controllers/posts_controller.ts
+++ b/backend/app/controllers/posts_controller.ts
@@ -2,7 +2,7 @@ import Post from '#models/post'
 import PostTranslation from '#models/post_translation'
 import PostPolicy from '#policies/post_policy'
 import PlaceholderService from '#services/placeholder_service'
-import { SlugService } from '#services/slug_service'
+import PostService from '#services/post_service'
 import {
   CreatePostValidator,
   PreviewPlaceholderValidator,
@@ -11,59 +11,7 @@ import {
   UpdatePostValidator,
 } from '#validators/post'
 import type { HttpContext } from '@adonisjs/core/http'
-import db from '@adonisjs/lucid/services/db'
-import { DateTime } from 'luxon'
-
-const SUPPORTED_LOCALES = ['fr', 'en'] as const
-const DEFAULT_LOCALE = 'en'
-
-/** Locale demandée via `?locale=`, validée contre les locales supportées. */
-function resolveLocale(value: unknown): string {
-  return SUPPORTED_LOCALES.includes(value as never) ? (value as string) : DEFAULT_LOCALE
-}
-
-function serializeAuthor(post: Post) {
-  if (!post.author) return undefined
-  return { id: post.author.id, username: post.author.username, avatarUrl: post.author.avatarUrl }
-}
-
-/** Forme publique : champs article + traduction résolue (avec fallback) + slugs. */
-function serializePost(post: Post, locale: string) {
-  const resolved = post.forLocale(locale)
-  return {
-    id: post.id,
-    title: resolved.title,
-    slug: resolved.slug,
-    content: resolved.content,
-    excerpt: resolved.excerpt,
-    coverImage: post.coverImage,
-    published: post.published,
-    viewCount: post.viewCount,
-    publishedAt: post.publishedAt,
-    defaultLocale: post.defaultLocale,
-    localeUsed: resolved.localeUsed,
-    slugs: post.slugsByLocale(),
-    userId: post.userId,
-    createdAt: post.createdAt,
-    updatedAt: post.updatedAt,
-    author: serializeAuthor(post),
-  }
-}
-
-/** Forme admin : la forme publique (langue principale) + toutes les traductions brutes. */
-function serializeAdminPost(post: Post) {
-  return {
-    ...serializePost(post, post.defaultLocale),
-    availableLocales: post.translations.map((t) => t.locale),
-    translations: post.translations.map((t) => ({
-      locale: t.locale,
-      title: t.title,
-      slug: t.slug,
-      content: t.content,
-      excerpt: t.excerpt,
-    })),
-  }
-}
+import { resolveLocale } from '../constants/locales.js'
 
 export default class PostsController {
   /**
@@ -94,7 +42,7 @@ export default class PostsController {
 
     return response.ok({
       meta: posts.toJSON().meta,
-      data: posts.all().map((post) => serializePost(post, locale)),
+      data: posts.all().map((post) => PostService.serialize(post, locale)),
     })
   }
 
@@ -135,7 +83,7 @@ export default class PostsController {
       return response.notFound({ message: i18n.t('messages.posts.notFound') })
     }
 
-    return response.ok(serializePost(post, locale))
+    return response.ok(PostService.serialize(post, locale))
   }
 
   /**
@@ -148,14 +96,7 @@ export default class PostsController {
    * @responseBody 204 - No content
    */
   async recordView({ params, response }: HttpContext) {
-    const translation = await PostTranslation.query().where('slug', params.slug).first()
-    if (translation) {
-      await Post.query()
-        .where('id', translation.postId)
-        .where('published', true)
-        .increment('view_count', 1)
-    }
-
+    await PostService.recordView(params.slug)
     return response.noContent()
   }
 
@@ -185,19 +126,7 @@ export default class PostsController {
     // L'endpoint est public : on lit l'utilisateur s'il est connecté sans l'imposer.
     await auth.check()
 
-    const now = DateTime.now().toSQL()
-    await db
-      .table('post_feedbacks')
-      .insert({
-        post_id: post.id,
-        visitor_id: visitorId,
-        user_id: auth.user?.id ?? null,
-        helpful,
-        created_at: now,
-        updated_at: now,
-      })
-      .onConflict(['post_id', 'visitor_id'])
-      .merge({ helpful, user_id: auth.user?.id ?? null, updated_at: now })
+    await PostService.recordFeedback(post, { helpful, visitorId, userId: auth.user?.id ?? null })
 
     return response.noContent()
   }
@@ -265,7 +194,7 @@ export default class PostsController {
 
     return response.ok({
       meta: posts.toJSON().meta,
-      data: posts.all().map((post) => serializeAdminPost(post)),
+      data: posts.all().map((post) => PostService.serializeAdmin(post)),
     })
   }
 
@@ -299,7 +228,7 @@ export default class PostsController {
       return response.forbidden({ error: i18n.t('messages.posts.updateOwnOnly') })
     }
 
-    return response.ok(serializeAdminPost(post))
+    return response.ok(PostService.serializeAdmin(post))
   }
 
   /**
@@ -338,38 +267,9 @@ export default class PostsController {
       })
     }
 
-    const post = await db.transaction(async (trx) => {
-      const created = await Post.create(
-        {
-          userId: user.id,
-          published: false,
-          coverImage: data.coverImage || null,
-          defaultLocale: data.defaultLocale,
-        },
-        { client: trx }
-      )
+    const post = await PostService.create(user.id, data)
 
-      for (const translation of data.translations) {
-        const slug = await SlugService.uniqueSlug(
-          translation.locale,
-          translation.slug || translation.title
-        )
-        await created.related('translations').create({
-          locale: translation.locale,
-          title: translation.title,
-          slug,
-          content: translation.content,
-          excerpt: translation.excerpt || null,
-        })
-      }
-
-      return created
-    })
-
-    await post.load('author')
-    await post.load('translations')
-
-    return response.created(serializeAdminPost(post))
+    return response.created(PostService.serializeAdmin(post))
   }
 
   /**
@@ -399,45 +299,9 @@ export default class PostsController {
 
     const data = await request.validateUsing(UpdatePostValidator)
 
-    await db.transaction(async (trx) => {
-      post.useTransaction(trx)
-      if (data.defaultLocale !== undefined) post.defaultLocale = data.defaultLocale
-      if (data.coverImage !== undefined) post.coverImage = data.coverImage || null
-      await post.save()
+    await PostService.update(post, data)
 
-      for (const entry of data.translations ?? []) {
-        const existing = await PostTranslation.query({ client: trx })
-          .where('post_id', post.id)
-          .where('locale', entry.locale)
-          .first()
-
-        if (existing) {
-          if (entry.title !== undefined) existing.title = entry.title
-          if (entry.content !== undefined) existing.content = entry.content
-          if (entry.excerpt !== undefined) existing.excerpt = entry.excerpt || null
-          if (entry.slug !== undefined) {
-            existing.slug = await SlugService.uniqueSlug(entry.locale, entry.slug, existing.id)
-          }
-          existing.useTransaction(trx)
-          await existing.save()
-        } else if (entry.title && entry.content) {
-          // Nouvelle langue : nécessite au minimum titre + contenu.
-          const slug = await SlugService.uniqueSlug(entry.locale, entry.slug || entry.title)
-          await post.related('translations').create({
-            locale: entry.locale,
-            title: entry.title,
-            slug,
-            content: entry.content,
-            excerpt: entry.excerpt || null,
-          })
-        }
-      }
-    })
-
-    await post.load('author')
-    await post.load('translations')
-
-    return response.ok(serializeAdminPost(post))
+    return response.ok(PostService.serializeAdmin(post))
   }
 
   /**
@@ -493,14 +357,9 @@ export default class PostsController {
       return response.forbidden({ error: i18n.t('messages.posts.publishOwnOnly') })
     }
 
-    post.published = true
-    post.publishedAt = DateTime.now()
-    await post.save()
+    await PostService.setPublished(post, true)
 
-    await post.load('author')
-    await post.load('translations')
-
-    return response.ok(serializeAdminPost(post))
+    return response.ok(PostService.serializeAdmin(post))
   }
 
   /**
@@ -527,14 +386,9 @@ export default class PostsController {
       return response.forbidden({ error: i18n.t('messages.posts.unpublishOwnOnly') })
     }
 
-    post.published = false
-    post.publishedAt = null
-    await post.save()
+    await PostService.setPublished(post, false)
 
-    await post.load('author')
-    await post.load('translations')
-
-    return response.ok(serializeAdminPost(post))
+    return response.ok(PostService.serializeAdmin(post))
   }
 
   /**
@@ -613,59 +467,6 @@ export default class PostsController {
 
     // L'analytics enregistre les vues par chemin exact ; un article a un chemin
     // par langue (slug par locale), on agrège donc sur tous ses slugs.
-    const paths = post.translations.map((t) => `/blog/${t.slug}`)
-    const resolved = post.forLocale(post.defaultLocale)
-
-    const [analyticsRow, feedbackRow, recentViewers] = await Promise.all([
-      db
-        .from('page_views')
-        .whereIn('path', paths)
-        .select(db.raw('count(*) as consented_views'))
-        .select(db.raw('count(*) filter (where user_id is not null) as logged_in_views'))
-        .select(db.raw('count(distinct visitor_id) as unique_visitors'))
-        .first(),
-
-      db
-        .from('post_feedbacks')
-        .where('post_id', post.id)
-        .select(db.raw('count(*) filter (where helpful) as helpful'))
-        .select(db.raw('count(*) filter (where not helpful) as not_helpful'))
-        .first(),
-
-      db
-        .from('page_views')
-        .join('users', 'users.id', 'page_views.user_id')
-        .whereIn('page_views.path', paths)
-        .select('users.id as id', 'users.username as username', 'users.avatar_url as avatar_url')
-        .select(db.raw('max(page_views.created_at) as last_viewed_at'))
-        .groupBy('users.id', 'users.username', 'users.avatar_url')
-        .orderByRaw('max(page_views.created_at) desc')
-        .limit(50),
-    ])
-
-    return response.ok({
-      post: {
-        id: post.id,
-        title: resolved.title,
-        slugs: post.slugsByLocale(),
-        viewCount: post.viewCount,
-      },
-      views: {
-        total: post.viewCount,
-        consented: Number(analyticsRow?.consented_views ?? 0),
-        loggedIn: Number(analyticsRow?.logged_in_views ?? 0),
-        uniqueVisitors: Number(analyticsRow?.unique_visitors ?? 0),
-      },
-      feedback: {
-        helpful: Number(feedbackRow?.helpful ?? 0),
-        notHelpful: Number(feedbackRow?.not_helpful ?? 0),
-      },
-      recentViewers: recentViewers.map((row) => ({
-        id: Number(row.id),
-        username: row.username,
-        avatarUrl: row.avatar_url,
-        lastViewedAt: row.last_viewed_at,
-      })),
-    })
+    return response.ok(await PostService.engagement(post))
   }
 }

--- a/backend/app/controllers/posts_controller.ts
+++ b/backend/app/controllers/posts_controller.ts
@@ -12,6 +12,7 @@ import {
 } from '#validators/post'
 import type { HttpContext } from '@adonisjs/core/http'
 import { resolveLocale } from '../constants/locales.js'
+import { requireAbility } from '#utils/require_ability'
 
 export default class PostsController {
   /**
@@ -160,15 +161,13 @@ export default class PostsController {
    * @responseBody 401 - {"error": "Unauthorized"}
    * @responseBody 403 - {"error": "Access denied. Writer privileges required."}
    */
-  async adminIndex({ request, response, auth, bouncer, i18n }: HttpContext) {
-    const user = auth.user
-    if (!user) {
-      return response.unauthorized({ error: i18n.t('messages.posts.unauthorized') })
-    }
-
-    if (await bouncer.with(PostPolicy).denies('manage')) {
-      return response.forbidden({ error: i18n.t('messages.posts.writerRequired') })
-    }
+  async adminIndex(ctx: HttpContext) {
+    const { request, response } = ctx
+    const user = await requireAbility(ctx, () => ctx.bouncer.with(PostPolicy).denies('manage'), {
+      unauthorized: 'messages.posts.unauthorized',
+      forbidden: 'messages.posts.writerRequired',
+    })
+    if (!user) return
 
     const page = Math.max(1, Number.parseInt(request.input('page', 1), 10) || 1)
     const limit = Math.min(100, Math.max(1, Number.parseInt(request.input('limit', 20), 10) || 20))
@@ -243,15 +242,13 @@ export default class PostsController {
    * @responseBody 403 - {"error": "Access denied. Writer privileges required."}
    * @responseBody 422 - {"errors": [{"message": "A translation in the primary language is required.", "field": "translations", "rule": "required"}]}
    */
-  async store({ request, auth, response, bouncer, i18n }: HttpContext) {
-    const user = auth.user
-    if (!user) {
-      return response.unauthorized({ error: i18n.t('messages.posts.unauthorized') })
-    }
-
-    if (await bouncer.with(PostPolicy).denies('manage')) {
-      return response.forbidden({ error: i18n.t('messages.posts.writerRequired') })
-    }
+  async store(ctx: HttpContext) {
+    const { request, response, i18n } = ctx
+    const user = await requireAbility(ctx, () => ctx.bouncer.with(PostPolicy).denies('manage'), {
+      unauthorized: 'messages.posts.unauthorized',
+      forbidden: 'messages.posts.writerRequired',
+    })
+    if (!user) return
 
     const data = await request.validateUsing(CreatePostValidator)
 
@@ -416,15 +413,14 @@ export default class PostsController {
    * @responseBody 403 - {"error": "Access denied. Writer privileges required."}
    * @responseBody 422 - {"errors": [{"message": "The serverId field must be defined", "field": "serverId", "rule": "required"}]}
    */
-  async previewPlaceholder({ request, response, auth, bouncer, i18n }: HttpContext) {
-    const user = auth.user
-    if (!user) {
-      return response.unauthorized({ error: i18n.t('messages.posts.unauthorized') })
-    }
-
-    if (await bouncer.with(PostPolicy).denies('manage')) {
-      return response.forbidden({ error: i18n.t('messages.posts.writerRequired') })
-    }
+  async previewPlaceholder(ctx: HttpContext) {
+    const { request, response } = ctx
+    const authorized = await requireAbility(
+      ctx,
+      () => ctx.bouncer.with(PostPolicy).denies('manage'),
+      { unauthorized: 'messages.posts.unauthorized', forbidden: 'messages.posts.writerRequired' }
+    )
+    if (!authorized) return
 
     const { placeholderName, serverId } = await request.validateUsing(PreviewPlaceholderValidator)
 

--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -1,20 +1,11 @@
-import Category from '#models/category'
 import ServerStat from '#models/server_stat'
 import ServerPolicy from '#policies/server_policy'
 import { CreateServerValidator, UpdateServerValidator } from '#validators/server'
 import type { HttpContext } from '@adonisjs/core/http'
-import {
-  INTERACTIVE_PING_TIMEOUT,
-  isPingPossible,
-  pingMinecraftServer,
-} from '../../minecraft-ping/minecraft_ping.js'
-import type { NormalizedPing } from '../../minecraft-ping/minecraft_ping.js'
 import Server from '../models/server.js'
 import CacheService from '#services/cache_service'
 import ServerListingService from '#services/server_listing_service'
-import DuplicateDetectionService from '#services/duplicate_detection_service'
-import Language from '#models/language'
-import { deriveServerWebsite } from '#utils/server_website'
+import ServerRegistrationService from '#services/server_registration_service'
 
 export default class ServersController {
   /**
@@ -103,71 +94,27 @@ export default class ServersController {
     }
 
     const validatedData = await CreateServerValidator.validate(data)
-    const type = validatedData.type ?? 'java'
 
-    // Ping interactif : sert à la fois de test de joignabilité ET de source
-    // pour les empreintes de détection de doublon (favicon, MOTD, version).
-    let pingData: NormalizedPing | null = null
-    try {
-      pingData = await pingMinecraftServer(
-        type,
-        validatedData.address,
-        validatedData.port,
-        INTERACTIVE_PING_TIMEOUT
-      )
-    } catch {
-      pingData = null
+    // Orchestration ping → fingerprint → doublon → création → taxonomie dans le
+    // service (testable sans HttpContext). Le controller ne fait que mapper le
+    // résultat sur la réponse HTTP.
+    const result = await ServerRegistrationService.register(validatedData, user)
+    switch (result.status) {
+      case 'unreachable':
+        return response.badRequest({ message: i18n.t('messages.servers.notReachable') })
+      case 'duplicate':
+        return response.conflict({
+          message: i18n.t('messages.servers.duplicate'),
+          existingServer: {
+            id: result.duplicate.server.id,
+            name: result.duplicate.server.name,
+          },
+          score: result.duplicate.score,
+          matchedSignals: result.duplicate.signals,
+        })
+      case 'created':
+        return result.server
     }
-    if (!pingData) {
-      return response.badRequest({ message: i18n.t('messages.servers.notReachable') })
-    }
-
-    // Détection de doublon : un même serveur listé sous plusieurs adresses
-    // (play./mc./IP brute). Lookups indexés — cf. DuplicateDetectionService.
-    const fingerprint = await DuplicateDetectionService.fingerprint(
-      validatedData.address,
-      validatedData.port,
-      pingData
-    )
-    const duplicate = await DuplicateDetectionService.findDuplicate(fingerprint)
-    if (duplicate) {
-      return response.conflict({
-        message: i18n.t('messages.servers.duplicate'),
-        existingServer: { id: duplicate.server.id, name: duplicate.server.name },
-        score: duplicate.score,
-        matchedSignals: duplicate.signals,
-      })
-    }
-
-    const { categories, languages, ...dataToCreate } = validatedData
-
-    // Website: provided by the owner, otherwise derived from the address.
-    const website = dataToCreate.website ?? deriveServerWebsite(validatedData.address)
-
-    const server = await Server.create({
-      ...dataToCreate,
-      type,
-      website,
-      version: fingerprint.version,
-      faviconHash: fingerprint.faviconHash,
-      resolvedEndpoint: fingerprint.resolvedEndpoint,
-      motdHash: fingerprint.motdHash,
-    })
-
-    const categoriesToAttach = await Promise.all(
-      categories.map((name) => Category.findBy('name', name))
-    )
-
-    await server.related('categories').attach(categoriesToAttach.flatMap((c) => (c ? [c.id] : [])))
-
-    const languagesToAttach = await Promise.all(
-      languages.map((code) => Language.findBy('code', code))
-    )
-
-    await server.related('languages').attach(languagesToAttach.flatMap((l) => (l ? [l.id] : [])))
-
-    await server.related('user').associate(user)
-    return server
   }
 
   private async getActualStats(server: Server, amount: number = 1) {
@@ -232,40 +179,12 @@ export default class ServersController {
       return response.forbidden({ message: i18n.t('messages.servers.unauthorized') })
     }
 
-    const { categories, languages, ...dataToUpdate } = validatedData
-
-    // If the address changes without an explicit website, re-derive it.
-    if (dataToUpdate.website === undefined && validatedData.address) {
-      const derived = deriveServerWebsite(validatedData.address)
-      if (derived) dataToUpdate.website = derived
-    }
-
-    const successPing = await isPingPossible(
-      validatedData.type ?? server.type,
-      validatedData.address ?? server.address,
-      validatedData.port ?? server.port
-    )
-    if (!successPing) {
+    // Re-ping de joignabilité + sync taxonomie + persistance dans le service.
+    const result = await ServerRegistrationService.update(server, validatedData)
+    if (result.status === 'unreachable') {
       return response.badRequest({ message: i18n.t('messages.servers.notReachable') })
     }
-
-    if (categories) {
-      const categoriesToAttach = await Promise.all(
-        categories.map((name) => Category.findBy('name', name))
-      )
-
-      await server.related('categories').sync(categoriesToAttach.flatMap((c) => (c ? [c.id] : [])))
-    }
-
-    if (languages) {
-      const languagesToAttach = await Promise.all(
-        languages.map((code) => Language.findBy('code', code))
-      )
-
-      await server.related('languages').sync(languagesToAttach.flatMap((l) => (l ? [l.id] : [])))
-    }
-
-    return server.merge(dataToUpdate).save()
+    return result.server
   }
 
   /**
@@ -358,9 +277,7 @@ export default class ServersController {
       ids: ids.join(','),
     })
 
-    const nocache = request.input('nocache') === '1'
-    const bypass =
-      nocache && (process.env.NODE_ENV !== 'production' || ctx.auth?.user?.role === 'admin')
+    const bypass = CacheService.bypassAllowed(ctx)
 
     // TTL réduit quand la requête est personnalisée (favoris) — la fragmentation
     // cache coûte moins en stockage, et les stats changent toutes les 10 min.

--- a/backend/app/controllers/stats_controller.ts
+++ b/backend/app/controllers/stats_controller.ts
@@ -4,12 +4,6 @@ import { StatValidator } from '#validators/stat'
 import { GlobalStatValidator } from '#validators/global_stat'
 import type { HttpContext } from '@adonisjs/core/http'
 
-function bypassFlag(ctx: HttpContext): boolean {
-  if (ctx.request.input('nocache') !== '1') return false
-  if (process.env.NODE_ENV !== 'production') return true
-  return ctx.auth?.user?.role === 'admin'
-}
-
 export default class StatsController {
   /**
    * @index
@@ -53,7 +47,7 @@ export default class StatsController {
       key,
       300,
       () => StatsService.getStats(validatedData),
-      { bypass: bypassFlag(ctx) }
+      { bypass: CacheService.bypassAllowed(ctx) }
     )
     return response.status(200).json(results)
   }
@@ -91,7 +85,7 @@ export default class StatsController {
       key,
       300,
       () => StatsService.getGlobalStats(validatedData),
-      { bypass: bypassFlag(ctx) }
+      { bypass: CacheService.bypassAllowed(ctx) }
     )
     return response.status(200).json(results)
   }

--- a/backend/app/controllers/uploads_controller.ts
+++ b/backend/app/controllers/uploads_controller.ts
@@ -2,6 +2,7 @@ import type { HttpContext } from '@adonisjs/core/http'
 import ImageStorageService from '#services/image_storage_service'
 import PostPolicy from '#policies/post_policy'
 import { readUploadedImage } from '#utils/uploaded_image'
+import { requireAbility } from '#utils/require_ability'
 
 export default class UploadsController {
   /**
@@ -17,15 +18,18 @@ export default class UploadsController {
    * @responseBody 403 - {"error": "Access denied. Writer privileges required."}
    * @responseBody 500 - {"error": "Failed to process image", "details": "<sharp error message>"}
    */
-  async uploadImage({ request, response, auth, bouncer, i18n }: HttpContext) {
-    const user = auth.user
-    if (!user) {
-      return response.unauthorized({ error: i18n.t('messages.uploads.unauthorized') })
-    }
+  async uploadImage(ctx: HttpContext) {
+    const { request, response, i18n } = ctx
+    const authorized = await requireAbility(
+      ctx,
+      () => ctx.bouncer.with(PostPolicy).denies('manage'),
+      {
+        unauthorized: 'messages.uploads.unauthorized',
+        forbidden: 'messages.uploads.writerRequired',
+      }
+    )
+    if (!authorized) return
 
-    if (await bouncer.with(PostPolicy).denies('manage')) {
-      return response.forbidden({ error: i18n.t('messages.uploads.writerRequired') })
-    }
     const image = request.file('image', {
       size: '5mb',
       extnames: ['jpg', 'jpeg', 'png', 'webp', 'gif'],

--- a/backend/app/controllers/uploads_controller.ts
+++ b/backend/app/controllers/uploads_controller.ts
@@ -1,7 +1,7 @@
 import type { HttpContext } from '@adonisjs/core/http'
-import fs from 'node:fs/promises'
 import ImageStorageService from '#services/image_storage_service'
 import PostPolicy from '#policies/post_policy'
+import { readUploadedImage } from '#utils/uploaded_image'
 
 export default class UploadsController {
   /**
@@ -31,21 +31,19 @@ export default class UploadsController {
       extnames: ['jpg', 'jpeg', 'png', 'webp', 'gif'],
     })
 
-    if (!image) {
-      return response.badRequest({ error: i18n.t('messages.uploads.noImageProvided') })
-    }
-
-    if (!image.isValid) {
-      return response.badRequest({ error: image.errors })
-    }
-
-    if (!image.tmpPath) {
+    const upload = await readUploadedImage(image)
+    if (!upload.ok) {
+      if (upload.reason === 'missing') {
+        return response.badRequest({ error: i18n.t('messages.uploads.noImageProvided') })
+      }
+      if (upload.reason === 'invalid') {
+        return response.badRequest({ error: upload.errors })
+      }
       return response.badRequest({ error: i18n.t('messages.uploads.invalidUpload') })
     }
 
     try {
-      const imageBuffer = await fs.readFile(image.tmpPath)
-      const url = await ImageStorageService.storeBlogImage(imageBuffer)
+      const url = await ImageStorageService.storeBlogImage(upload.buffer)
       return response.ok({ url })
     } catch (error) {
       return response.internalServerError({

--- a/backend/app/controllers/users_controller.ts
+++ b/backend/app/controllers/users_controller.ts
@@ -1,9 +1,9 @@
 import Server from '#models/server'
 import User from '#models/user'
 import UserPolicy from '#policies/user_policy'
+import DuplicateAccountService from '#services/duplicate_account_service'
 import { CreateUserValidator, UpdateUserValidator } from '#validators/user'
 import type { HttpContext } from '@adonisjs/core/http'
-import db from '@adonisjs/lucid/services/db'
 
 export default class UsersController {
   /**
@@ -189,7 +189,7 @@ export default class UsersController {
       .preload('languages')
       .orderBy('created_at', 'desc')
 
-    const duplicates = await this.findDuplicateAccounts(user.id)
+    const duplicates = await DuplicateAccountService.forUser(user.id)
 
     // `email` and `provider` are intentionally surfaced here even though the model
     // hides `email` from default serialization — this admin-only view needs them.
@@ -212,69 +212,6 @@ export default class UsersController {
         duplicateCount: duplicates.length,
       },
     })
-  }
-
-  /**
-   * Finds other accounts that share a device (same anonymous visitor) or a
-   * network (same hashed IP) with the given user — the strongest signals we have
-   * for spotting multi-accounting, sourced from the analytics visitor tables.
-   */
-  private async findDuplicateAccounts(userId: number) {
-    const ownLinks = await db.from('visitor_accounts').where('user_id', userId).select('visitor_id')
-    const visitorIds = ownLinks.map((row) => row.visitor_id)
-    if (visitorIds.length === 0) return []
-
-    const ipHashRows = await db
-      .from('visitors')
-      .whereIn('id', visitorIds)
-      .whereNotNull('ip_hash')
-      .select('ip_hash')
-    const ipHashes = ipHashRows.map((row) => row.ip_hash)
-
-    let sharedIpVisitorIds: number[] = []
-    if (ipHashes.length > 0) {
-      const ipVisitorRows = await db.from('visitors').whereIn('ip_hash', ipHashes).select('id')
-      sharedIpVisitorIds = ipVisitorRows.map((row) => row.id)
-    }
-
-    // candidate userId → which signals tie them back to the target user.
-    const signals = new Map<number, { sameDevice: boolean; sameIp: boolean }>()
-    const flag = (rows: { user_id: number }[], key: 'sameDevice' | 'sameIp') => {
-      for (const { user_id: candidateId } of rows) {
-        if (candidateId === userId) continue
-        const entry = signals.get(candidateId) ?? { sameDevice: false, sameIp: false }
-        entry[key] = true
-        signals.set(candidateId, entry)
-      }
-    }
-
-    const deviceRows = await db
-      .from('visitor_accounts')
-      .whereIn('visitor_id', visitorIds)
-      .select('user_id')
-    flag(deviceRows, 'sameDevice')
-
-    if (sharedIpVisitorIds.length > 0) {
-      const ipRows = await db
-        .from('visitor_accounts')
-        .whereIn('visitor_id', sharedIpVisitorIds)
-        .select('user_id')
-      flag(ipRows, 'sameIp')
-    }
-
-    if (signals.size === 0) return []
-
-    const candidates = await User.query().whereIn('id', [...signals.keys()])
-    return candidates
-      .map((candidate) => ({
-        id: candidate.id,
-        username: candidate.username,
-        email: candidate.email,
-        role: candidate.role,
-        createdAt: candidate.createdAt,
-        signals: signals.get(candidate.id)!,
-      }))
-      .sort((a, b) => Number(b.signals.sameDevice) - Number(a.signals.sameDevice))
   }
 
   /**

--- a/backend/app/controllers/users_controller.ts
+++ b/backend/app/controllers/users_controller.ts
@@ -3,6 +3,7 @@ import User from '#models/user'
 import UserPolicy from '#policies/user_policy'
 import DuplicateAccountService from '#services/duplicate_account_service'
 import { CreateUserValidator, UpdateUserValidator } from '#validators/user'
+import { requireAbility } from '#utils/require_ability'
 import type { HttpContext } from '@adonisjs/core/http'
 
 export default class UsersController {
@@ -125,15 +126,17 @@ export default class UsersController {
    * @responseBody 401 - {"error": "Unauthorized"}
    * @responseBody 403 - {"error": "Access denied. Admin privileges required."}
    */
-  async adminIndex({ request, response, auth, bouncer, i18n }: HttpContext) {
-    const currentUser = auth.user
-    if (!currentUser) {
-      return response.unauthorized({ error: i18n.t('messages.users.unauthorized') })
-    }
-
-    if (await bouncer.with(UserPolicy).denies('manage')) {
-      return response.forbidden({ error: i18n.t('messages.users.adminRequired') })
-    }
+  async adminIndex(ctx: HttpContext) {
+    const { request, response } = ctx
+    const authorized = await requireAbility(
+      ctx,
+      () => ctx.bouncer.with(UserPolicy).denies('manage'),
+      {
+        unauthorized: 'messages.users.unauthorized',
+        forbidden: 'messages.users.adminRequired',
+      }
+    )
+    if (!authorized) return
 
     const page = Math.max(1, Number.parseInt(request.input('page', 1), 10) || 1)
     const limit = Math.min(100, Math.max(1, Number.parseInt(request.input('limit', 20), 10) || 20))
@@ -169,15 +172,17 @@ export default class UsersController {
    * @responseBody 403 - {"error": "Access denied. Admin privileges required."}
    * @responseBody 404 - {"error": "User not found"}
    */
-  async adminShow({ params, response, auth, bouncer, i18n }: HttpContext) {
-    const currentUser = auth.user
-    if (!currentUser) {
-      return response.unauthorized({ error: i18n.t('messages.users.unauthorized') })
-    }
-
-    if (await bouncer.with(UserPolicy).denies('manage')) {
-      return response.forbidden({ error: i18n.t('messages.users.adminRequired') })
-    }
+  async adminShow(ctx: HttpContext) {
+    const { params, response, i18n } = ctx
+    const authorized = await requireAbility(
+      ctx,
+      () => ctx.bouncer.with(UserPolicy).denies('manage'),
+      {
+        unauthorized: 'messages.users.unauthorized',
+        forbidden: 'messages.users.adminRequired',
+      }
+    )
+    if (!authorized) return
 
     const user = await User.find(params.id)
     if (!user) {

--- a/backend/app/models/server.ts
+++ b/backend/app/models/server.ts
@@ -150,6 +150,25 @@ export default class Server extends BaseModel {
     }
   }
 
+  /**
+   * Résout des noms de catégories en ids existants (les inconnus sont ignorés).
+   * Mutualise le lookup nom→id dupliqué entre la création et la mise à jour d'un
+   * serveur (attach vs sync).
+   */
+  static async resolveCategoryIds(names: string[]): Promise<number[]> {
+    const categories = await Promise.all(names.map((name) => Category.findBy('name', name)))
+    return categories.flatMap((c) => (c ? [c.id] : []))
+  }
+
+  /**
+   * Résout des codes de langues en ids existants (les inconnus sont ignorés).
+   * Pendant de {@link resolveCategoryIds} pour la relation langues.
+   */
+  static async resolveLanguageIds(codes: string[]): Promise<number[]> {
+    const languages = await Promise.all(codes.map((code) => Language.findBy('code', code)))
+    return languages.flatMap((l) => (l ? [l.id] : []))
+  }
+
   async syncLanguages(languageCodes: LanguageCode[]) {
     const trx = await db.transaction()
     try {

--- a/backend/app/services/ad_redirect_service.ts
+++ b/backend/app/services/ad_redirect_service.ts
@@ -1,0 +1,67 @@
+/**
+ * Défense anti open-redirect / header-injection pour les liens de publicité.
+ *
+ * Extraite du controller pour être testable en isolation : la redirection de clic
+ * n'est autorisée que vers une URL `http(s)` qui apparaît littéralement comme un
+ * `href` dans le HTML stocké de la publicité. Toute la logique de normalisation
+ * (entités HTML, caractères de contrôle) et l'allow-list vivent ici.
+ */
+export default class AdRedirectService {
+  /**
+   * Décode les entités HTML les plus courantes (le navigateur les décode côté
+   * client, il faut donc comparer sur la même base). Décodage en une seule passe :
+   * la sortie n'est jamais re-traitée, donc aucun risque de double-décodage
+   * (ex. "&amp;#38;" reste "&#38;").
+   */
+  private static decodeHtmlEntities(value: string): string {
+    return value.replace(/&(?:amp|#38|#x26);/gi, '&')
+  }
+
+  /**
+   * Retire les caractères de contrôle (saut de ligne, tabulation, etc.) d'une URL.
+   * Les navigateurs les retirent des URLs ; ils sont surtout interdits dans un
+   * en-tête HTTP `Location` et provoqueraient un crash s'ils étaient renvoyés tels
+   * quels.
+   */
+  static sanitizeUrl(value: string): string {
+    // eslint-disable-next-line no-control-regex
+    return value.replace(/[\x00-\x1F\x7F]/g, '').trim()
+  }
+
+  /**
+   * Extrait les URLs des attributs `href` présents dans le HTML d'une publicité.
+   * Sert de liste blanche pour la redirection de clic.
+   */
+  static extractHrefs(html: string): Set<string> {
+    const urls = new Set<string>()
+    const regex = /href\s*=\s*["']([^"']+)["']/gi
+    let match: RegExpExecArray | null
+    while ((match = regex.exec(html)) !== null) {
+      const href = this.sanitizeUrl(match[1])
+      urls.add(href)
+      urls.add(this.sanitizeUrl(this.decodeHtmlEntities(href)))
+    }
+    return urls
+  }
+
+  /**
+   * Résout une cible de redirection sûre depuis le `to` demandé et le HTML de la
+   * publicité. Renvoie l'URL normalisée (`URL.href`, sûre pour un en-tête HTTP)
+   * si `to`, une fois nettoyé, est un lien `http(s)` présent dans l'allow-list des
+   * href de la pub ; sinon `null`.
+   */
+  static resolveTarget(htmlContent: string, to: string): string | null {
+    const sanitized = this.sanitizeUrl(to)
+    if (!sanitized || !this.extractHrefs(htmlContent).has(sanitized)) return null
+
+    try {
+      const parsed = new URL(sanitized)
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+        return parsed.href
+      }
+    } catch {
+      return null
+    }
+    return null
+  }
+}

--- a/backend/app/services/cache_service.ts
+++ b/backend/app/services/cache_service.ts
@@ -1,6 +1,7 @@
 import redis from '@adonisjs/redis/services/main'
 import logger from '@adonisjs/core/services/logger'
 import { Counter, register } from 'prom-client'
+import type { HttpContext } from '@adonisjs/core/http'
 
 const metricPrefix = `${process.env.APP_NAME ?? 'app'}_`
 
@@ -109,6 +110,17 @@ export default class CacheService {
   static quantizeEpochMs(epochMs: number, gridSeconds = 300): number {
     const gridMs = gridSeconds * 1000
     return Math.floor(epochMs / gridMs) * gridMs
+  }
+
+  /**
+   * Autorise le contournement du cache (`?nocache=1`) : toujours en dev, et en
+   * production uniquement pour un admin. Mutualise la règle qui était dupliquée
+   * entre le StatsController et le ServersController.
+   */
+  static bypassAllowed(ctx: HttpContext): boolean {
+    if (ctx.request.input('nocache') !== '1') return false
+    if (process.env.NODE_ENV !== 'production') return true
+    return ctx.auth?.user?.role === 'admin'
   }
 
   /**

--- a/backend/app/services/duplicate_account_service.ts
+++ b/backend/app/services/duplicate_account_service.ts
@@ -1,0 +1,88 @@
+import User from '#models/user'
+import db from '@adonisjs/lucid/services/db'
+import type { DateTime } from 'luxon'
+
+export interface DuplicateAccountSignals {
+  sameDevice: boolean
+  sameIp: boolean
+}
+
+export interface DuplicateAccount {
+  id: number
+  username: string
+  email: string
+  role: User['role']
+  createdAt: DateTime
+  signals: DuplicateAccountSignals
+}
+
+/**
+ * Détection de multi-comptes — pendant, côté utilisateurs, de
+ * `DuplicateDetectionService` (côté serveurs). Extraite du controller pour être
+ * testable et pour que l'accès aux tables analytics (`visitor_accounts`,
+ * `visitors`) reste concentré ici plutôt que dispersé dans un handler HTTP.
+ */
+export default class DuplicateAccountService {
+  /**
+   * Trouve les autres comptes qui partagent un appareil (même visiteur anonyme)
+   * ou un réseau (même IP hashée) avec l'utilisateur donné — les signaux les plus
+   * forts pour repérer le multi-comptes, issus des tables visiteurs de l'analytics.
+   */
+  static async forUser(userId: number): Promise<DuplicateAccount[]> {
+    const ownLinks = await db.from('visitor_accounts').where('user_id', userId).select('visitor_id')
+    const visitorIds = ownLinks.map((row) => row.visitor_id)
+    if (visitorIds.length === 0) return []
+
+    const ipHashRows = await db
+      .from('visitors')
+      .whereIn('id', visitorIds)
+      .whereNotNull('ip_hash')
+      .select('ip_hash')
+    const ipHashes = ipHashRows.map((row) => row.ip_hash)
+
+    let sharedIpVisitorIds: number[] = []
+    if (ipHashes.length > 0) {
+      const ipVisitorRows = await db.from('visitors').whereIn('ip_hash', ipHashes).select('id')
+      sharedIpVisitorIds = ipVisitorRows.map((row) => row.id)
+    }
+
+    // candidate userId → which signals tie them back to the target user.
+    const signals = new Map<number, DuplicateAccountSignals>()
+    const flag = (rows: { user_id: number }[], key: 'sameDevice' | 'sameIp') => {
+      for (const { user_id: candidateId } of rows) {
+        if (candidateId === userId) continue
+        const entry = signals.get(candidateId) ?? { sameDevice: false, sameIp: false }
+        entry[key] = true
+        signals.set(candidateId, entry)
+      }
+    }
+
+    const deviceRows = await db
+      .from('visitor_accounts')
+      .whereIn('visitor_id', visitorIds)
+      .select('user_id')
+    flag(deviceRows, 'sameDevice')
+
+    if (sharedIpVisitorIds.length > 0) {
+      const ipRows = await db
+        .from('visitor_accounts')
+        .whereIn('visitor_id', sharedIpVisitorIds)
+        .select('user_id')
+      flag(ipRows, 'sameIp')
+    }
+
+    if (signals.size === 0) return []
+
+    const candidates = await User.query().whereIn('id', [...signals.keys()])
+    return candidates
+      .map((candidate) => ({
+        id: candidate.id,
+        username: candidate.username,
+        email: candidate.email,
+        role: candidate.role,
+        createdAt: candidate.createdAt,
+        signals: signals.get(candidate.id)!,
+      }))
+      .sort((a, b) => Number(b.signals.sameDevice) - Number(a.signals.sameDevice))
+  }
+}

--- a/backend/app/services/post_service.ts
+++ b/backend/app/services/post_service.ts
@@ -1,0 +1,256 @@
+import Post from '#models/post'
+import PostTranslation from '#models/post_translation'
+import { SlugService } from '#services/slug_service'
+import { type CreatePostValidator, type UpdatePostValidator } from '#validators/post'
+import db from '@adonisjs/lucid/services/db'
+import { DateTime } from 'luxon'
+
+type CreatePostData = Awaited<ReturnType<typeof CreatePostValidator.validate>>
+type UpdatePostData = Awaited<ReturnType<typeof UpdatePostValidator.validate>>
+
+export interface PostFeedbackInput {
+  helpful: boolean
+  visitorId: string
+  userId: number | null
+}
+
+/**
+ * Logique métier des articles — extraite du controller (qui était le plus gros du
+ * repo) pour être testable et pour que les transactions, la génération de slug,
+ * l'upsert de traductions, la sérialisation et l'agrégation analytics vivent au
+ * même endroit plutôt que dispersées dans les handlers HTTP.
+ */
+export default class PostService {
+  // ---------------------------------------------------------------------------
+  // Sérialisation
+  // ---------------------------------------------------------------------------
+
+  static serializeAuthor(post: Post) {
+    if (!post.author) return undefined
+    return { id: post.author.id, username: post.author.username, avatarUrl: post.author.avatarUrl }
+  }
+
+  /** Forme publique : champs article + traduction résolue (avec fallback) + slugs. */
+  static serialize(post: Post, locale: string) {
+    const resolved = post.forLocale(locale)
+    return {
+      id: post.id,
+      title: resolved.title,
+      slug: resolved.slug,
+      content: resolved.content,
+      excerpt: resolved.excerpt,
+      coverImage: post.coverImage,
+      published: post.published,
+      viewCount: post.viewCount,
+      publishedAt: post.publishedAt,
+      defaultLocale: post.defaultLocale,
+      localeUsed: resolved.localeUsed,
+      slugs: post.slugsByLocale(),
+      userId: post.userId,
+      createdAt: post.createdAt,
+      updatedAt: post.updatedAt,
+      author: this.serializeAuthor(post),
+    }
+  }
+
+  /** Forme admin : la forme publique (langue principale) + toutes les traductions brutes. */
+  static serializeAdmin(post: Post) {
+    return {
+      ...this.serialize(post, post.defaultLocale),
+      availableLocales: post.translations.map((t) => t.locale),
+      translations: post.translations.map((t) => ({
+        locale: t.locale,
+        title: t.title,
+        slug: t.slug,
+        content: t.content,
+        excerpt: t.excerpt,
+      })),
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Écritures
+  // ---------------------------------------------------------------------------
+
+  /** Crée un brouillon + ses traductions (slugs générés par locale) dans une transaction. */
+  static async create(userId: number, data: CreatePostData): Promise<Post> {
+    const post = await db.transaction(async (trx) => {
+      const created = await Post.create(
+        {
+          userId,
+          published: false,
+          coverImage: data.coverImage || null,
+          defaultLocale: data.defaultLocale,
+        },
+        { client: trx }
+      )
+
+      for (const translation of data.translations) {
+        const slug = await SlugService.uniqueSlug(
+          translation.locale,
+          translation.slug || translation.title
+        )
+        await created.related('translations').create({
+          locale: translation.locale,
+          title: translation.title,
+          slug,
+          content: translation.content,
+          excerpt: translation.excerpt || null,
+        })
+      }
+
+      return created
+    })
+
+    await post.load('author')
+    await post.load('translations')
+    return post
+  }
+
+  /** Met à jour les champs partagés et upsert les traductions fournies. */
+  static async update(post: Post, data: UpdatePostData): Promise<Post> {
+    await db.transaction(async (trx) => {
+      post.useTransaction(trx)
+      if (data.defaultLocale !== undefined) post.defaultLocale = data.defaultLocale
+      if (data.coverImage !== undefined) post.coverImage = data.coverImage || null
+      await post.save()
+
+      for (const entry of data.translations ?? []) {
+        const existing = await PostTranslation.query({ client: trx })
+          .where('post_id', post.id)
+          .where('locale', entry.locale)
+          .first()
+
+        if (existing) {
+          if (entry.title !== undefined) existing.title = entry.title
+          if (entry.content !== undefined) existing.content = entry.content
+          if (entry.excerpt !== undefined) existing.excerpt = entry.excerpt || null
+          if (entry.slug !== undefined) {
+            existing.slug = await SlugService.uniqueSlug(entry.locale, entry.slug, existing.id)
+          }
+          existing.useTransaction(trx)
+          await existing.save()
+        } else if (entry.title && entry.content) {
+          // Nouvelle langue : nécessite au minimum titre + contenu.
+          const slug = await SlugService.uniqueSlug(entry.locale, entry.slug || entry.title)
+          await post.related('translations').create({
+            locale: entry.locale,
+            title: entry.title,
+            slug,
+            content: entry.content,
+            excerpt: entry.excerpt || null,
+          })
+        }
+      }
+    })
+
+    await post.load('author')
+    await post.load('translations')
+    return post
+  }
+
+  /** Bascule l'état de publication et (dé)positionne `publishedAt`. */
+  static async setPublished(post: Post, published: boolean): Promise<Post> {
+    post.published = published
+    post.publishedAt = published ? DateTime.now() : null
+    await post.save()
+    await post.load('author')
+    await post.load('translations')
+    return post
+  }
+
+  /** Incrémente le compteur de vues (partagé entre toutes les traductions). */
+  static async recordView(slug: string): Promise<void> {
+    const translation = await PostTranslation.query().where('slug', slug).first()
+    if (translation) {
+      await Post.query()
+        .where('id', translation.postId)
+        .where('published', true)
+        .increment('view_count', 1)
+    }
+  }
+
+  /** Enregistre un feedback « article utile ? », dédupliqué par visiteur anonyme. */
+  static async recordFeedback(post: Post, input: PostFeedbackInput): Promise<void> {
+    const now = DateTime.now().toSQL()
+    await db
+      .table('post_feedbacks')
+      .insert({
+        post_id: post.id,
+        visitor_id: input.visitorId,
+        user_id: input.userId,
+        helpful: input.helpful,
+        created_at: now,
+        updated_at: now,
+      })
+      .onConflict(['post_id', 'visitor_id'])
+      .merge({ helpful: input.helpful, user_id: input.userId, updated_at: now })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Analytics d'engagement
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Agrège vues + feedback + lecteurs récents d'un article. L'analytics enregistre
+   * les vues par chemin exact ; un article a un chemin par langue (slug par locale),
+   * on agrège donc sur tous ses slugs. Sort les requêtes SQL analytics hors du
+   * controller.
+   */
+  static async engagement(post: Post) {
+    const paths = post.translations.map((t) => `/blog/${t.slug}`)
+    const resolved = post.forLocale(post.defaultLocale)
+
+    const [analyticsRow, feedbackRow, recentViewers] = await Promise.all([
+      db
+        .from('page_views')
+        .whereIn('path', paths)
+        .select(db.raw('count(*) as consented_views'))
+        .select(db.raw('count(*) filter (where user_id is not null) as logged_in_views'))
+        .select(db.raw('count(distinct visitor_id) as unique_visitors'))
+        .first(),
+
+      db
+        .from('post_feedbacks')
+        .where('post_id', post.id)
+        .select(db.raw('count(*) filter (where helpful) as helpful'))
+        .select(db.raw('count(*) filter (where not helpful) as not_helpful'))
+        .first(),
+
+      db
+        .from('page_views')
+        .join('users', 'users.id', 'page_views.user_id')
+        .whereIn('page_views.path', paths)
+        .select('users.id as id', 'users.username as username', 'users.avatar_url as avatar_url')
+        .select(db.raw('max(page_views.created_at) as last_viewed_at'))
+        .groupBy('users.id', 'users.username', 'users.avatar_url')
+        .orderByRaw('max(page_views.created_at) desc')
+        .limit(50),
+    ])
+
+    return {
+      post: {
+        id: post.id,
+        title: resolved.title,
+        slugs: post.slugsByLocale(),
+        viewCount: post.viewCount,
+      },
+      views: {
+        total: post.viewCount,
+        consented: Number(analyticsRow?.consented_views ?? 0),
+        loggedIn: Number(analyticsRow?.logged_in_views ?? 0),
+        uniqueVisitors: Number(analyticsRow?.unique_visitors ?? 0),
+      },
+      feedback: {
+        helpful: Number(feedbackRow?.helpful ?? 0),
+        notHelpful: Number(feedbackRow?.not_helpful ?? 0),
+      },
+      recentViewers: recentViewers.map((row) => ({
+        id: Number(row.id),
+        username: row.username,
+        avatarUrl: row.avatar_url,
+        lastViewedAt: row.last_viewed_at,
+      })),
+    }
+  }
+}

--- a/backend/app/services/server_registration_service.ts
+++ b/backend/app/services/server_registration_service.ts
@@ -1,0 +1,105 @@
+import Server from '#models/server'
+import type User from '#models/user'
+import DuplicateDetectionService from '#services/duplicate_detection_service'
+import { type CreateServerValidator, type UpdateServerValidator } from '#validators/server'
+import { deriveServerWebsite } from '#utils/server_website'
+import {
+  INTERACTIVE_PING_TIMEOUT,
+  isPingPossible,
+  pingMinecraftServer,
+} from '../../minecraft-ping/minecraft_ping.js'
+import type { NormalizedPing } from '../../minecraft-ping/minecraft_ping.js'
+
+type CreateServerData = Awaited<ReturnType<typeof CreateServerValidator.validate>>
+type UpdateServerData = Awaited<ReturnType<typeof UpdateServerValidator.validate>>
+type Duplicate = NonNullable<Awaited<ReturnType<typeof DuplicateDetectionService.findDuplicate>>>
+
+export type ServerRegisterResult =
+  | { status: 'unreachable' }
+  | { status: 'duplicate'; duplicate: Duplicate }
+  | { status: 'created'; server: Server }
+
+export type ServerUpdateResult = { status: 'unreachable' } | { status: 'updated'; server: Server }
+
+/**
+ * Orchestration de l'inscription et de la mise à jour d'un serveur — extraite du
+ * controller pour être testable sans `HttpContext`. Regroupe au même endroit le
+ * ping, le fingerprinting, la détection de doublon et la synchronisation de la
+ * taxonomie (catégories / langues).
+ *
+ * NB : la création fait un ping complet (source des empreintes de doublon), tandis
+ * que la mise à jour se contente d'un test de joignabilité booléen (`isPingPossible`).
+ * Cette asymétrie est volontairement préservée à l'identique du comportement
+ * historique — refaire un fingerprint à l'update rouvrirait la question de
+ * l'auto-détection de doublon (un serveur détecté comme doublon de lui-même).
+ */
+export default class ServerRegistrationService {
+  static async register(data: CreateServerData, user: User): Promise<ServerRegisterResult> {
+    const type = data.type ?? 'java'
+
+    // Ping interactif : test de joignabilité ET source des empreintes de doublon.
+    let pingData: NormalizedPing | null = null
+    try {
+      pingData = await pingMinecraftServer(type, data.address, data.port, INTERACTIVE_PING_TIMEOUT)
+    } catch {
+      pingData = null
+    }
+    if (!pingData) return { status: 'unreachable' }
+
+    const fingerprint = await DuplicateDetectionService.fingerprint(
+      data.address,
+      data.port,
+      pingData
+    )
+    const duplicate = await DuplicateDetectionService.findDuplicate(fingerprint)
+    if (duplicate) return { status: 'duplicate', duplicate }
+
+    const { categories, languages, ...dataToCreate } = data
+
+    // Website : fourni par le propriétaire, sinon dérivé de l'adresse.
+    const website = dataToCreate.website ?? deriveServerWebsite(data.address)
+
+    const server = await Server.create({
+      ...dataToCreate,
+      type,
+      website,
+      version: fingerprint.version,
+      faviconHash: fingerprint.faviconHash,
+      resolvedEndpoint: fingerprint.resolvedEndpoint,
+      motdHash: fingerprint.motdHash,
+    })
+
+    await server.related('categories').attach(await Server.resolveCategoryIds(categories))
+    await server.related('languages').attach(await Server.resolveLanguageIds(languages))
+    await server.related('user').associate(user)
+
+    return { status: 'created', server }
+  }
+
+  static async update(server: Server, data: UpdateServerData): Promise<ServerUpdateResult> {
+    const { categories, languages, ...dataToUpdate } = data
+
+    // Si l'adresse change sans website explicite, on le re-dérive.
+    if (dataToUpdate.website === undefined && data.address) {
+      const derived = deriveServerWebsite(data.address)
+      if (derived) dataToUpdate.website = derived
+    }
+
+    const successPing = await isPingPossible(
+      data.type ?? server.type,
+      data.address ?? server.address,
+      data.port ?? server.port
+    )
+    if (!successPing) return { status: 'unreachable' }
+
+    if (categories) {
+      await server.related('categories').sync(await Server.resolveCategoryIds(categories))
+    }
+    if (languages) {
+      await server.related('languages').sync(await Server.resolveLanguageIds(languages))
+    }
+
+    const saved = await server.merge(dataToUpdate).save()
+    return { status: 'updated', server: saved }
+  }
+}

--- a/backend/app/utils/require_ability.ts
+++ b/backend/app/utils/require_ability.ts
@@ -1,0 +1,37 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import type User from '#models/user'
+
+/**
+ * Garde d'autorisation mutualisée (réponse de forme `{ error }`).
+ *
+ * Remplace le triptyque répété « lire l'utilisateur → 401 si absent → 403 si la
+ * policy refuse ». Écrit la réponse d'erreur appropriée et renvoie `null` en cas
+ * d'échec ; sinon renvoie l'utilisateur authentifié. À utiliser uniquement quand
+ * la vérification a lieu *avant* le chargement d'une ressource (sinon l'ordre
+ * 401-avant-404 changerait) et que la réponse attendue est `{ error }`.
+ *
+ * Usage :
+ * ```ts
+ * const user = await requireAbility(ctx, () => ctx.bouncer.with(PostPolicy).denies('manage'), {
+ *   unauthorized: 'messages.posts.unauthorized',
+ *   forbidden: 'messages.posts.writerRequired',
+ * })
+ * if (!user) return
+ * ```
+ */
+export async function requireAbility(
+  ctx: HttpContext,
+  denies: () => Promise<boolean>,
+  keys: { unauthorized: string; forbidden: string }
+): Promise<User | null> {
+  const user = ctx.auth.user
+  if (!user) {
+    ctx.response.unauthorized({ error: ctx.i18n.t(keys.unauthorized) })
+    return null
+  }
+  if (await denies()) {
+    ctx.response.forbidden({ error: ctx.i18n.t(keys.forbidden) })
+    return null
+  }
+  return user
+}

--- a/backend/app/utils/uploaded_image.ts
+++ b/backend/app/utils/uploaded_image.ts
@@ -1,0 +1,23 @@
+import type { MultipartFile } from '@adonisjs/core/bodyparser'
+import fs from 'node:fs/promises'
+
+/**
+ * Résultat de validation d'une image uploadée en multipart. Discrimine les trois
+ * cas d'échec que les controllers traduisaient chacun de leur côté (fichier absent,
+ * invalide, sans chemin temporaire) pour qu'ils mappent leur propre message i18n.
+ */
+export type UploadedImageResult =
+  | { ok: true; buffer: Buffer }
+  | { ok: false; reason: 'missing' | 'invalid' | 'noTmpPath'; errors?: unknown }
+
+/**
+ * Valide un `request.file(...)` image et renvoie son contenu en Buffer, ou la
+ * raison de l'échec. Mutualise le pattern « présence → isValid → tmpPath →
+ * readFile » dupliqué entre l'upload d'images de blog et l'upload d'avatar.
+ */
+export async function readUploadedImage(image: MultipartFile | null): Promise<UploadedImageResult> {
+  if (!image) return { ok: false, reason: 'missing' }
+  if (!image.isValid) return { ok: false, reason: 'invalid', errors: image.errors }
+  if (!image.tmpPath) return { ok: false, reason: 'noTmpPath' }
+  return { ok: true, buffer: await fs.readFile(image.tmpPath) }
+}

--- a/backend/app/validators/global_stat.ts
+++ b/backend/app/validators/global_stat.ts
@@ -1,13 +1,12 @@
 import vine from '@vinejs/vine'
 import { epochMsField } from './helpers.js'
+import { STAT_INTERVALS } from '../constants/intervals.js'
 
 export const GlobalStatValidator = vine.compile(
   vine.object({
     fromDate: epochMsField().optional(),
     toDate: epochMsField().optional(),
-    interval: vine
-      .enum(['30 minutes', '1 hour', '1 day', '2 hours', '6 hours', '1 week'])
-      .optional(),
+    interval: vine.enum(STAT_INTERVALS).optional(),
     categoryId: vine.number().optional(),
     languageId: vine.number().optional(),
   })

--- a/backend/app/validators/post.ts
+++ b/backend/app/validators/post.ts
@@ -1,6 +1,7 @@
 import vine from '@vinejs/vine'
+import { SUPPORTED_LOCALES } from '../constants/locales.js'
 
-const localeEnum = vine.enum(['fr', 'en', 'es'])
+const localeEnum = vine.enum(SUPPORTED_LOCALES)
 
 // Une traduction à la création : titre et contenu requis, slug/excerpt optionnels.
 const translationCreate = vine.object({

--- a/backend/app/validators/stat.ts
+++ b/backend/app/validators/stat.ts
@@ -1,5 +1,6 @@
 import vine from '@vinejs/vine'
 import { epochMsField } from './helpers.js'
+import { STAT_INTERVALS } from '../constants/intervals.js'
 
 export const StatValidator = vine.compile(
   vine.object({
@@ -7,8 +8,6 @@ export const StatValidator = vine.compile(
     exactTime: epochMsField().optional(),
     fromDate: epochMsField().optional(),
     toDate: epochMsField().optional(),
-    interval: vine
-      .enum(['30 minutes', '1 hour', '1 day', '2 hours', '6 hours', '1 week'])
-      .optional(),
+    interval: vine.enum(STAT_INTERVALS).optional(),
   })
 )

--- a/backend/tests/unit/ad_redirect_service.spec.ts
+++ b/backend/tests/unit/ad_redirect_service.spec.ts
@@ -1,0 +1,49 @@
+import { test } from '@japa/runner'
+import AdRedirectService from '#services/ad_redirect_service'
+
+test.group('AdRedirectService.extractHrefs', () => {
+  test('collecte les href du HTML (guillemets simples ou doubles)', ({ assert }) => {
+    const hrefs = AdRedirectService.extractHrefs(
+      `<a href="https://example.com">x</a><a href='http://foo.bar/path'>y</a>`
+    )
+    assert.isTrue(hrefs.has('https://example.com'))
+    assert.isTrue(hrefs.has('http://foo.bar/path'))
+  })
+
+  test('ajoute la variante décodée des entités HTML', ({ assert }) => {
+    const hrefs = AdRedirectService.extractHrefs(`<a href="https://x.com/a&amp;b">x</a>`)
+    assert.isTrue(hrefs.has('https://x.com/a&b'))
+  })
+})
+
+test.group('AdRedirectService.resolveTarget', () => {
+  const html = `<a href="https://example.com/promo">Click</a>`
+
+  test('renvoie la cible normalisée si elle est dans la liste blanche', ({ assert }) => {
+    assert.equal(
+      AdRedirectService.resolveTarget(html, 'https://example.com/promo'),
+      'https://example.com/promo'
+    )
+  })
+
+  test('null si la cible ne figure pas dans le HTML de la pub', ({ assert }) => {
+    assert.isNull(AdRedirectService.resolveTarget(html, 'https://evil.com'))
+  })
+
+  test('null pour un protocole non http(s), même présent dans le HTML', ({ assert }) => {
+    const js = `<a href="javascript:alert(1)">x</a>`
+    assert.isNull(AdRedirectService.resolveTarget(js, 'javascript:alert(1)'))
+  })
+
+  test('null pour une cible vide', ({ assert }) => {
+    assert.isNull(AdRedirectService.resolveTarget(html, ''))
+  })
+
+  test('les caractères de contrôle sont retirés avant comparaison', ({ assert }) => {
+    // Un CRLF injecté ne doit pas contourner l'allow-list ni polluer l'en-tête Location.
+    assert.equal(
+      AdRedirectService.resolveTarget(html, 'https://example.com/promo\r\n'),
+      'https://example.com/promo'
+    )
+  })
+})

--- a/frontend/src/components/rankings/metric.ts
+++ b/frontend/src/components/rankings/metric.ts
@@ -1,4 +1,5 @@
 import { RankingEntry, RankingSort } from "@/http/rankings";
+import { formatGrowth } from "@/lib/format";
 
 export type MetricTone = "up" | "down" | "neutral";
 
@@ -23,7 +24,6 @@ interface Formatter {
   dateTime: (value: Date, options?: { dateStyle?: "full" | "long" | "medium" | "short" }) => string;
 }
 
-const formatGrowth = (growth: number) => `${growth >= 0 ? "+" : ""}${Math.round(growth * 100)}%`;
 
 /**
  * Métrique mise en avant pour une entrée de classement, selon le tri. Centralise

--- a/frontend/src/components/serveur/card/server-status.tsx
+++ b/frontend/src/components/serveur/card/server-status.tsx
@@ -4,6 +4,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { cn } from "@/lib/utils";
 import { ServerGrowthStat, ServerStat } from "@/types/server";
 import { getLastStat } from "@/utils/stats";
+import { formatGrowth } from "@/lib/format";
 
 interface ServerStatusProps {
   stats: ServerStat[];
@@ -11,7 +12,6 @@ interface ServerStatusProps {
   lastOnlineAt?: string | null;
 }
 
-const formatGrowth = (growth: number) => `${growth >= 0 ? "+" : ""}${Math.round(growth * 100)}%`;
 
 const StatusReading = ({ online, label }: { online: boolean; label: string }) => (
   <div className="flex flex-row items-center gap-2">

--- a/frontend/src/components/serveur/server-detail-header.tsx
+++ b/frontend/src/components/serveur/server-detail-header.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/lib/utils";
 import { useFormatter, useTranslations } from "next-intl";
 import { Category, Server, ServerGrowthStat, ServerStat } from "@/types/server";
 import { getLastStat } from "@/utils/stats";
+import { formatGrowth } from "@/lib/format";
 import ServerImage from "./card/server-image";
 import ServerInfo from "./card/server-info";
 import ServerCategories from "./card/server-category";
@@ -14,7 +15,6 @@ interface ServerDetailHeaderProps {
   growthStat: ServerGrowthStat | null;
 }
 
-const formatGrowth = (growth: number) => `${growth >= 0 ? "+" : ""}${Math.round(growth * 100)}%`;
 
 /**
  * Server detail page header card. Composes the existing card subcomponents

--- a/frontend/src/http/advertisement.ts
+++ b/frontend/src/http/advertisement.ts
@@ -6,7 +6,7 @@ import {
   AdvertisementInput,
   PublicAd,
 } from "@/types/advertisement";
-import { getErrorMessage } from "./auth";
+import { apiFetch } from "./client";
 
 // --- Endpoints publics (diffusion) ---
 
@@ -14,24 +14,12 @@ import { getErrorMessage } from "./auth";
  * Récupère les publicités diffusables pour un emplacement donné.
  * Sur les pages serveur, categoryIds permet le ciblage par catégorie.
  */
-export const getActiveAds = async (
-  placement: AdPlacement,
-  categoryIds?: number[]
-): Promise<PublicAd[]> => {
+export const getActiveAds = (placement: AdPlacement, categoryIds?: number[]): Promise<PublicAd[]> => {
   const params = new URLSearchParams({ placement });
   if (categoryIds && categoryIds.length > 0) {
     params.set("categoryIds", categoryIds.join(","));
   }
-
-  const response = await fetch(`${getBaseUrl()}/advertisements?${params.toString()}`, {
-    headers: { "Content-Type": "application/json" },
-  });
-
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
-
-  return response.json() as Promise<PublicAd[]>;
+  return apiFetch<PublicAd[]>(`/advertisements?${params.toString()}`);
 };
 
 /**
@@ -72,87 +60,31 @@ export const buildAdClickUrl = (
 
 // --- Endpoints admin ---
 
-const authHeaders = (token: string) => ({
-  "Content-Type": "application/json",
-  Authorization: `Bearer ${token}`,
-});
+export const getAdminAdvertisements = (token: string): Promise<Advertisement[]> =>
+  apiFetch<Advertisement[]>("/admin/advertisements", { token });
 
-export const getAdminAdvertisements = async (token: string): Promise<Advertisement[]> => {
-  const response = await fetch(`${getBaseUrl()}/admin/advertisements`, {
-    headers: authHeaders(token),
-  });
+export const getAdminAdvertisement = (id: number, token: string): Promise<Advertisement> =>
+  apiFetch<Advertisement>(`/admin/advertisements/${id}`, { token });
 
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
-
-  return response.json() as Promise<Advertisement[]>;
-};
-
-export const getAdminAdvertisement = async (
-  id: number,
-  token: string
-): Promise<Advertisement> => {
-  const response = await fetch(`${getBaseUrl()}/admin/advertisements/${id}`, {
-    headers: authHeaders(token),
-  });
-
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
-
-  return response.json() as Promise<Advertisement>;
-};
-
-export const createAdvertisement = async (
+export const createAdvertisement = (
   data: AdvertisementInput,
   token: string
-): Promise<Advertisement> => {
-  const response = await fetch(`${getBaseUrl()}/admin/advertisements`, {
-    method: "POST",
-    headers: authHeaders(token),
-    body: JSON.stringify(data),
-  });
+): Promise<Advertisement> =>
+  apiFetch<Advertisement>("/admin/advertisements", { method: "POST", token, body: data });
 
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
-
-  return response.json() as Promise<Advertisement>;
-};
-
-export const updateAdvertisement = async (
+export const updateAdvertisement = (
   id: number,
   data: Partial<AdvertisementInput>,
   token: string
-): Promise<Advertisement> => {
-  const response = await fetch(`${getBaseUrl()}/admin/advertisements/${id}`, {
-    method: "PUT",
-    headers: authHeaders(token),
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
-
-  return response.json() as Promise<Advertisement>;
-};
+): Promise<Advertisement> =>
+  apiFetch<Advertisement>(`/admin/advertisements/${id}`, { method: "PUT", token, body: data });
 
 export const deleteAdvertisement = async (id: number, token: string): Promise<boolean> => {
-  const response = await fetch(`${getBaseUrl()}/admin/advertisements/${id}`, {
-    method: "DELETE",
-    headers: authHeaders(token),
-  });
-
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
-
+  await apiFetch<void>(`/admin/advertisements/${id}`, { method: "DELETE", token });
   return true;
 };
 
-export const getAdvertisementStats = async (
+export const getAdvertisementStats = (
   id: number,
   token: string,
   options: { interval?: "hour" | "day"; fromDate?: number; toDate?: number } = {}
@@ -162,14 +94,8 @@ export const getAdvertisementStats = async (
   if (options.fromDate) params.set("fromDate", String(options.fromDate));
   if (options.toDate) params.set("toDate", String(options.toDate));
 
-  const response = await fetch(
-    `${getBaseUrl()}/admin/advertisements/${id}/stats?${params.toString()}`,
-    { headers: authHeaders(token) }
+  return apiFetch<AdStatsResponse>(
+    `/admin/advertisements/${id}/stats?${params.toString()}`,
+    { token }
   );
-
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
-
-  return response.json() as Promise<AdStatsResponse>;
 };

--- a/frontend/src/http/analytics.ts
+++ b/frontend/src/http/analytics.ts
@@ -1,6 +1,6 @@
 import { getBaseUrl } from "@/app/_cheatcode";
 import { AnalyticsDashboard } from "@/types/analytics";
-import { getErrorMessage } from "./auth";
+import { apiFetch } from "./client";
 
 // --- Tracking public (best-effort, fire-and-forget) ---
 
@@ -76,7 +76,7 @@ export const identifyVisitor = (visitorId: string, token: string): void => {
 
 // --- Dashboard admin ---
 
-export const getAnalyticsDashboard = async (
+export const getAnalyticsDashboard = (
   token: string,
   options: { fromDate?: number; toDate?: number } = {}
 ): Promise<AnalyticsDashboard> => {
@@ -84,13 +84,5 @@ export const getAnalyticsDashboard = async (
   if (options.fromDate) params.set("fromDate", String(options.fromDate));
   if (options.toDate) params.set("toDate", String(options.toDate));
 
-  const response = await fetch(`${getBaseUrl()}/admin/analytics?${params.toString()}`, {
-    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-  });
-
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
-
-  return response.json() as Promise<AnalyticsDashboard>;
+  return apiFetch<AnalyticsDashboard>(`/admin/analytics?${params.toString()}`, { token });
 };

--- a/frontend/src/http/api-token.ts
+++ b/frontend/src/http/api-token.ts
@@ -1,49 +1,12 @@
-import { getBaseUrl } from "@/app/_cheatcode";
 import { ApiToken, CreateApiTokenInput, CreatedApiToken } from "@/types/api-token";
-import { getErrorMessage } from "./auth";
+import { apiFetch } from "./client";
 
-export const getApiTokens = async (token: string) => {
-  const response = await fetch(`${getBaseUrl()}/account/api-tokens`, {
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
+export const getApiTokens = (token: string) =>
+  apiFetch<ApiToken[]>("/account/api-tokens", { token });
 
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
-
-  return response.json() as Promise<ApiToken[]>;
-};
-
-export const createApiToken = async (input: CreateApiTokenInput, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/account/api-tokens`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(input),
-  });
-
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
-
-  return response.json() as Promise<CreatedApiToken>;
-};
+export const createApiToken = (input: CreateApiTokenInput, token: string) =>
+  apiFetch<CreatedApiToken>("/account/api-tokens", { method: "POST", token, body: input });
 
 export const revokeApiToken = async (id: string | number, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/account/api-tokens/${id}`, {
-    method: "DELETE",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
+  await apiFetch<void>(`/account/api-tokens/${id}`, { method: "DELETE", token });
 };

--- a/frontend/src/http/auth.ts
+++ b/frontend/src/http/auth.ts
@@ -1,164 +1,67 @@
 "use client";
 
-import { getBaseUrl, localeHeaders } from "@/app/_cheatcode";
+import { localeHeaders } from "@/app/_cheatcode";
 import { AccessToken, User } from "@/types/auth";
+import { apiFetch } from "./client";
 
-export const registerUser = async (credentials: {
+export const registerUser = (credentials: {
   username: string;
   email: string;
   password: string;
   turnstileToken?: string | null;
-}) => {
-  const response = await fetch(`${getBaseUrl()}/register`, {
+}) => apiFetch<User>("/register", { method: "POST", body: credentials, headers: localeHeaders() });
+
+export const verifyEmail = (credentials: { token: string }) =>
+  apiFetch<User>("/verify-email", { method: "POST", body: credentials, headers: localeHeaders() });
+
+export const requestPasswordReset = (credentials: { email: string; turnstileToken?: string | null }) =>
+  apiFetch<{ message: string }>("/forgot-password", {
     method: "POST",
-    body: JSON.stringify(credentials),
-    headers: {
-      ...localeHeaders(),
-      "Content-Type": "application/json",
-    },
+    body: credentials,
+    headers: localeHeaders(),
   });
 
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-  return response.json() as Promise<User>;
-};
-
-export const verifyEmail = async (credentials: { token: string }) => {
-  const response = await fetch(`${getBaseUrl()}/verify-email`, {
+export const resetPassword = (credentials: { token: string; password: string }) =>
+  apiFetch<{ message: string }>("/reset-password", {
     method: "POST",
-    headers: {
-      ...localeHeaders(),
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(credentials),
+    body: credentials,
+    headers: localeHeaders(),
   });
 
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  return response.json() as Promise<User>;
-};
-
-export const requestPasswordReset = async (credentials: { email: string; turnstileToken?: string | null }) => {
-  const response = await fetch(`${getBaseUrl()}/forgot-password`, {
-    method: "POST",
-    headers: {
-      ...localeHeaders(),
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(credentials),
-  });
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  return response.json() as Promise<{ message: string }>;
-};
-
-export const resetPassword = async (credentials: { token: string; password: string }) => {
-  const response = await fetch(`${getBaseUrl()}/reset-password`, {
-    method: "POST",
-    headers: {
-      ...localeHeaders(),
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(credentials),
-  });
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  return response.json() as Promise<{ message: string }>;
-};
-
-export const loginUser = async (credentials: {
+export const loginUser = (credentials: {
   email: string;
   password: string;
   turnstileToken?: string | null;
-}) => {
-  const response = await fetch(`${getBaseUrl()}/login`, {
+}) =>
+  apiFetch<{ accessToken: AccessToken; user: User }>("/login", {
     method: "POST",
-    headers: {
-      ...localeHeaders(),
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(credentials),
+    body: credentials,
+    headers: localeHeaders(),
   });
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  return response.json() as Promise<{
-    accessToken: AccessToken;
-    user: User;
-  }>;
-};
 
 export const getUser = async (token: string) => {
-  const response = await fetch(`${getBaseUrl()}/me`, {
-    method: "GET",
-    headers: {
-      ...localeHeaders(),
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  const body = (await response.json()) as { user?: User };
+  const body = await apiFetch<{ user?: User }>("/me", { token, headers: localeHeaders() });
   return body.user;
 };
 
-export const changeUserPassword = async (credentials: { oldPassword: string; newPassword: string }, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/change-password`, {
+export const changeUserPassword = (
+  credentials: { oldPassword: string; newPassword: string },
+  token: string
+) =>
+  apiFetch<User>("/change-password", {
     method: "POST",
-    headers: {
-      ...localeHeaders(),
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(credentials),
+    token,
+    body: credentials,
+    headers: localeHeaders(),
   });
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  return response.json() as Promise<User>;
-};
 
 export const changeUsername = async (credentials: { username: string }, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/change-username`, {
+  const body = await apiFetch<{ user: User }>("/change-username", {
     method: "POST",
-    headers: {
-      ...localeHeaders(),
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(credentials),
+    token,
+    body: credentials,
+    headers: localeHeaders(),
   });
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  const body = (await response.json()) as { user: User };
   return body.user;
 };
 
@@ -166,62 +69,17 @@ export const uploadUserAvatar = async (file: File, token: string) => {
   const formData = new FormData();
   formData.append("avatar", file);
 
-  const response = await fetch(`${getBaseUrl()}/account/avatar`, {
+  const body = await apiFetch<{ user: User }>("/account/avatar", {
     method: "POST",
-    headers: {
-      ...localeHeaders(),
-      Authorization: `Bearer ${token}`,
-    },
+    token,
     body: formData,
+    headers: localeHeaders(),
   });
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  const body = (await response.json()) as { user: User };
   return body.user;
 };
 
-export const logoutUser = async (token: string) => {
-  const response = await fetch(`${getBaseUrl()}/logout`, {
-    method: "POST",
-    headers: {
-      ...localeHeaders(),
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
+export const logoutUser = (token: string) =>
+  apiFetch<{ message: string }>("/logout", { method: "POST", token, headers: localeHeaders() });
 
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  return response.json();
-};
-
-export const logoutAllUser = async (token: string) => {
-  const response = await fetch(`${getBaseUrl()}/logout-all`, {
-    method: "POST",
-    headers: {
-      ...localeHeaders(),
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  return response.json();
-};
-
-export const getErrorMessage = async (response: Response): Promise<string | undefined> => {
-  const error = (await response.json()) as { error?: { message?: string }; errors?: { message?: string }[]; message?: string };
-  const errorMessage = error?.error?.message || error?.errors?.[0]?.message || error?.message;
-  return errorMessage;
-};
+export const logoutAllUser = (token: string) =>
+  apiFetch<{ message: string }>("/logout-all", { method: "POST", token, headers: localeHeaders() });

--- a/frontend/src/http/client.ts
+++ b/frontend/src/http/client.ts
@@ -1,0 +1,86 @@
+import { getBaseUrl, HttpError } from "@/app/_cheatcode";
+
+/**
+ * Client HTTP profond partagé par tous les modules `src/http/*`.
+ *
+ * Avant : chaque fonction d'endpoint réécrivait à la main la même mécanique de
+ * transport — construction de l'URL depuis `getBaseUrl()`, en-tête
+ * `Authorization: Bearer`, `Content-Type`, `JSON.stringify`, test `!response.ok`
+ * puis extraction du message d'erreur. Cette logique vit désormais à un seul
+ * endroit ; un appel d'endpoint se réduit à `apiFetch<T>(path, opts)`.
+ */
+
+interface ApiErrorBody {
+  error?: { message?: string };
+  errors?: { message?: string }[];
+  message?: string;
+}
+
+/** Extrait le message d'un corps d'erreur Adonis ({message} | {errors:[{message}]} | {error:{message}}). */
+function extractMessage(body: unknown): string | undefined {
+  const b = body as ApiErrorBody | undefined;
+  return b?.error?.message || b?.errors?.[0]?.message || b?.message;
+}
+
+/**
+ * Erreur HTTP enrichie du corps d'erreur parsé. Étend `HttpError` (donc porte le
+ * `status`, ce sur quoi SWR s'appuie pour ne pas re-tenter un 404) et expose en
+ * plus `body`, pour les rares appelants qui doivent lire des champs spécifiques
+ * de la réponse d'erreur (ex. `existingServer` d'un conflit 409 de doublon).
+ */
+export class ApiError extends HttpError {
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message, status);
+    this.name = "ApiError";
+    this.body = body;
+  }
+}
+
+export interface ApiOptions {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  /** Jeton d'accès ; ajouté en `Authorization: Bearer` quand présent. */
+  token?: string;
+  /** Corps de requête ; sérialisé en JSON, sauf `FormData` (envoyé tel quel). */
+  body?: unknown;
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+  /** Stratégie de cache fetch (ex. `"no-store"`). Transmise telle quelle. */
+  cache?: RequestCache;
+  /** Options ISR de Next (`revalidate`, `tags`). Transmises telles quelles. */
+  next?: { revalidate?: number | false; tags?: string[] };
+}
+
+/**
+ * Exécute une requête vers l'API et renvoie le JSON typé. Lève une {@link ApiError}
+ * (message extrait du corps) sur réponse non-2xx. Renvoie `undefined` pour un 204.
+ */
+export async function apiFetch<T>(path: string, opts: ApiOptions = {}): Promise<T> {
+  const { method = "GET", token, body, headers = {}, signal, cache, next } = opts;
+  const isForm = typeof FormData !== "undefined" && body instanceof FormData;
+
+  const finalHeaders: Record<string, string> = { ...headers };
+  if (token) finalHeaders.Authorization = `Bearer ${token}`;
+  if (body !== undefined && !isForm && finalHeaders["Content-Type"] === undefined) {
+    finalHeaders["Content-Type"] = "application/json";
+  }
+
+  const response = await fetch(`${getBaseUrl()}${path}`, {
+    method,
+    headers: finalHeaders,
+    body: body === undefined ? undefined : isForm ? (body as FormData) : JSON.stringify(body),
+    signal,
+    cache,
+    next,
+  });
+
+  if (!response.ok) {
+    const parsed = await response.json().catch(() => undefined);
+    const message = extractMessage(parsed) ?? `Request failed with status ${response.status}`;
+    throw new ApiError(message, response.status, parsed);
+  }
+
+  if (response.status === 204) return undefined as T;
+  return response.json() as Promise<T>;
+}

--- a/frontend/src/http/post.ts
+++ b/frontend/src/http/post.ts
@@ -9,58 +9,23 @@ import {
   PostsListResponse,
   UpdatePostInput,
 } from '@/types/post'
-import { getErrorMessage } from './auth'
+import { apiFetch } from './client'
 
 // Public endpoints
 
-export const getPosts = async (page: number = 1, limit: number = 10, locale: PostLocale = 'en') => {
-  const response = await fetch(`${getBaseUrl()}/posts?page=${page}&limit=${limit}&locale=${locale}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
+export const getPosts = (page: number = 1, limit: number = 10, locale: PostLocale = 'en') =>
+  apiFetch<PostsListResponse>(`/posts?page=${page}&limit=${limit}&locale=${locale}`, {
     cache: 'no-store',
   })
 
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<PostsListResponse>
-}
-
-export const resolvePlaceholders = async (placeholders: string[]) => {
-  const response = await fetch(`${getBaseUrl()}/posts/placeholders/resolve`, {
+export const resolvePlaceholders = (placeholders: string[]) =>
+  apiFetch<Record<string, string>>('/posts/placeholders/resolve', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ placeholders }),
+    body: { placeholders },
   })
 
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<Record<string, string>>
-}
-
-export const getPostBySlug = async (slug: string, locale: PostLocale = 'en') => {
-  const response = await fetch(`${getBaseUrl()}/posts/${slug}?locale=${locale}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    cache: 'no-store',
-  })
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<Post>
-}
+export const getPostBySlug = (slug: string, locale: PostLocale = 'en') =>
+  apiFetch<Post>(`/posts/${slug}?locale=${locale}`, { cache: 'no-store' })
 
 /**
  * Records a view for the article. Consent-exempt and best-effort: it only bumps
@@ -88,233 +53,73 @@ export const submitPostFeedback = async (
   visitorId: string,
   token?: string | null
 ) => {
-  const response = await fetch(`${getBaseUrl()}/posts/${slug}/feedback`, {
+  await apiFetch<void>(`/posts/${slug}/feedback`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-    body: JSON.stringify({ helpful, visitorId }),
+    token: token ?? undefined,
+    body: { helpful, visitorId },
   })
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
   return true
 }
 
 // Admin endpoints
 
-export const getAdminPosts = async (
+export const getAdminPosts = (
   token: string,
   page: number = 1,
   limit: number = 20,
   status: 'all' | 'published' | 'draft' = 'all'
-) => {
-  const response = await fetch(
-    `${getBaseUrl()}/admin/posts?page=${page}&limit=${limit}&status=${status}`,
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-    }
+) =>
+  apiFetch<AdminPostsListResponse>(
+    `/admin/posts?page=${page}&limit=${limit}&status=${status}`,
+    { token }
   )
 
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<AdminPostsListResponse>
-}
-
 /** Single post with all its translations, for the edit screen. */
-export const getAdminPost = async (postId: number, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/admin/posts/${postId}`, {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-  })
+export const getAdminPost = (postId: number, token: string) =>
+  apiFetch<AdminPost>(`/admin/posts/${postId}`, { token })
 
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
+export const getAdminPostStats = (postId: number, token: string) =>
+  apiFetch<PostStats>(`/admin/posts/${postId}/stats`, { token })
 
-  return response.json() as Promise<AdminPost>
-}
+export const createPost = (data: CreatePostInput, token: string) =>
+  apiFetch<AdminPost>('/admin/posts', { method: 'POST', token, body: data })
 
-export const getAdminPostStats = async (postId: number, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/admin/posts/${postId}/stats`, {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-  })
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<PostStats>
-}
-
-export const createPost = async (data: CreatePostInput, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/admin/posts`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(data),
-  })
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<AdminPost>
-}
-
-export const updatePost = async (postId: number, data: UpdatePostInput, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/admin/posts/${postId}`, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(data),
-  })
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<AdminPost>
-}
+export const updatePost = (postId: number, data: UpdatePostInput, token: string) =>
+  apiFetch<AdminPost>(`/admin/posts/${postId}`, { method: 'PUT', token, body: data })
 
 export const deletePost = async (postId: number, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/admin/posts/${postId}`, {
-    method: 'DELETE',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-  })
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
+  await apiFetch<void>(`/admin/posts/${postId}`, { method: 'DELETE', token })
   return true
 }
 
-export const publishPost = async (postId: number, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/admin/posts/${postId}/publish`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-  })
+export const publishPost = (postId: number, token: string) =>
+  apiFetch<Post>(`/admin/posts/${postId}/publish`, { method: 'POST', token })
 
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
+export const unpublishPost = (postId: number, token: string) =>
+  apiFetch<Post>(`/admin/posts/${postId}/unpublish`, { method: 'POST', token })
 
-  return response.json() as Promise<Post>
-}
-
-export const unpublishPost = async (postId: number, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/admin/posts/${postId}/unpublish`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-  })
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<Post>
-}
-
-export const uploadImage = async (file: File, token: string) => {
+export const uploadImage = (file: File, token: string) => {
   const formData = new FormData()
   formData.append('image', file)
-
-  const response = await fetch(`${getBaseUrl()}/uploads/image`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-    body: formData,
-  })
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<{ url: string }>
+  return apiFetch<{ url: string }>('/uploads/image', { method: 'POST', token, body: formData })
 }
 
 // Placeholders
 
-export const getPlaceholders = async () => {
-  const response = await fetch(`${getBaseUrl()}/posts/placeholders/list`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    cache: 'no-store',
-  })
+export const getPlaceholders = () =>
+  apiFetch<PlaceholderInfo[]>('/posts/placeholders/list', { cache: 'no-store' })
 
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<PlaceholderInfo[]>
-}
-
-export const previewPlaceholder = async (
-  placeholderName: string,
-  serverId: number,
-  token: string
-) => {
-  const response = await fetch(`${getBaseUrl()}/admin/posts/placeholders/preview`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({ placeholderName, serverId }),
-  })
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<{
+export const previewPlaceholder = (placeholderName: string, serverId: number, token: string) =>
+  apiFetch<{
     placeholder: string
     value: string
     serverId: number
     placeholderName: string
-  }>
-}
+  }>('/admin/posts/placeholders/preview', {
+    method: 'POST',
+    token,
+    body: { placeholderName, serverId },
+  })
 
 export interface PlaceholderInfo {
   name: string

--- a/frontend/src/http/rankings.ts
+++ b/frontend/src/http/rankings.ts
@@ -1,5 +1,5 @@
-import { getBaseUrl } from "@/app/_cheatcode";
 import { Category, Server, ServerGrowthStat, ServerStat } from "@/types/server";
+import { apiFetch } from "./client";
 
 /**
  * Classements des pages /rankings. Chaque tri est servi par le même endpoint
@@ -40,14 +40,7 @@ export interface RankingResponse {
  * pour éviter les problèmes de loopback NAT. ISR : revalidation toutes les 10 min,
  * alignée sur le TTL du cache backend.
  */
-export const getRanking = async (sort: RankingSort, limit = 15): Promise<RankingResponse> => {
-  const response = await fetch(`${getBaseUrl()}/servers/paginate?sort=${sort}&limit=${limit}`, {
+export const getRanking = (sort: RankingSort, limit = 15): Promise<RankingResponse> =>
+  apiFetch<RankingResponse>(`/servers/paginate?sort=${sort}&limit=${limit}`, {
     next: { revalidate: 600 },
   });
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${sort} ranking: ${response.status}`);
-  }
-
-  return response.json() as Promise<RankingResponse>;
-};

--- a/frontend/src/http/server.ts
+++ b/frontend/src/http/server.ts
@@ -1,5 +1,5 @@
-import { getBaseUrl, HttpError } from "@/app/_cheatcode";
 import { Category, Server, ServerGrowthStat, ServerStat, ServerType } from "@/types/server";
+import { apiFetch, ApiError } from "./client";
 
 export interface ServerPayload {
   name: string;
@@ -10,9 +10,9 @@ export interface ServerPayload {
   languages?: string[];
   website?: string;
 }
+
 // Note: GET /api/v1/servers is a lightweight endpoint that returns only { server } (no stats/categories).
 // For richer data, use /servers/paginate or /servers/:id.
-import { getErrorMessage } from "./auth";
 
 export interface DuplicateServerInfo {
   id: number;
@@ -34,48 +34,23 @@ export class DuplicateServerError extends Error {
   }
 }
 
-export const addMinecraftServer = async (
-  data: ServerPayload,
-  token: string
-) => {
-  const response = await fetch(`${getBaseUrl()}/servers`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    if (response.status === 409) {
-      const body = await response.json().catch(() => null);
+export const addMinecraftServer = async (data: ServerPayload, token: string) => {
+  try {
+    return await apiFetch<Server>("/servers", { method: "POST", token, body: data });
+  } catch (err) {
+    // Conflit 409 = doublon : on remonte l'info du serveur existant à l'UI.
+    if (err instanceof ApiError && err.status === 409) {
+      const body = err.body as { message?: string; existingServer?: DuplicateServerInfo } | undefined;
       throw new DuplicateServerError(
         body?.message ?? "This server is already listed.",
         body?.existingServer ?? { id: 0, name: "" }
       );
     }
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
+    throw err;
   }
-
-  return response.json() as Promise<Server>;
 };
 
-export const getServers = async () => {
-  const response = await fetch(`${getBaseUrl()}/servers`, {
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  return response.json() as Promise<{ server: Server }[]>;
-};
+export const getServers = () => apiFetch<{ server: Server }[]>("/servers");
 
 export interface MyServerItem {
   server: Server;
@@ -83,90 +58,28 @@ export interface MyServerItem {
   growthStat: ServerGrowthStat | null;
 }
 
-export const getMyServers = async (token: string) => {
-  const response = await fetch(`${getBaseUrl()}/servers/mine`, {
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
+export const getMyServers = (token: string) =>
+  apiFetch<MyServerItem[]>("/servers/mine", { token });
 
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
+export const getServer = (serverId: number) =>
+  apiFetch<{ server: Server; stats: ServerStat[]; categories: Category[] }>(`/servers/${serverId}`);
 
-  return response.json() as Promise<MyServerItem[]>;
-};
-
-export const getServer = async (serverId: number) => {
-  const response = await fetch(`${getBaseUrl()}/servers/${serverId}`);
-  if (!response.ok) {
-    throw new HttpError(`Failed to fetch server ${serverId}`, response.status);
-  }
-  return response.json() as Promise<{ server: Server; stats: ServerStat[]; categories: Category[] }>;
-};
-
-export const getServerStats = async (
+export const getServerStats = (
   serverId: number,
   fromDate: EpochTimeStamp,
   toDate: EpochTimeStamp,
   interval?: string
-) => {
-  const response = await fetch(
-    `${getBaseUrl()}/servers/${serverId}/stats?fromDate=${fromDate}&toDate=${toDate}${
+) =>
+  apiFetch<ServerStat[]>(
+    `/servers/${serverId}/stats?fromDate=${fromDate}&toDate=${toDate}${
       interval ? `&interval=${interval}` : ""
-    }`,
-    {
-      headers: {
-        "Content-Type": "application/json",
-      },
-    }
+    }`
   );
 
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  return response.json() as Promise<ServerStat[]>;
-};
-
 export const deleteServer = async (serverId: number, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/servers/${serverId}`, {
-    method: "DELETE",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
+  await apiFetch<void>(`/servers/${serverId}`, { method: "DELETE", token });
   return true;
 };
 
-export const editServer = async (
-  serverId: number,
-  data: ServerPayload,
-  token: string
-) => {
-  const response = await fetch(`${getBaseUrl()}/servers/${serverId}`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response);
-    throw new Error(errorMessage);
-  }
-
-  return response.json() as Promise<Server>;
-};
+export const editServer = (serverId: number, data: ServerPayload, token: string) =>
+  apiFetch<Server>(`/servers/${serverId}`, { method: "PUT", token, body: data });

--- a/frontend/src/http/user.ts
+++ b/frontend/src/http/user.ts
@@ -1,7 +1,6 @@
-import { getBaseUrl } from '@/app/_cheatcode'
 import { AdminUserProfile, User } from '@/types/auth'
 import { AdminUserServer } from '@/types/server'
-import { getErrorMessage } from './auth'
+import { apiFetch } from './client'
 
 export interface UsersListResponse {
   data: User[]
@@ -35,7 +34,7 @@ export interface AdminUserDetailResponse {
   }
 }
 
-export const getAdminUsers = async (
+export const getAdminUsers = (
   token: string,
   page: number = 1,
   limit: number = 20,
@@ -55,55 +54,14 @@ export const getAdminUsers = async (
     params.append('role', role)
   }
 
-  const response = await fetch(`${getBaseUrl()}/admin/users?${params.toString()}`, {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-  })
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<UsersListResponse>
+  return apiFetch<UsersListResponse>(`/admin/users?${params.toString()}`, { token })
 }
 
-export const getAdminUserDetail = async (userId: number, token: string) => {
-  const response = await fetch(`${getBaseUrl()}/admin/users/${userId}`, {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-  })
+export const getAdminUserDetail = (userId: number, token: string) =>
+  apiFetch<AdminUserDetailResponse>(`/admin/users/${userId}`, { token })
 
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<AdminUserDetailResponse>
-}
-
-export const updateUserRole = async (
+export const updateUserRole = (
   userId: number,
   role: 'admin' | 'writer' | 'user',
   token: string
-) => {
-  const response = await fetch(`${getBaseUrl()}/admin/users/${userId}/role`, {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({ role }),
-  })
-
-  if (!response.ok) {
-    const errorMessage = await getErrorMessage(response)
-    throw new Error(errorMessage)
-  }
-
-  return response.json() as Promise<User>
-}
+) => apiFetch<User>(`/admin/users/${userId}/role`, { method: 'PATCH', token, body: { role } })

--- a/frontend/src/http/vote.ts
+++ b/frontend/src/http/vote.ts
@@ -1,5 +1,4 @@
-import { getBaseUrl } from "@/app/_cheatcode";
-import { getErrorMessage } from "./auth";
+import { apiFetch } from "./client";
 
 export interface VotePlayer {
   username: string;
@@ -34,44 +33,22 @@ interface SubmitVoteInput {
  * traduit renvoyé par l'API (pseudo invalide, conditions non acceptées, captcha,
  * cooldown 429…). Le pseudo Minecraft est le seul champ requis de l'utilisateur.
  */
-export const submitVote = async (
-  serverId: number,
-  input: SubmitVoteInput
-): Promise<VoteResult> => {
-  const response = await fetch(`${getBaseUrl()}/servers/${serverId}/vote`, {
+export const submitVote = (serverId: number, input: SubmitVoteInput): Promise<VoteResult> =>
+  apiFetch<VoteResult>(`/servers/${serverId}/vote`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
+    body: {
       username: input.username,
       visitorId: input.visitorId,
       acceptedTerms: input.acceptedTerms,
       turnstileToken: input.turnstileToken ?? undefined,
-    }),
+    },
   });
-
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
-
-  return response.json() as Promise<VoteResult>;
-};
 
 /**
  * Indique si le visiteur peut voter maintenant pour ce serveur (cooldown), la
  * date du prochain vote possible et le total de votes. Pilote l'état du bouton.
  */
-export const getVoteStatus = async (
-  serverId: number,
-  visitorId: string
-): Promise<VoteStatus> => {
+export const getVoteStatus = (serverId: number, visitorId: string): Promise<VoteStatus> => {
   const params = new URLSearchParams({ visitorId });
-  const response = await fetch(
-    `${getBaseUrl()}/servers/${serverId}/vote-status?${params.toString()}`
-  );
-
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response));
-  }
-
-  return response.json() as Promise<VoteStatus>;
+  return apiFetch<VoteStatus>(`/servers/${serverId}/vote-status?${params.toString()}`);
 };

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,8 @@
+/**
+ * Formate un ratio de croissance en pourcentage signé, ex. `0.12` → `+12%`,
+ * `-0.03` → `-3%`. Mutualise un formateur qui était copié à l'identique dans
+ * trois composants (rankings/metric, server-detail-header, card/server-status).
+ */
+export function formatGrowth(growth: number): string {
+  return `${growth >= 0 ? "+" : ""}${Math.round(growth * 100)}%`;
+}

--- a/frontend/src/lib/post-form.ts
+++ b/frontend/src/lib/post-form.ts
@@ -1,14 +1,15 @@
 import type { LocaleFields, PostFormValues } from "@/components/admin/post-form";
 import type { AdminPost, CreatePostInput, PostLocale, PostTranslationInput } from "@/types/post";
+import { routing } from "@/i18n/routing";
 
-export const POST_LOCALES: PostLocale[] = ["en", "fr", "es"];
+export { slugify } from "@/lib/slug";
 
-export function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "");
-}
+/**
+ * Locales dans lesquelles un article peut être rédigé — dérivées du routing i18n
+ * (source unique de vérité) pour ne plus pouvoir diverger de l'ensemble de locales
+ * réellement exposé et servi par le backend.
+ */
+export const POST_LOCALES: PostLocale[] = [...routing.locales];
 
 function emptyLocaleFields(): LocaleFields {
   return { title: "", slug: "", excerpt: "", content: "" };

--- a/frontend/src/lib/server-url.ts
+++ b/frontend/src/lib/server-url.ts
@@ -9,12 +9,11 @@
  * one shared definition so they always agree.
  */
 
+import { slugify } from "@/lib/slug";
+
 /** Lowercase, hyphenated slug derived from a server's display name. */
 export function serverSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "");
+  return slugify(name);
 }
 
 /**

--- a/frontend/src/lib/slug.ts
+++ b/frontend/src/lib/slug.ts
@@ -1,0 +1,18 @@
+/**
+ * Slug URL-safe partagé — source unique de vérité côté frontend.
+ *
+ * Historique : la même transformation était copiée à l'identique dans
+ * `serverSlug` (server-url.ts) et `slugify` (post-form.ts). Toute évolution de la
+ * règle (gestion des accents, de `&`, …) devait être faite aux deux endroits sous
+ * peine de voir les URLs diverger. Un seul primitif désormais.
+ *
+ * NB : côté articles, le backend reste l'autorité (il génère le slug réellement
+ * stocké via `string.slug`, unicode-aware) ; ce `slugify` n'alimente que l'aperçu
+ * live du champ dans le formulaire d'édition.
+ */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}


### PR DESCRIPTION
Suite de la revue d'architecture (skill *improve-codebase-architecture*). Consolide des concepts dupliqués en modules profonds, corrige deux bugs latents nés de cette duplication, et sort la logique métier des controllers vers des services testables. **Bilan : 38 fichiers, ~−200 lignes nettes** (3 commits).

Aucun changement de comportement volontaire : le refactor est à iso-fonctionnalité, sauf les deux corrections de bugs ci-dessous.

## 🔴 Bugs latents corrigés
- **Locales divergentes** — le back ne servait que `fr/en` (`resolveLocale`) alors que le front autorisait `es`. Un article espagnol pouvait être créé (le validator acceptait `es`) mais était silencieusement rabattu sur `en` à la lecture → traduction perdue. `SUPPORTED_LOCALES` est désormais une source unique (`backend/app/constants/locales.ts`) incluant `es` ; côté front `POST_LOCALES` dérive du routing i18n.
- **Slug généré 3 fois** (2 copies identiques) — le front partage maintenant un seul `slugify` (`frontend/src/lib/slug.ts`).

## 🟢 Backend — controllers gras → services testables
- **`ServerRegistrationService`** — orchestration ping → fingerprint → doublon → création + sync taxonomie sortie de `ServersController` ; `Server.resolveCategoryIds/resolveLanguageIds` dédupliquent le lookup nom→id partagé création/mise à jour.
- **`PostService`** — transactions, génération de slug, upsert de traductions, sérialisation **et l'agrégation analytics d'engagement** sorties du `PostsController` (671 loc → ~330).
- **`AdRedirectService`** — défense anti open-redirect / header-injection (allow-list des `href`, nettoyage des caractères de contrôle, validation `http(s)`) extraite de `AdvertisementsController.click`, **avec test unitaire** (`tests/unit/ad_redirect_service.spec.ts`).
- **`DuplicateAccountService`** — détection multi-comptes (5 requêtes sur les tables analytics visiteurs) extraite de `UsersController`.

## 🟢 Backend — value objects & gardes partagés
- **`STAT_INTERVALS`** — ensemble d'intervalles unique alimentant les deux validators de stats.
- **`CacheService.bypassAllowed()`** — règle `nocache` mutualisée (stats + servers).
- **`readUploadedImage()`** — validation multipart mutualisée (upload blog + avatar).
- **`requireAbility()`** — garde d'autorisation partagée, appliquée aux sites au contrat strictement identique (`{error}` + policy `manage` : posts `adminIndex/store/previewPlaceholder`, `uploadImage`, users `adminIndex/adminShow`). Les gardes aux contrats distincts (`users` CRUD en `{message}`, `advertisements` en 403 fusionné) sont **volontairement conservées** — les uniformiser (ou une middleware de route) changerait le status/shape dont dépend le frontend.

## 🟢 Frontend — client API profond
- **`apiFetch<T>`** (`http/client.ts`) — transport unique (base URL, header Bearer, corps JSON, extraction d'erreur via `ApiError`) remplaçant **~50 `fetch` réécrits à la main** dans les 9 clients HTTP ; le doublon `getErrorMessage` est supprimé. Les trackers *fire-and-forget* (`keepalive`) restent inchangés.
- **`formatGrowth`** (`lib/format.ts`) — remplace 3 copies identiques.

## ✅ Vérifications
- Backend `typecheck` + `lint` verts.
- Frontend `tsc --noEmit` (hors une erreur pré-existante de résolution d'un import `.svg`) + `next lint` verts.
- La logique de `AdRedirectService` a été validée cas par cas (URL valide / hors allow-list / `javascript:` / vide / CRLF injecté).
- ⚠️ Les tests Japa backend n'ont **pas pu être exécutés** dans l'environnement de dev (pas de base de données ni de `.env` : échec au bootstrap env, avant toute logique). Ils s'exécuteront en CI, dont le nouveau spec du `AdRedirectService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3qacJgWdYAXjuDHou4xzB