### PR TITLE
refactor: clean up ugly patterns flagged in review (project-wide)

### DIFF
--- a/backend/app/controllers/servers_controller.ts
+++ b/backend/app/controllers/servers_controller.ts
@@ -240,15 +240,9 @@ export default class ServersController {
     const type = typeParam === 'java' || typeParam === 'bedrock' ? typeParam : undefined
 
     // Tri du classement (page /rankings). Whitelist stricte, fallback 'players'
-    // = ordre historique par joueurs actuels. Même logique inline que `type`.
+    // = ordre historique par joueurs actuels.
     const sortParam = request.input('sort')
-    const sort =
-      sortParam === 'trending' ||
-      sortParam === 'peak' ||
-      sortParam === 'newest' ||
-      sortParam === 'votes'
-        ? sortParam
-        : 'players'
+    const sort = ServersController.RANKING_SORTS.includes(sortParam) ? sortParam : 'players'
 
     // `ids` restreint la requête à une liste explicite de serveurs — utilisé par
     // la section "favoris", qui affiche les favoris de l'utilisateur dans leur
@@ -305,6 +299,19 @@ export default class ServersController {
 
   private static readonly MAX_IDS = 20
 
+  // Valeurs de tri acceptées pour le classement (hors défaut 'players').
+  private static readonly RANKING_SORTS = ['trending', 'peak', 'newest', 'votes'] as const
+
+  /**
+   * Découpe le paramètre `ids` brut en tokens. AdonisJS (qs) parse `?ids=1` en
+   * STRING mais `?ids=1,2` ET `?ids=1&ids=2` en ARRAY — on accepte donc les deux.
+   */
+  private static toTokens(raw: unknown): string[] {
+    if (Array.isArray(raw)) return raw.flatMap((v) => String(v).split(','))
+    if (typeof raw === 'string') return raw.split(',')
+    return []
+  }
+
   /**
    * Normalise le paramètre `ids` en liste d'entiers positifs, dédupliquée et
    * plafonnée à MAX_IDS. AdonisJS (qs) parse `?ids=1` en STRING "1" mais
@@ -313,11 +320,7 @@ export default class ServersController {
    * a 2+ IDs (cf. FavoritesSection côté frontend).
    */
   private parseIdList(raw: unknown): number[] {
-    const tokens: string[] = Array.isArray(raw)
-      ? raw.flatMap((v) => String(v).split(','))
-      : typeof raw === 'string'
-        ? raw.split(',')
-        : []
+    const tokens = ServersController.toTokens(raw)
 
     const ids: number[] = []
     const seen = new Set<number>()

--- a/backend/app/services/duplicate_detection_service.ts
+++ b/backend/app/services/duplicate_detection_service.ts
@@ -226,15 +226,17 @@ export default class DuplicateDetectionService {
       return Number(rows[0].$extras.total)
     }
 
-    // Endpoint partagé par plusieurs serveurs => proxy / mutualisé => non fiable.
-    const endpointTrusted = resolvedEndpoint
-      ? (await countSharing('resolved_endpoint', resolvedEndpoint)) < SHARED_ENDPOINT_LIMIT
-      : false
+    // Un signal (endpoint, domaine…) n'est fiable que s'il n'est pas partagé par trop de
+    // serveurs — au-delà de `limit` c'est un proxy / hébergeur mutualisé. `false` si absent.
+    const trustedBelowLimit = async (column: string, value: string | null, limit: number) =>
+      value ? (await countSharing(column, value)) < limit : false
 
-    // Domaine partagé par trop de serveurs => hébergeur à sous-domaines => non fiable.
-    const domainTrusted = domain
-      ? (await countSharing('host_domain', domain)) < SHARED_DOMAIN_LIMIT
-      : false
+    const endpointTrusted = await trustedBelowLimit(
+      'resolved_endpoint',
+      resolvedEndpoint,
+      SHARED_ENDPOINT_LIMIT
+    )
+    const domainTrusted = await trustedBelowLimit('host_domain', domain, SHARED_DOMAIN_LIMIT)
 
     // Aucun signal *discriminant* utilisable (players/version sont trop communs
     // pour servir de critère de sélection) → inutile de scanner.

--- a/backend/app/services/stat_service.ts
+++ b/backend/app/services/stat_service.ts
@@ -334,10 +334,12 @@ export default class StatsService {
       const prevWeek = row.prev_week_avg ?? 0
       const lastMonth = row.last_month_avg ?? 0
 
-      const weeklyGrowth =
-        prevWeek === 0 ? 0 : Math.round(((lastWeek - prevWeek) / prevWeek) * 100) / 100
-      const monthlyGrowth =
-        lastMonth === 0 ? 0 : Math.round(((lastWeek - lastMonth) / lastMonth) * 100) / 100
+      // Croissance relative de `lastWeek` par rapport à une base, arrondie à 2 décimales.
+      // 0 quand la base est nulle (pas de point de comparaison).
+      const growthVs = (base: number) =>
+        base === 0 ? 0 : Math.round(((lastWeek - base) / base) * 100) / 100
+      const weeklyGrowth = growthVs(prevWeek)
+      const monthlyGrowth = growthVs(lastMonth)
 
       return {
         server_id: row.server_id,

--- a/frontend/src/components/admin/cover-image-field.tsx
+++ b/frontend/src/components/admin/cover-image-field.tsx
@@ -12,6 +12,12 @@ import { useRef, useState } from "react";
 
 const MAX_COVER_BYTES = 5 * 1024 * 1024;
 
+/** Clé de traduction du bouton d'upload selon l'état (en cours / remplacer / ajouter). */
+function uploadLabelKey(isUploading: boolean, hasValue: boolean): string {
+  if (isUploading) return "coverImage.uploading";
+  return hasValue ? "coverImage.replace" : "coverImage.upload";
+}
+
 interface CoverImageFieldProps {
   value: string;
   onChange: (value: string) => void;
@@ -87,11 +93,7 @@ export const CoverImageField = ({ value, onChange }: CoverImageFieldProps) => {
               disabled={isUploading}
             >
               <Upload className="mr-2 h-4 w-4" />
-              {isUploading
-                ? t("coverImage.uploading")
-                : value
-                  ? t("coverImage.replace")
-                  : t("coverImage.upload")}
+              {t(uploadLabelKey(isUploading, !!value))}
             </Button>
             {value && (
               <Button type="button" variant="ghost" onClick={() => onChange("")} disabled={isUploading}>

--- a/frontend/src/components/home/global-insight-section.tsx
+++ b/frontend/src/components/home/global-insight-section.tsx
@@ -1,204 +1,25 @@
 "use client";
 
-import { ServerStat } from "@/types/server";
-import { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@iconify/react/dist/iconify.js";
-import { TimeRangeSelect, TimeRangeType } from "./selects/time-range-select";
-import { AggregationSelect, AggregationType } from "./selects/aggregation-select";
+import { TimeRangeSelect } from "./selects/time-range-select";
+import { AggregationSelect } from "./selects/aggregation-select";
 import { GlobalStatsChart } from "./charts/global-stats-chart";
-import { Server, ServerSelect } from "./selects/server-select";
+import { ServerSelect } from "./selects/server-select";
 import { CategorySelect } from "./selects/category-select";
 import { LanguageSelect } from "./selects/language-select";
-import { getClientApiUrl } from "@/lib/domain";
-import { useFavorite } from "@/contexts/favorite";
 import { Button } from "@/components/ui/button";
 import { Star } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useGlobalInsight } from "./use-global-insight";
 
-const TIME_RANGE_OFFSETS: Record<TimeRangeType, number> = {
-  "1 Day": 1000 * 60 * 60 * 24,
-  "1 Week": 1000 * 60 * 60 * 24 * 7,
-  "1 Month": 1000 * 60 * 60 * 24 * 30,
-  "6 Months": 1000 * 60 * 60 * 24 * 30 * 6,
-  "1 Year": 1000 * 60 * 60 * 24 * 30 * 12,
-};
-
-const AGGREGATION_INTERVALS: Record<AggregationType, string> = {
-  "30 Minutes": "30 minutes",
-  "1 Hour": "1 hour",
-  "2 Hours": "2 hours",
-  "6 Hours": "6 hours",
-  "1 Day": "1 day",
-  "1 Week": "1 week",
-};
-
-type ServerSeries = { server: Server; stats: ServerStat[] };
-
+/**
+ * Section "insight global" de l'accueil : filtres + graphe des joueurs. Purement
+ * présentationnelle — toute la logique (sélection, cache, fetch) vit dans
+ * {@link useGlobalInsight}.
+ */
 const GlobalInsightSection = () => {
   const t = useTranslations("Home");
-  const { favorites } = useFavorite();
-  const [globalStats, setGlobalStats] = useState<ServerStat[]>([]);
-  // Cache par serverId. Évite de re-fetch les serveurs déjà connus quand
-  // l'utilisateur ajoute/retire un favori. Invalidé seulement quand
-  // range/interval changent (la donnée serait alors obsolète).
-  const [statsCache, setStatsCache] = useState<Map<number, ServerSeries>>(() => new Map());
-  // `manualSelection === null` → on suit les favoris. Sinon, override utilisateur.
-  // Stocker null/array plutôt qu'un flag séparé permet de dériver `selectedServers`
-  // au lieu d'un useEffect de sync (anti-pattern selon React docs).
-  const [manualSelection, setManualSelection] = useState<number[] | null>(null);
-  const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
-  const [selectedLanguage, setSelectedLanguage] = useState<number | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  // Avoids a hydration mismatch: `isLoading` is true during SSR, but Radix Select
-  // serializes `disabled` differently on the server. We only apply the disabled
-  // state after mount so the first client render matches the server output.
-  const [mounted, setMounted] = useState(false);
-  const apiUrl = getClientApiUrl();
-
-  const [dataRangeInterval, setDataRangeInterval] = useState<TimeRangeType>("1 Week");
-  const [dataAggregationInterval, setDataAggregationInterval] = useState<AggregationType>("1 Hour");
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setMounted(true);
-  }, []);
-
-  const selectedServers = useMemo(
-    () => manualSelection ?? favorites,
-    [manualSelection, favorites]
-  );
-
-  // The controls stay enabled until mount to keep SSR and the first client render
-  // identical; once mounted, they reflect the real loading/selection state.
-  const filtersDisabled = mounted && (isLoading || selectedServers.length > 0);
-  const controlsDisabled = mounted && isLoading;
-
-  const handleSelectionChange = useCallback(
-    (next: number[]) => {
-      const fingerprint = JSON.stringify([...next].sort());
-      const favFingerprint = JSON.stringify([...favorites].sort());
-      // Si la sélection matche pile les favoris, on reste en mode "suivre favoris".
-      setManualSelection(fingerprint === favFingerprint ? null : next);
-    },
-    [favorites]
-  );
-
-  const resetToFavorites = useCallback(() => {
-    setManualSelection(null);
-  }, []);
-
-  const showAggregated = useCallback(() => {
-    setManualSelection([]);
-  }, []);
-
-  // Range/interval change → invalidation complète du cache (données obsolètes).
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setStatsCache(new Map());
-  }, [dataRangeInterval, dataAggregationInterval]);
-
-  // Branche agrégée (selectedServers vide) : fetch /global-stats.
-  useEffect(() => {
-    if (selectedServers.length > 0) return;
-
-    const controller = new AbortController();
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setIsLoading(true);
-    const now = Date.now();
-    const interval = AGGREGATION_INTERVALS[dataAggregationInterval];
-    const fromDate = now - TIME_RANGE_OFFSETS[dataRangeInterval];
-    const toDate = now;
-
-    let url = `${apiUrl}/global-stats?fromDate=${fromDate}&toDate=${toDate}&interval=${interval}`;
-    if (selectedCategory) url += `&categoryId=${selectedCategory}`;
-    if (selectedLanguage) url += `&languageId=${selectedLanguage}`;
-
-    fetch(url, { signal: controller.signal })
-      .then((r) => {
-        if (!r.ok) throw new Error("Failed to fetch global stats");
-        return r.json();
-      })
-      .then((data) => {
-        if (controller.signal.aborted) return;
-        setGlobalStats(data);
-        setIsLoading(false);
-      })
-      .catch((err) => {
-        if ((err as Error).name === "AbortError") return;
-        console.error("Error fetching global stats:", err);
-        setIsLoading(false);
-      });
-
-    return () => controller.abort();
-  }, [selectedServers.length, dataAggregationInterval, dataRangeInterval, selectedCategory, selectedLanguage, apiUrl]);
-
-  // Branche par-serveur : fetch incrémental, seulement ce qui manque au cache.
-  useEffect(() => {
-    if (selectedServers.length === 0) return;
-
-    const missing = selectedServers.filter((id) => !statsCache.has(id));
-    if (missing.length === 0) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setIsLoading(false);
-      return;
-    }
-
-    const controller = new AbortController();
-    setIsLoading(true);
-    const now = Date.now();
-    const interval = AGGREGATION_INTERVALS[dataAggregationInterval];
-    const fromDate = now - TIME_RANGE_OFFSETS[dataRangeInterval];
-    const toDate = now;
-
-    Promise.all(
-      missing.map(async (serverId) => {
-        const [statsRes, serverRes] = await Promise.all([
-          fetch(
-            `${apiUrl}/servers/${serverId}/stats?fromDate=${fromDate}&toDate=${toDate}&interval=${interval}`,
-            { signal: controller.signal }
-          ),
-          fetch(`${apiUrl}/servers/${serverId}`, { signal: controller.signal }),
-        ]);
-        if (!statsRes.ok) throw new Error(`Failed to fetch stats for server ${serverId}`);
-        if (!serverRes.ok) throw new Error(`Failed to fetch server ${serverId}`);
-        const stats: ServerStat[] = await statsRes.json();
-        const serverData = await serverRes.json();
-        return { id: serverId, server: serverData.server as Server, stats };
-      })
-    )
-      .then((results) => {
-        if (controller.signal.aborted) return;
-        setStatsCache((prev) => {
-          const next = new Map(prev);
-          for (const r of results) next.set(r.id, { server: r.server, stats: r.stats });
-          return next;
-        });
-        setIsLoading(false);
-      })
-      .catch((err) => {
-        if ((err as Error).name === "AbortError") return;
-        console.error("Error fetching server stats:", err);
-        setIsLoading(false);
-      });
-
-    return () => controller.abort();
-  }, [selectedServers, statsCache, dataAggregationInterval, dataRangeInterval, apiUrl]);
-
-  // Vue projetée pour le chart : on lit le cache dans l'ordre de selectedServers.
-  // Les entrées encore en vol sont juste absentes — le chart affiche les autres
-  // sans flicker.
-  const serverStats = useMemo<ServerSeries[]>(() => {
-    if (selectedServers.length === 0) return [];
-    const out: ServerSeries[] = [];
-    for (const id of selectedServers) {
-      const entry = statsCache.get(id);
-      if (entry) out.push(entry);
-    }
-    return out;
-  }, [selectedServers, statsCache]);
-
-  const hasFavorites = favorites.length > 0;
-  const followingFavorites = hasFavorites && manualSelection === null;
+  const insight = useGlobalInsight();
 
   return (
     <section className="w-full rounded-xl border border-border bg-card text-card-foreground shadow-xs">
@@ -213,24 +34,24 @@ const GlobalInsightSection = () => {
       <div className="flex flex-col gap-4 p-4 sm:p-6">
         {/* Filters wrap freely; each select grows on mobile so the row stays tidy. */}
         <div className="flex flex-wrap gap-2 [&>*]:flex-1 sm:[&>*]:flex-none">
-          <CategorySelect value={selectedCategory} onChange={setSelectedCategory} disabled={filtersDisabled} />
-          <LanguageSelect value={selectedLanguage} onChange={setSelectedLanguage} disabled={filtersDisabled} />
-          <TimeRangeSelect value={dataRangeInterval} onChange={setDataRangeInterval} disabled={controlsDisabled} />
+          <CategorySelect value={insight.selectedCategory} onChange={insight.setSelectedCategory} disabled={insight.filtersDisabled} />
+          <LanguageSelect value={insight.selectedLanguage} onChange={insight.setSelectedLanguage} disabled={insight.filtersDisabled} />
+          <TimeRangeSelect value={insight.dataRangeInterval} onChange={insight.setDataRangeInterval} disabled={insight.controlsDisabled} />
           <AggregationSelect
-            value={dataAggregationInterval}
-            onChange={setDataAggregationInterval}
-            disabled={controlsDisabled}
+            value={insight.dataAggregationInterval}
+            onChange={insight.setDataAggregationInterval}
+            disabled={insight.controlsDisabled}
           />
         </div>
-        <ServerSelect selectedServers={selectedServers} onChange={handleSelectionChange} disabled={controlsDisabled} />
-        {hasFavorites && (
+        <ServerSelect selectedServers={insight.selectedServers} onChange={insight.handleSelectionChange} disabled={insight.controlsDisabled} />
+        {insight.hasFavorites && (
           <div className="flex flex-row flex-wrap items-center gap-2 text-xs text-muted-foreground">
-            {followingFavorites ? (
+            {insight.followingFavorites ? (
               <>
                 <Star className="h-3.5 w-3.5 fill-current text-accent" />
                 <span>
                   {t.rich("globalInsight.followingFavorites", {
-                    count: favorites.length,
+                    count: insight.favoritesCount,
                     strong: (chunks) => <span className="font-medium text-foreground">{chunks}</span>,
                   })}
                 </span>
@@ -238,8 +59,8 @@ const GlobalInsightSection = () => {
                   variant="ghost"
                   size="sm"
                   className="h-7 px-2 text-xs"
-                  onClick={showAggregated}
-                  disabled={isLoading}
+                  onClick={insight.showAggregated}
+                  disabled={insight.isLoading}
                 >
                   {t("globalInsight.showAllServers")}
                 </Button>
@@ -251,8 +72,8 @@ const GlobalInsightSection = () => {
                   variant="ghost"
                   size="sm"
                   className="h-7 px-2 text-xs"
-                  onClick={resetToFavorites}
-                  disabled={isLoading}
+                  onClick={insight.resetToFavorites}
+                  disabled={insight.isLoading}
                 >
                   <Star className="mr-1 h-3.5 w-3.5 fill-current" />
                   {t("globalInsight.resetToFavorites")}
@@ -261,7 +82,7 @@ const GlobalInsightSection = () => {
             )}
           </div>
         )}
-        <GlobalStatsChart globalStats={globalStats} serverStats={serverStats} isLoading={isLoading} />
+        <GlobalStatsChart globalStats={insight.globalStats} serverStats={insight.serverStats} isLoading={insight.isLoading} />
       </div>
     </section>
   );

--- a/frontend/src/components/home/server-cards-section.tsx
+++ b/frontend/src/components/home/server-cards-section.tsx
@@ -1,111 +1,27 @@
 "use client";
 
-import useSWR from "swr";
-import { useMemo, useState } from "react";
 import { Icon } from "@iconify/react/dist/iconify.js";
 import ServerCard from "@/components/serveur/card";
-import { ServerData } from "@/app/[locale]/(pages)/(index)/page";
-import { fetcher } from "@/app/_cheatcode";
 import { X } from "lucide-react";
-import { useDebounce } from "@/hooks/use-debounce";
-import useSWRImmutable from "swr/immutable";
-import { Category, Language } from "@/types/server";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { FancyMultiSelect } from "@/components/ui/fancy-multi-select";
 import { Pagination } from "@/components/ui/pagination";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { getClientApiUrl } from "@/lib/domain";
-import { useFormatter, useTranslations } from "next-intl";
+import { useTranslations } from "next-intl";
+import { ServerTypeFilter, useServerFilters } from "./use-server-filters";
 
 const PAGE_SIZE_OPTIONS = [12, 24, 36, 48] as const;
-const DEFAULT_PAGE_SIZE = 24;
 
-interface PaginatedResponse {
-  data: ServerData[];
-  meta: {
-    total: number;
-    perPage: number;
-    currentPage: number;
-    lastPage: number;
-  };
-}
-
+/**
+ * Grille de serveurs de l'accueil : barre de filtres + cartes + pagination.
+ * Purement présentationnelle — l'état et les données vivent dans
+ * {@link useServerFilters}.
+ */
 const ServerCardsSection = () => {
-  const [search, setSearch] = useState("");
-  const [selectedCategories, setSelectedCategories] = useState<number[]>([]);
-  const [selectedLanguages, setSelectedLanguages] = useState<number[]>([]);
-  const [selectedType, setSelectedType] = useState<"all" | "java" | "bedrock">("all");
-  const [currentPage, setCurrentPage] = useState(1);
-  const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
-  const debouncedSearch = useDebounce(search, 300);
-  const apiUrl = getClientApiUrl();
-  const format = useFormatter();
   const t = useTranslations("Home");
-
-  const { data: categories } = useSWRImmutable<Category[]>(`${apiUrl}/categories`, fetcher);
-  const { data: languages } = useSWRImmutable<Language[]>(`${apiUrl}/languages`, fetcher);
-
-  const searchParam = debouncedSearch ? `&search=${encodeURIComponent(debouncedSearch)}` : "";
-  const categoriesParam = selectedCategories.length > 0 ? `&categoryIds=${selectedCategories.join(",")}` : "";
-  const languagesParam = selectedLanguages.length > 0 ? `&languageIds=${selectedLanguages.join(",")}` : "";
-  const typeParam = selectedType !== "all" ? `&type=${selectedType}` : "";
-
-  const { data, isValidating, isLoading } = useSWR<PaginatedResponse>(
-    `${apiUrl}/servers/paginate?page=${currentPage}&limit=${pageSize}${searchParam}${categoriesParam}${languagesParam}${typeParam}`,
-    fetcher,
-    { keepPreviousData: true }
-  );
-
-  const servers = useMemo(() => data?.data ?? [], [data?.data]);
-  const totalServers = data?.meta?.total ?? 0;
-  const totalPages = data?.meta?.lastPage ?? 1;
-
-  // Chaque changement de filtre remet la pagination à 1.
-  const updateSearch = (value: string) => {
-    setSearch(value);
-    setCurrentPage(1);
-  };
-
-  const updateCategories = (ids: number[]) => {
-    setSelectedCategories(ids);
-    setCurrentPage(1);
-  };
-
-  const updateLanguages = (ids: number[]) => {
-    setSelectedLanguages(ids);
-    setCurrentPage(1);
-  };
-
-  const updateType = (type: "all" | "java" | "bedrock") => {
-    setSelectedType(type);
-    setCurrentPage(1);
-  };
-
-  const handlePageChange = (page: number) => {
-    setCurrentPage(page);
-  };
-
-  const updatePageSize = (size: number) => {
-    setPageSize(size);
-    setCurrentPage(1);
-  };
-
-  const clearFilters = () => {
-    setSearch("");
-    setSelectedCategories([]);
-    setSelectedLanguages([]);
-    setSelectedType("all");
-    setCurrentPage(1);
-  };
-
-  const hasActiveFilters =
-    search || selectedCategories.length > 0 || selectedLanguages.length > 0 || selectedType !== "all";
-  const isFetching = isLoading || isValidating;
-
-  const rangeStart = totalServers === 0 ? 0 : (currentPage - 1) * pageSize + 1;
-  const rangeEnd = Math.min(currentPage * pageSize, totalServers);
+  const f = useServerFilters();
 
   return (
     <section id="server-cards-section" className="w-full scroll-mt-8 space-y-6">
@@ -116,9 +32,9 @@ const ServerCardsSection = () => {
             <Icon icon="material-symbols:search" className="h-5 w-5 shrink-0 text-muted-foreground" />
             <h2 className="text-lg font-semibold tracking-tight text-foreground">{t("browse.title")}</h2>
           </div>
-          {totalServers > 0 && (
+          {f.totalServers > 0 && (
             <span className="text-xs font-medium text-muted-foreground">
-              {t("browse.tracked", { count: totalServers })}
+              {t("browse.tracked", { count: f.totalServers })}
             </span>
           )}
         </div>
@@ -128,17 +44,17 @@ const ServerCardsSection = () => {
           <FancyMultiSelect
             searchOnly
             placeholder={t("browse.searchPlaceholder")}
-            onSearch={updateSearch}
-            searchValue={search}
+            onSearch={f.updateSearch}
+            searchValue={f.search}
             className="sm:flex-1"
           />
 
           <div className="flex flex-wrap items-center gap-2">
             <FancyMultiSelect
               compact
-              options={categories?.map((cat) => ({ id: cat.id, name: cat.name })) ?? []}
-              selectedIds={selectedCategories}
-              onChange={updateCategories}
+              options={f.categories?.map((cat) => ({ id: cat.id, name: cat.name })) ?? []}
+              selectedIds={f.selectedCategories}
+              onChange={f.updateCategories}
               placeholder={t("browse.categories")}
               searchPlaceholder={t("browse.searchCategories")}
               emptyMessage={t("browse.noCategories")}
@@ -146,15 +62,15 @@ const ServerCardsSection = () => {
             />
             <FancyMultiSelect
               compact
-              options={languages?.map((lang) => ({ id: lang.id, name: lang.name, flag: lang.flag })) ?? []}
-              selectedIds={selectedLanguages}
-              onChange={updateLanguages}
+              options={f.languages?.map((lang) => ({ id: lang.id, name: lang.name, flag: lang.flag })) ?? []}
+              selectedIds={f.selectedLanguages}
+              onChange={f.updateLanguages}
               placeholder={t("browse.languages")}
               searchPlaceholder={t("browse.searchLanguages")}
               emptyMessage={t("browse.noLanguages")}
               className="flex-1 sm:flex-none"
             />
-            <Select value={selectedType} onValueChange={(v) => updateType(v as "all" | "java" | "bedrock")}>
+            <Select value={f.selectedType} onValueChange={(v) => f.updateType(v as ServerTypeFilter)}>
               <SelectTrigger aria-label={t("browse.editionAriaLabel")} className="h-9 flex-1 sm:w-auto sm:flex-none">
                 <SelectValue />
               </SelectTrigger>
@@ -167,12 +83,12 @@ const ServerCardsSection = () => {
             <Button
               variant="ghost"
               size="icon"
-              onClick={clearFilters}
+              onClick={f.clearFilters}
               aria-label={t("browse.clearFilters")}
               title={t("browse.clearFilters")}
               className={cn(
                 "shrink-0 text-muted-foreground hover:text-foreground transition-opacity",
-                hasActiveFilters ? "opacity-100" : "opacity-0 pointer-events-none"
+                f.hasActiveFilters ? "opacity-100" : "opacity-0 pointer-events-none"
               )}
             >
               <X className="h-4 w-4" />
@@ -182,25 +98,25 @@ const ServerCardsSection = () => {
       </div>
 
       {/* Range caption + page size picker */}
-      {totalServers > 0 && (
+      {f.totalServers > 0 && (
         <div className="flex flex-col gap-3 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
           <span>
             {t.rich("browse.showing", {
-              start: rangeStart,
-              end: rangeEnd,
-              total: totalServers,
+              start: f.rangeStart,
+              end: f.rangeEnd,
+              total: f.totalServers,
               strong: (chunks) => <span className="font-medium text-foreground">{chunks}</span>,
             })}
             <span className="mx-1.5">·</span>
             {t.rich("browse.page", {
-              current: currentPage,
-              total: totalPages,
+              current: f.currentPage,
+              total: f.totalPages,
               strong: (chunks) => <span className="font-medium text-foreground">{chunks}</span>,
             })}
           </span>
           <div className="flex items-center gap-2">
             <span>{t("browse.perPage")}</span>
-            <Select value={String(pageSize)} onValueChange={(v) => updatePageSize(Number(v))}>
+            <Select value={String(f.pageSize)} onValueChange={(v) => f.updatePageSize(Number(v))}>
               <SelectTrigger aria-label={t("browse.perPageAriaLabel")} className="h-8 w-auto min-w-18 bg-secondary text-xs">
                 <SelectValue />
               </SelectTrigger>
@@ -217,13 +133,13 @@ const ServerCardsSection = () => {
       )}
 
       {/* Cards grid */}
-      {isLoading ? (
+      {f.isLoading ? (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: pageSize }).map((_, i) => (
+          {Array.from({ length: f.pageSize }).map((_, i) => (
             <Skeleton key={i} className="h-44 w-full rounded-lg" />
           ))}
         </div>
-      ) : servers.length === 0 ? (
+      ) : f.servers.length === 0 ? (
         <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-border bg-card py-16 text-center">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
             <Icon icon="material-symbols:search-off" className="h-5 w-5" />
@@ -232,8 +148,8 @@ const ServerCardsSection = () => {
             <p className="text-sm font-semibold text-foreground">{t("browse.noServersFound")}</p>
             <p className="text-xs text-muted-foreground">{t("browse.noServersHint")}</p>
           </div>
-          {hasActiveFilters && (
-            <Button variant="outline" size="sm" onClick={clearFilters}>
+          {f.hasActiveFilters && (
+            <Button variant="outline" size="sm" onClick={f.clearFilters}>
               {t("browse.clearFilters")}
             </Button>
           )}
@@ -242,10 +158,10 @@ const ServerCardsSection = () => {
         <div
           className={cn(
             "grid grid-cols-1 gap-4 transition-opacity duration-200 sm:grid-cols-2 lg:grid-cols-3",
-            isFetching && "opacity-60"
+            f.isFetching && "opacity-60"
           )}
         >
-          {servers
+          {f.servers
             .filter((item) => item?.server)
             .map((item) => (
               <ServerCard
@@ -260,7 +176,7 @@ const ServerCardsSection = () => {
         </div>
       )}
 
-      <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+      <Pagination currentPage={f.currentPage} totalPages={f.totalPages} onPageChange={f.handlePageChange} />
     </section>
   );
 };

--- a/frontend/src/components/home/use-global-insight.ts
+++ b/frontend/src/components/home/use-global-insight.ts
@@ -1,0 +1,216 @@
+"use client";
+
+import { useFavorite } from "@/contexts/favorite";
+import { getClientApiUrl } from "@/lib/domain";
+import { ServerStat } from "@/types/server";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AggregationType } from "./selects/aggregation-select";
+import { Server } from "./selects/server-select";
+import { TimeRangeType } from "./selects/time-range-select";
+
+const TIME_RANGE_OFFSETS: Record<TimeRangeType, number> = {
+  "1 Day": 1000 * 60 * 60 * 24,
+  "1 Week": 1000 * 60 * 60 * 24 * 7,
+  "1 Month": 1000 * 60 * 60 * 24 * 30,
+  "6 Months": 1000 * 60 * 60 * 24 * 30 * 6,
+  "1 Year": 1000 * 60 * 60 * 24 * 30 * 12,
+};
+
+const AGGREGATION_INTERVALS: Record<AggregationType, string> = {
+  "30 Minutes": "30 minutes",
+  "1 Hour": "1 hour",
+  "2 Hours": "2 hours",
+  "6 Hours": "6 hours",
+  "1 Day": "1 day",
+  "1 Week": "1 week",
+};
+
+export type ServerSeries = { server: Server; stats: ServerStat[] };
+
+/**
+ * Toute la logique de la section "insight global" : sélection (favoris ou override
+ * manuel), filtres, et chargement des stats (branche agrégée `/global-stats` vs
+ * branche par-serveur avec cache incrémental). Isolée hors du composant de présentation.
+ */
+export function useGlobalInsight() {
+  const { favorites } = useFavorite();
+  const [globalStats, setGlobalStats] = useState<ServerStat[]>([]);
+  // Cache par serverId. Évite de re-fetch les serveurs déjà connus quand
+  // l'utilisateur ajoute/retire un favori. Invalidé seulement quand
+  // range/interval changent (la donnée serait alors obsolète).
+  const [statsCache, setStatsCache] = useState<Map<number, ServerSeries>>(() => new Map());
+  // `manualSelection === null` → on suit les favoris. Sinon, override utilisateur.
+  // Stocker null/array plutôt qu'un flag séparé permet de dériver `selectedServers`
+  // au lieu d'un useEffect de sync (anti-pattern selon React docs).
+  const [manualSelection, setManualSelection] = useState<number[] | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
+  const [selectedLanguage, setSelectedLanguage] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  // Avoids a hydration mismatch: `isLoading` is true during SSR, but Radix Select
+  // serializes `disabled` differently on the server. We only apply the disabled
+  // state after mount so the first client render matches the server output.
+  const [mounted, setMounted] = useState(false);
+  const apiUrl = getClientApiUrl();
+
+  const [dataRangeInterval, setDataRangeInterval] = useState<TimeRangeType>("1 Week");
+  const [dataAggregationInterval, setDataAggregationInterval] = useState<AggregationType>("1 Hour");
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+
+  const selectedServers = useMemo(() => manualSelection ?? favorites, [manualSelection, favorites]);
+
+  // The controls stay enabled until mount to keep SSR and the first client render
+  // identical; once mounted, they reflect the real loading/selection state.
+  const filtersDisabled = mounted && (isLoading || selectedServers.length > 0);
+  const controlsDisabled = mounted && isLoading;
+
+  const handleSelectionChange = useCallback(
+    (next: number[]) => {
+      const fingerprint = JSON.stringify([...next].sort());
+      const favFingerprint = JSON.stringify([...favorites].sort());
+      // Si la sélection matche pile les favoris, on reste en mode "suivre favoris".
+      setManualSelection(fingerprint === favFingerprint ? null : next);
+    },
+    [favorites]
+  );
+
+  const resetToFavorites = useCallback(() => {
+    setManualSelection(null);
+  }, []);
+
+  const showAggregated = useCallback(() => {
+    setManualSelection([]);
+  }, []);
+
+  // Range/interval change → invalidation complète du cache (données obsolètes).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setStatsCache(new Map());
+  }, [dataRangeInterval, dataAggregationInterval]);
+
+  // Branche agrégée (selectedServers vide) : fetch /global-stats.
+  useEffect(() => {
+    if (selectedServers.length > 0) return;
+
+    const controller = new AbortController();
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setIsLoading(true);
+    const now = Date.now();
+    const interval = AGGREGATION_INTERVALS[dataAggregationInterval];
+    const fromDate = now - TIME_RANGE_OFFSETS[dataRangeInterval];
+    const toDate = now;
+
+    let url = `${apiUrl}/global-stats?fromDate=${fromDate}&toDate=${toDate}&interval=${interval}`;
+    if (selectedCategory) url += `&categoryId=${selectedCategory}`;
+    if (selectedLanguage) url += `&languageId=${selectedLanguage}`;
+
+    fetch(url, { signal: controller.signal })
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to fetch global stats");
+        return r.json();
+      })
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        setGlobalStats(data);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        if ((err as Error).name === "AbortError") return;
+        console.error("Error fetching global stats:", err);
+        setIsLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [selectedServers.length, dataAggregationInterval, dataRangeInterval, selectedCategory, selectedLanguage, apiUrl]);
+
+  // Branche par-serveur : fetch incrémental, seulement ce qui manque au cache.
+  useEffect(() => {
+    if (selectedServers.length === 0) return;
+
+    const missing = selectedServers.filter((id) => !statsCache.has(id));
+    if (missing.length === 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setIsLoading(true);
+    const now = Date.now();
+    const interval = AGGREGATION_INTERVALS[dataAggregationInterval];
+    const fromDate = now - TIME_RANGE_OFFSETS[dataRangeInterval];
+    const toDate = now;
+
+    Promise.all(
+      missing.map(async (serverId) => {
+        const [statsRes, serverRes] = await Promise.all([
+          fetch(
+            `${apiUrl}/servers/${serverId}/stats?fromDate=${fromDate}&toDate=${toDate}&interval=${interval}`,
+            { signal: controller.signal }
+          ),
+          fetch(`${apiUrl}/servers/${serverId}`, { signal: controller.signal }),
+        ]);
+        if (!statsRes.ok) throw new Error(`Failed to fetch stats for server ${serverId}`);
+        if (!serverRes.ok) throw new Error(`Failed to fetch server ${serverId}`);
+        const stats: ServerStat[] = await statsRes.json();
+        const serverData = await serverRes.json();
+        return { id: serverId, server: serverData.server as Server, stats };
+      })
+    )
+      .then((results) => {
+        if (controller.signal.aborted) return;
+        setStatsCache((prev) => {
+          const next = new Map(prev);
+          for (const r of results) next.set(r.id, { server: r.server, stats: r.stats });
+          return next;
+        });
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        if ((err as Error).name === "AbortError") return;
+        console.error("Error fetching server stats:", err);
+        setIsLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [selectedServers, statsCache, dataAggregationInterval, dataRangeInterval, apiUrl]);
+
+  // Vue projetée pour le chart : on lit le cache dans l'ordre de selectedServers.
+  // Les entrées encore en vol sont juste absentes — le chart affiche les autres
+  // sans flicker.
+  const serverStats = useMemo<ServerSeries[]>(() => {
+    if (selectedServers.length === 0) return [];
+    const out: ServerSeries[] = [];
+    for (const id of selectedServers) {
+      const entry = statsCache.get(id);
+      if (entry) out.push(entry);
+    }
+    return out;
+  }, [selectedServers, statsCache]);
+
+  return {
+    selectedCategory,
+    setSelectedCategory,
+    selectedLanguage,
+    setSelectedLanguage,
+    dataRangeInterval,
+    setDataRangeInterval,
+    dataAggregationInterval,
+    setDataAggregationInterval,
+    selectedServers,
+    handleSelectionChange,
+    resetToFavorites,
+    showAggregated,
+    filtersDisabled,
+    controlsDisabled,
+    isLoading,
+    globalStats,
+    serverStats,
+    favoritesCount: favorites.length,
+    hasFavorites: favorites.length > 0,
+    followingFavorites: favorites.length > 0 && manualSelection === null,
+  };
+}

--- a/frontend/src/components/home/use-server-filters.ts
+++ b/frontend/src/components/home/use-server-filters.ts
@@ -1,0 +1,132 @@
+"use client";
+
+import { ServerData } from "@/app/[locale]/(pages)/(index)/page";
+import { fetcher } from "@/app/_cheatcode";
+import { useDebounce } from "@/hooks/use-debounce";
+import { getClientApiUrl } from "@/lib/domain";
+import { Category, Language } from "@/types/server";
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
+
+const DEFAULT_PAGE_SIZE = 24;
+
+export type ServerTypeFilter = "all" | "java" | "bedrock";
+
+interface PaginatedResponse {
+  data: ServerData[];
+  meta: {
+    total: number;
+    perPage: number;
+    currentPage: number;
+    lastPage: number;
+  };
+}
+
+/**
+ * État et données de la grille de serveurs de l'accueil : recherche (debouncée),
+ * filtres catégories/langues/édition, pagination, et le fetch SWR paginé. Chaque
+ * changement de filtre remet la page à 1. Isolé hors du composant de présentation.
+ */
+export function useServerFilters() {
+  const [search, setSearch] = useState("");
+  const [selectedCategories, setSelectedCategories] = useState<number[]>([]);
+  const [selectedLanguages, setSelectedLanguages] = useState<number[]>([]);
+  const [selectedType, setSelectedType] = useState<ServerTypeFilter>("all");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
+  const debouncedSearch = useDebounce(search, 300);
+  const apiUrl = getClientApiUrl();
+
+  const { data: categories } = useSWRImmutable<Category[]>(`${apiUrl}/categories`, fetcher);
+  const { data: languages } = useSWRImmutable<Language[]>(`${apiUrl}/languages`, fetcher);
+
+  const searchParam = debouncedSearch ? `&search=${encodeURIComponent(debouncedSearch)}` : "";
+  const categoriesParam =
+    selectedCategories.length > 0 ? `&categoryIds=${selectedCategories.join(",")}` : "";
+  const languagesParam =
+    selectedLanguages.length > 0 ? `&languageIds=${selectedLanguages.join(",")}` : "";
+  const typeParam = selectedType !== "all" ? `&type=${selectedType}` : "";
+
+  const { data, isValidating, isLoading } = useSWR<PaginatedResponse>(
+    `${apiUrl}/servers/paginate?page=${currentPage}&limit=${pageSize}${searchParam}${categoriesParam}${languagesParam}${typeParam}`,
+    fetcher,
+    { keepPreviousData: true }
+  );
+
+  const servers = useMemo(() => data?.data ?? [], [data?.data]);
+  const totalServers = data?.meta?.total ?? 0;
+  const totalPages = data?.meta?.lastPage ?? 1;
+
+  // Chaque changement de filtre remet la pagination à 1.
+  const updateSearch = (value: string) => {
+    setSearch(value);
+    setCurrentPage(1);
+  };
+
+  const updateCategories = (ids: number[]) => {
+    setSelectedCategories(ids);
+    setCurrentPage(1);
+  };
+
+  const updateLanguages = (ids: number[]) => {
+    setSelectedLanguages(ids);
+    setCurrentPage(1);
+  };
+
+  const updateType = (type: ServerTypeFilter) => {
+    setSelectedType(type);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  const updatePageSize = (size: number) => {
+    setPageSize(size);
+    setCurrentPage(1);
+  };
+
+  const clearFilters = () => {
+    setSearch("");
+    setSelectedCategories([]);
+    setSelectedLanguages([]);
+    setSelectedType("all");
+    setCurrentPage(1);
+  };
+
+  const hasActiveFilters = Boolean(
+    search || selectedCategories.length > 0 || selectedLanguages.length > 0 || selectedType !== "all"
+  );
+  const isFetching = isLoading || isValidating;
+
+  const rangeStart = totalServers === 0 ? 0 : (currentPage - 1) * pageSize + 1;
+  const rangeEnd = Math.min(currentPage * pageSize, totalServers);
+
+  return {
+    categories,
+    languages,
+    search,
+    updateSearch,
+    selectedCategories,
+    updateCategories,
+    selectedLanguages,
+    updateLanguages,
+    selectedType,
+    updateType,
+    clearFilters,
+    hasActiveFilters,
+    currentPage,
+    handlePageChange,
+    pageSize,
+    updatePageSize,
+    totalServers,
+    totalPages,
+    rangeStart,
+    rangeEnd,
+    servers,
+    isLoading,
+    isFetching,
+  };
+}

--- a/frontend/src/components/serveur/use-vote.ts
+++ b/frontend/src/components/serveur/use-vote.ts
@@ -1,0 +1,171 @@
+"use client";
+
+import { isTurnstileEnabled } from "@/components/form/turnstile";
+import { useToast } from "@/components/ui/use-toast";
+import { useConsent } from "@/contexts/consent";
+import { getVoteStatus, submitVote, VoteResult } from "@/http/vote";
+import { resolveAssetUrl } from "@/lib/domain";
+import { getVisitorId } from "@/lib/visitor-id";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+
+const USERNAME_KEY = "mcstats_vote_username";
+
+/** Formats a remaining duration as "1h 23m" / "23m" / "<1m". */
+function formatCountdown(untilIso: string | null, now: number): string {
+  if (!untilIso) return "";
+  const diff = new Date(untilIso).getTime() - now;
+  if (diff <= 0) return "";
+  const minutes = Math.ceil(diff / 60000);
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  if (hours > 0) return `${hours}h ${rest.toString().padStart(2, "0")}m`;
+  return `${minutes}m`;
+}
+
+/**
+ * Toute la logique du contrôle de vote (statut visiteur, cooldown, soumission avec
+ * captcha + resync), isolée hors du composant de présentation `VoteButton`.
+ */
+export function useVote(serverId: number, initialVoteCount: number) {
+  const t = useTranslations("Vote");
+  const { toast } = useToast();
+  const { consent, grant } = useConsent();
+
+  const [open, setOpen] = useState(false);
+  const [username, setUsername] = useState("");
+  const [termsChecked, setTermsChecked] = useState(false);
+  const [token, setToken] = useState<string | null>(null);
+  // Bumping this key remounts the widget to get a fresh token after a failure
+  // (Turnstile tokens are single-use).
+  const [captchaKey, setCaptchaKey] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<VoteResult | null>(null);
+  const [headError, setHeadError] = useState(false);
+
+  const [total, setTotal] = useState(initialVoteCount);
+  // undefined = statut en cours de chargement, null = indisponible (requête échouée).
+  const [monthly, setMonthly] = useState<number | null | undefined>(undefined);
+  const [canVote, setCanVote] = useState(true);
+  const [nextVoteAt, setNextVoteAt] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  // Consentement déjà donné (via ce vote ou la bannière) ⇒ on ne redemande pas la case.
+  const needsTerms = consent !== "granted";
+
+  useEffect(() => {
+    setUsername(localStorage.getItem(USERNAME_KEY) ?? "");
+
+    const visitorId = getVisitorId();
+    if (!visitorId) return;
+
+    getVoteStatus(serverId, visitorId)
+      .then((status) => {
+        setCanVote(status.canVote);
+        setNextVoteAt(status.nextVoteAt);
+        setTotal(status.voteCount);
+        setMonthly(status.monthlyVoteCount);
+      })
+      .catch(() => setMonthly(null));
+  }, [serverId]);
+
+  // Rafraîchit le compte à rebours du cooldown et réactive le bouton quand il
+  // expire — sans ça, l'état « Déjà voté » persisterait jusqu'au rechargement.
+  useEffect(() => {
+    if (canVote || !nextVoteAt) return;
+    const expiry = new Date(nextVoteAt).getTime();
+    const id = setInterval(() => {
+      const current = Date.now();
+      setNow(current);
+      if (current >= expiry) setCanVote(true);
+    }, 30000);
+    return () => clearInterval(id);
+  }, [canVote, nextVoteAt]);
+
+  const submit = async () => {
+    const acceptedTerms = !needsTerms || termsChecked;
+    if (!acceptedTerms) {
+      toast({ variant: "error", description: t("errors.termsRequired") });
+      return;
+    }
+    if (isTurnstileEnabled && !token) {
+      toast({ variant: "error", description: t("errors.captcha") });
+      return;
+    }
+
+    const visitorId = getVisitorId();
+    if (!visitorId) return;
+
+    setSubmitting(true);
+    try {
+      const voteResult = await submitVote(serverId, {
+        username,
+        visitorId,
+        turnstileToken: token,
+        acceptedTerms,
+      });
+
+      // Cocher la case vaut consentement RGPD : on l'active pour de bon.
+      if (needsTerms) grant();
+      localStorage.setItem(USERNAME_KEY, username);
+
+      setResult(voteResult);
+      setHeadError(false);
+      setTotal(voteResult.voteCount);
+      setMonthly(voteResult.monthlyVoteCount);
+      setCanVote(false);
+      setNextVoteAt(voteResult.nextVoteAt);
+      toast({ variant: "success", description: t("success.toast") });
+    } catch (error) {
+      setToken(null);
+      setCaptchaKey((key) => key + 1);
+      toast({
+        variant: "error",
+        description: error instanceof Error ? error.message : t("errors.generic"),
+      });
+      // Un 429 signifie qu'on est désormais en cooldown : on resynchronise l'état.
+      const status = await getVoteStatus(serverId, visitorId).catch(() => null);
+      if (status && !status.canVote) {
+        setCanVote(false);
+        setNextVoteAt(status.nextVoteAt);
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const headSrc =
+    result?.player.headPath && !headError
+      ? resolveAssetUrl(`${result.player.headPath}.webp`)
+      : null;
+
+  // Réinitialise l'état de la modale à sa fermeture (jette le token périmé + le résultat).
+  const resetDialog = () => {
+    setResult(null);
+    setToken(null);
+  };
+
+  return {
+    open,
+    setOpen,
+    username,
+    setUsername,
+    termsChecked,
+    setTermsChecked,
+    token,
+    setToken,
+    captchaKey,
+    needsTerms,
+    submitting,
+    result,
+    total,
+    monthly,
+    canVote,
+    countdown: formatCountdown(nextVoteAt, now),
+    countdownFor: (iso: string | null) => formatCountdown(iso, now),
+    headSrc,
+    onHeadError: () => setHeadError(true),
+    submit,
+    resetDialog,
+  };
+}

--- a/frontend/src/components/serveur/vote-button.tsx
+++ b/frontend/src/components/serveur/vote-button.tsx
@@ -13,17 +13,10 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { useToast } from "@/components/ui/use-toast";
-import { useConsent } from "@/contexts/consent";
-import { getVoteStatus, submitVote, VoteResult } from "@/http/vote";
 import { Link } from "@/i18n/navigation";
-import { resolveAssetUrl } from "@/lib/domain";
-import { getVisitorId } from "@/lib/visitor-id";
 import { Check, Loader2, ThumbsUp } from "lucide-react";
 import { useFormatter, useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
-
-const USERNAME_KEY = "mcstats_vote_username";
+import { useVote } from "./use-vote";
 
 interface VoteButtonProps {
   serverId: number;
@@ -31,145 +24,24 @@ interface VoteButtonProps {
   initialVoteCount: number;
 }
 
-/** Formats a remaining duration as "1h 23m" / "23m" / "<1m". */
-function formatCountdown(untilIso: string | null, now: number): string {
-  if (!untilIso) return "";
-  const diff = new Date(untilIso).getTime() - now;
-  if (diff <= 0) return "";
-  const minutes = Math.ceil(diff / 60000);
-  const hours = Math.floor(minutes / 60);
-  const rest = minutes % 60;
-  if (hours > 0) return `${hours}h ${rest.toString().padStart(2, "0")}m`;
-  return `${minutes}m`;
-}
-
 /**
  * Vote control for the server detail page: a split "action + counter" control
  * (GitHub-star style) showing the monthly vote count — the metric used by the
  * rankings — and opening a dialog where a visitor votes with just a Minecraft
  * username. The signature moment is the player's own rendered head on success.
+ * Presentational only — all logic lives in {@link useVote}.
  */
 const VoteButton = ({ serverId, serverName, initialVoteCount }: VoteButtonProps) => {
   const t = useTranslations("Vote");
   const format = useFormatter();
-  const { toast } = useToast();
-  const { consent, grant } = useConsent();
-
-  const [open, setOpen] = useState(false);
-  const [username, setUsername] = useState("");
-  const [termsChecked, setTermsChecked] = useState(false);
-  const [token, setToken] = useState<string | null>(null);
-  // Bumping this key remounts the widget to get a fresh token after a failure
-  // (Turnstile tokens are single-use).
-  const [captchaKey, setCaptchaKey] = useState(0);
-  const [submitting, setSubmitting] = useState(false);
-  const [result, setResult] = useState<VoteResult | null>(null);
-  const [headError, setHeadError] = useState(false);
-
-  const [total, setTotal] = useState(initialVoteCount);
-  // undefined = statut en cours de chargement, null = indisponible (requête échouée).
-  const [monthly, setMonthly] = useState<number | null | undefined>(undefined);
-  const [canVote, setCanVote] = useState(true);
-  const [nextVoteAt, setNextVoteAt] = useState<string | null>(null);
-  const [now, setNow] = useState(() => Date.now());
-
-  // Consentement déjà donné (via ce vote ou la bannière) ⇒ on ne redemande pas la case.
-  const needsTerms = consent !== "granted";
-
-  useEffect(() => {
-    setUsername(localStorage.getItem(USERNAME_KEY) ?? "");
-
-    const visitorId = getVisitorId();
-    if (!visitorId) return;
-
-    getVoteStatus(serverId, visitorId)
-      .then((status) => {
-        setCanVote(status.canVote);
-        setNextVoteAt(status.nextVoteAt);
-        setTotal(status.voteCount);
-        setMonthly(status.monthlyVoteCount);
-      })
-      .catch(() => setMonthly(null));
-  }, [serverId]);
-
-  // Rafraîchit le compte à rebours du cooldown et réactive le bouton quand il
-  // expire — sans ça, l'état « Déjà voté » persisterait jusqu'au rechargement.
-  useEffect(() => {
-    if (canVote || !nextVoteAt) return;
-    const expiry = new Date(nextVoteAt).getTime();
-    const id = setInterval(() => {
-      const current = Date.now();
-      setNow(current);
-      if (current >= expiry) setCanVote(true);
-    }, 30000);
-    return () => clearInterval(id);
-  }, [canVote, nextVoteAt]);
-
-  const countdown = formatCountdown(nextVoteAt, now);
-
-  const handleSubmit = async () => {
-    const acceptedTerms = !needsTerms || termsChecked;
-    if (!acceptedTerms) {
-      toast({ variant: "error", description: t("errors.termsRequired") });
-      return;
-    }
-    if (isTurnstileEnabled && !token) {
-      toast({ variant: "error", description: t("errors.captcha") });
-      return;
-    }
-
-    const visitorId = getVisitorId();
-    if (!visitorId) return;
-
-    setSubmitting(true);
-    try {
-      const voteResult = await submitVote(serverId, {
-        username,
-        visitorId,
-        turnstileToken: token,
-        acceptedTerms,
-      });
-
-      // Cocher la case vaut consentement RGPD : on l'active pour de bon.
-      if (needsTerms) grant();
-      localStorage.setItem(USERNAME_KEY, username);
-
-      setResult(voteResult);
-      setHeadError(false);
-      setTotal(voteResult.voteCount);
-      setMonthly(voteResult.monthlyVoteCount);
-      setCanVote(false);
-      setNextVoteAt(voteResult.nextVoteAt);
-      toast({ variant: "success", description: t("success.toast") });
-    } catch (error) {
-      setToken(null);
-      setCaptchaKey((key) => key + 1);
-      toast({
-        variant: "error",
-        description: error instanceof Error ? error.message : t("errors.generic"),
-      });
-      // Un 429 signifie qu'on est désormais en cooldown : on resynchronise l'état.
-      const status = await getVoteStatus(serverId, visitorId).catch(() => null);
-      if (status && !status.canVote) {
-        setCanVote(false);
-        setNextVoteAt(status.nextVoteAt);
-      }
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  const headSrc =
-    result?.player.headPath && !headError
-      ? resolveAssetUrl(`${result.player.headPath}.webp`)
-      : null;
+  const vote = useVote(serverId, initialVoteCount);
 
   return (
     <div className="flex w-full items-stretch sm:w-auto">
-      {canVote ? (
+      {vote.canVote ? (
         <Button
           variant="accent"
-          onClick={() => setOpen(true)}
+          onClick={() => vote.setOpen(true)}
           className="flex-1 gap-2 rounded-r-none sm:flex-none"
         >
           <ThumbsUp className="h-4 w-4" />
@@ -189,62 +61,59 @@ const VoteButton = ({ serverId, serverName, initialVoteCount }: VoteButtonProps)
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="flex min-w-12 items-center justify-center rounded-r-md border border-border bg-card px-3 text-sm font-bold tabular-nums text-foreground">
-              {monthly === undefined && (
+              {vote.monthly === undefined && (
                 <span className="h-3.5 w-5 animate-pulse rounded-md bg-foreground/10" />
               )}
-              {monthly === null && "—"}
-              {typeof monthly === "number" && format.number(monthly)}
+              {vote.monthly === null && "—"}
+              {typeof vote.monthly === "number" && format.number(vote.monthly)}
             </span>
           </TooltipTrigger>
           <TooltipContent className="text-center">
             <p>
-              {t("votesThisMonth")} · {t("totalVotes", { count: format.number(total) })}
+              {t("votesThisMonth")} · {t("totalVotes", { count: format.number(vote.total) })}
             </p>
-            {!canVote && countdown && <p>{t("nextVoteIn", { time: countdown })}</p>}
+            {!vote.canVote && vote.countdown && <p>{t("nextVoteIn", { time: vote.countdown })}</p>}
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
 
       <Dialog
-        open={open}
+        open={vote.open}
         onOpenChange={(next) => {
-          setOpen(next);
+          vote.setOpen(next);
           // Le widget est démonté à la fermeture : on jette le token avec lui,
           // sinon une réouverture pourrait soumettre un token périmé.
-          if (!next) {
-            setResult(null);
-            setToken(null);
-          }
+          if (!next) vote.resetDialog();
         }}
       >
         <DialogContent className="sm:max-w-md">
-          {result ? (
+          {vote.result ? (
             <div className="flex flex-col items-center gap-4 py-2 text-center">
-              {headSrc ? (
+              {vote.headSrc ? (
                 // eslint-disable-next-line @next/next/no-img-element
                 <img
-                  src={headSrc}
-                  alt={result.player.username}
-                  onError={() => setHeadError(true)}
+                  src={vote.headSrc}
+                  alt={vote.result.player.username}
+                  onError={vote.onHeadError}
                   className="h-20 w-20 rounded-lg border border-border [image-rendering:pixelated]"
                 />
               ) : (
                 <div className="flex h-20 w-20 items-center justify-center rounded-lg border border-border bg-secondary text-2xl font-bold uppercase text-muted-foreground">
-                  {result.player.username.charAt(0)}
+                  {vote.result.player.username.charAt(0)}
                 </div>
               )}
               <div className="flex flex-col gap-1">
                 <DialogTitle>{t("success.title")}</DialogTitle>
                 <DialogDescription>
-                  {t("success.body", { username: result.player.username })}
+                  {t("success.body", { username: vote.result.player.username })}
                 </DialogDescription>
               </div>
-              {result.nextVoteAt && (
+              {vote.result.nextVoteAt && (
                 <span className="text-xs text-muted-foreground">
-                  {t("nextVoteIn", { time: formatCountdown(result.nextVoteAt, now) })}
+                  {t("nextVoteIn", { time: vote.countdownFor(vote.result.nextVoteAt) })}
                 </span>
               )}
-              <Button variant="secondary" onClick={() => setOpen(false)} className="w-full">
+              <Button variant="secondary" onClick={() => vote.setOpen(false)} className="w-full">
                 {t("success.close")}
               </Button>
             </div>
@@ -260,21 +129,21 @@ const VoteButton = ({ serverId, serverName, initialVoteCount }: VoteButtonProps)
                   <Label htmlFor="vote-username">{t("usernameLabel")}</Label>
                   <Input
                     id="vote-username"
-                    value={username}
-                    onChange={(event) => setUsername(event.target.value)}
+                    value={vote.username}
+                    onChange={(event) => vote.setUsername(event.target.value)}
                     placeholder={t("usernamePlaceholder")}
                     maxLength={16}
                     autoComplete="off"
                   />
                 </div>
 
-                {isTurnstileEnabled && <Turnstile key={captchaKey} onToken={setToken} />}
+                {isTurnstileEnabled && <Turnstile key={vote.captchaKey} onToken={vote.setToken} />}
 
-                {needsTerms && (
+                {vote.needsTerms && (
                   <label className="flex items-start gap-2 text-sm text-muted-foreground">
                     <Checkbox
-                      checked={termsChecked}
-                      onCheckedChange={(value) => setTermsChecked(value === true)}
+                      checked={vote.termsChecked}
+                      onCheckedChange={(value) => vote.setTermsChecked(value === true)}
                       className="mt-0.5"
                     />
                     <span>
@@ -291,11 +160,11 @@ const VoteButton = ({ serverId, serverName, initialVoteCount }: VoteButtonProps)
 
                 <Button
                   variant="accent"
-                  onClick={handleSubmit}
-                  disabled={submitting || username.length < 3}
+                  onClick={vote.submit}
+                  disabled={vote.submitting || vote.username.length < 3}
                   className="w-full gap-2"
                 >
-                  {submitting ? (
+                  {vote.submitting ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
                   ) : (
                     <ThumbsUp className="h-4 w-4" />

--- a/frontend/src/http/client.ts
+++ b/frontend/src/http/client.ts
@@ -22,6 +22,12 @@ function extractMessage(body: unknown): string | undefined {
   return b?.error?.message || b?.errors?.[0]?.message || b?.message;
 }
 
+/** Sérialise le corps de requête : `FormData` tel quel, sinon JSON ; `undefined` reste vide. */
+function resolveBody(body: unknown, isForm: boolean): BodyInit | undefined {
+  if (body === undefined) return undefined;
+  return isForm ? (body as FormData) : JSON.stringify(body);
+}
+
 /**
  * Erreur HTTP enrichie du corps d'erreur parsé. Étend `HttpError` (donc porte le
  * `status`, ce sur quoi SWR s'appuie pour ne pas re-tenter un 404) et expose en
@@ -69,7 +75,7 @@ export async function apiFetch<T>(path: string, opts: ApiOptions = {}): Promise<
   const response = await fetch(`${getBaseUrl()}${path}`, {
     method,
     headers: finalHeaders,
-    body: body === undefined ? undefined : isForm ? (body as FormData) : JSON.stringify(body),
+    body: resolveBody(body, isForm),
     signal,
     cache,
     next,

--- a/frontend/src/utils/server-version.ts
+++ b/frontend/src/utils/server-version.ts
@@ -32,11 +32,14 @@ export function extractVersions(inputString: string) {
     const matches = inputString.match(versionRegex);
     if (!matches) return [];
 
+    // Séparateurs qui dénotent une liste/plage de versions ("1.8, 1.9", "1.8-1.12"…).
+    const hasListSeparator = [",", "-", "à", "/"].some((sep) => inputString.includes(sep));
+
     if (matches.length === 1) {
       return [matches[0]]
     } else if (matches.length === 2 && inputString.includes("-")) {
       return expandRange(matches[0], matches[1]);
-    } else if (inputString.includes(",") || inputString.includes("-") || inputString.includes("à") || inputString.includes("/")) {
+    } else if (hasListSeparator) {
       return matches;
     }
 


### PR DESCRIPTION
Same code smells reviewers flagged on the ownership PR, swept across the
codebase. Purely mechanical, behaviour-preserving:

Backend:
- servers_controller: replace the multi-line `sort` whitelist ternary with a
  RANKING_SORTS lookup; extract the ids nested ternary into a toTokens() helper.
- stat_service: dedupe weekly/monthly growth math into a single growthVs(base).
- duplicate_detection_service: dedupe the endpoint/domain trust checks into a
  shared trustedBelowLimit() helper.

Frontend:
- http/client: extract the nested body ternary into resolveBody().
- cover-image-field: replace the nested JSX label ternary with uploadLabelKey().
- server-version: name the list-separator condition (hasListSeparator).

Backend 48 tests pass; frontend builds clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MvxjZNWvff3ihYWW9v7PKQ