### PR TITLE
feat(auth): allow linking multiple OAuth providers via email confirmation

### DIFF
--- a/backend/.adonisjs/server/controllers.ts
+++ b/backend/.adonisjs/server/controllers.ts
@@ -16,6 +16,7 @@ export const controllers = {
   Servers: () => import('#controllers/servers_controller'),
   Stats: () => import('#controllers/stats_controller'),
   Uploads: () => import('#controllers/uploads_controller'),
+  UserProviders: () => import('#controllers/user_providers_controller'),
   Users: () => import('#controllers/users_controller'),
   WebsiteStats: () => import('#controllers/website_stats_controller'),
 }

--- a/backend/app/controllers/auth_controller.ts
+++ b/backend/app/controllers/auth_controller.ts
@@ -1,6 +1,8 @@
+import ProviderLinkNotification from '#mails/provider_link_notification'
 import ResetPasswordNotification from '#mails/reset_password_notification'
 import VerifyENotification from '#mails/verify_e_notification'
 import User from '#models/user'
+import UserProvider from '#models/user_provider'
 import ImageStorageService from '#services/image_storage_service'
 import TurnstileService from '#services/turnstile_service'
 import env from '#start/env'
@@ -375,54 +377,15 @@ export default class AuthController {
    * @operationId oauthDiscordCallback
    * @tag AUTH
    * @summary OAuth callback endpoint for Discord
-   * @description Handles the redirect from Discord after the user grants or denies access. On success, finds or creates the user (using Discord nickname, avatar and verified-email state), then returns the user along with a freshly issued access token. Errors during the OAuth handshake (cancellation, state mismatch, generic provider error) are returned as 400 responses.
+   * @description Handles the redirect from Discord after the user grants or denies access. On success, finds or creates the user (using Discord nickname, avatar and verified-email state), then returns the user along with a freshly issued access token. If an account with the same email already exists but Discord is not linked to it yet, no login happens: a confirmation email is sent to the account owner and a 202 is returned (the link becomes usable once confirmProviderLink is called). Errors during the OAuth handshake (cancellation, state mismatch, generic provider error) are returned as 400 responses.
    * @responseBody 200 - {"user": {"id": 1, "username": "discord_user", "verified": true, "provider": "discord", "role": "user", "avatarUrl": "https://cdn.discordapp.com/avatars/...", "createdAt": "2026-05-28T12:00:00.000Z", "updatedAt": "2026-05-28T12:00:00.000Z"}, "accessToken": {"type": "bearer", "token": "oat_...", "expiresAt": "2026-06-27T12:00:00.000Z"}}
+   * @responseBody 202 - {"status": "link_email_sent", "message": "We sent you an email to confirm adding this sign-in method to your account."}
    * @responseBody 400 - {"message": "You have cancelled the login process"}
    * @responseBody 400 - {"message": "We are unable to verify the request. Please try again"}
    * @responseBody 400 - {"message": "An error occurred while logging in. Please try again"}
-   * @responseBody 400 - {"message": "Cannot login with this third-party provider"}
    */
-  async discordCallback({ ally, response, i18n }: HttpContext) {
-    const discordInstance = ally.use('discord')
-    const discordUser = await discordInstance.user()
-
-    if (discordInstance.accessDenied())
-      return response.badRequest({ message: i18n.t('messages.auth.oauthCancelled') })
-
-    if (discordInstance.stateMisMatch())
-      return response.badRequest({
-        message: i18n.t('messages.auth.oauthStateMismatch'),
-      })
-
-    if (discordInstance.hasError())
-      return response.badRequest({
-        message: i18n.t('messages.auth.oauthError'),
-      })
-
-    // Find-or-create manuel (plutôt que firstOrCreate) : le pseudo Discord peut
-    // entrer en collision avec un username existant, donc on en dérive un unique
-    // à la création pour ne pas violer l'index unique lower(username).
-    let user = await User.findBy('email', discordUser.email)
-    if (!user) {
-      user = await User.create({
-        email: discordUser.email,
-        username: await User.generateUniqueUsername(discordUser.nickName),
-        password: Math.random().toString(36).slice(2),
-        verified: discordUser.emailVerificationState === 'verified',
-        provider: 'discord',
-        avatarUrl: discordUser.avatarUrl,
-      })
-    }
-
-    if (user.provider !== 'discord')
-      return response.badRequest({ message: i18n.t('messages.auth.cannotLoginWithProvider') })
-
-    await this.rehostProviderAvatar(user)
-
-    return {
-      user,
-      accessToken: await User.accessTokens.create(user),
-    }
+  async discordCallback(ctx: HttpContext) {
+    return this.handleProviderCallback(ctx, 'discord')
   }
 
   /**
@@ -445,16 +408,32 @@ export default class AuthController {
    * @operationId oauthGoogleCallback
    * @tag AUTH
    * @summary OAuth callback endpoint for Google
-   * @description Handles the redirect from Google after the user grants or denies access. On success, finds or creates the user (Google accounts are treated as verified) and returns the user with a freshly issued access token. Errors during the OAuth handshake (cancellation, state mismatch, generic provider error) are returned as 400 responses.
+   * @description Handles the redirect from Google after the user grants or denies access. On success, finds or creates the user (Google accounts are treated as verified) and returns the user with a freshly issued access token. If an account with the same email already exists but Google is not linked to it yet, no login happens: a confirmation email is sent to the account owner and a 202 is returned (the link becomes usable once confirmProviderLink is called). Errors during the OAuth handshake (cancellation, state mismatch, generic provider error) are returned as 400 responses.
    * @responseBody 200 - {"user": {"id": 1, "username": "Google User", "verified": true, "provider": "google", "role": "user", "avatarUrl": "https://lh3.googleusercontent.com/...", "createdAt": "2026-05-28T12:00:00.000Z", "updatedAt": "2026-05-28T12:00:00.000Z"}, "accessToken": {"type": "bearer", "token": "oat_...", "expiresAt": "2026-06-27T12:00:00.000Z"}}
+   * @responseBody 202 - {"status": "link_email_sent", "message": "We sent you an email to confirm adding this sign-in method to your account."}
    * @responseBody 400 - {"message": "You have cancelled the login process"}
    * @responseBody 400 - {"message": "We are unable to verify the request. Please try again"}
    * @responseBody 400 - {"message": "An error occurred while logging in. Please try again"}
-   * @responseBody 400 - {"message": "Cannot login with this third-party provider"}
    */
-  async googleCallback({ ally, response, i18n }: HttpContext) {
-    const driverInstance = ally.use('google')
-    const googleUser = await driverInstance.user()
+  async googleCallback(ctx: HttpContext) {
+    return this.handleProviderCallback(ctx, 'google')
+  }
+
+  /**
+   * Handshake OAuth commun aux deux providers. Trois issues possibles :
+   * - compte inexistant → création (provider confirmé d'office) + connexion ;
+   * - provider déjà lié (ligne user_providers confirmée) → connexion ;
+   * - compte existant sans ce provider → AUCUNE connexion : un email identique ne
+   *   prouve pas la possession du compte (pre-account takeover). On envoie un
+   *   email de confirmation et le lien ne devient utilisable qu'une fois validé
+   *   via confirmProviderLink.
+   */
+  private async handleProviderCallback(
+    { ally, response, i18n }: HttpContext,
+    provider: 'google' | 'discord'
+  ) {
+    const driverInstance = ally.use(provider)
+    const oauthUser = await driverInstance.user()
 
     if (driverInstance.accessDenied())
       return response.badRequest({ message: i18n.t('messages.auth.oauthCancelled') })
@@ -469,23 +448,53 @@ export default class AuthController {
         message: i18n.t('messages.auth.oauthError'),
       })
 
-    // Find-or-create manuel (plutôt que firstOrCreate) : le nom Google peut entrer
-    // en collision avec un username existant, donc on en dérive un unique à la
-    // création pour ne pas violer l'index unique lower(username).
-    let user = await User.findBy('email', googleUser.email)
+    // Find-or-create manuel (plutôt que firstOrCreate) : le pseudo fourni peut
+    // entrer en collision avec un username existant, donc on en dérive un unique
+    // à la création pour ne pas violer l'index unique lower(username).
+    let user = await User.findBy('email', oauthUser.email)
     if (!user) {
       user = await User.create({
-        email: googleUser.email,
-        username: await User.generateUniqueUsername(googleUser.name),
+        email: oauthUser.email,
+        username: await User.generateUniqueUsername(
+          provider === 'discord' ? oauthUser.nickName : oauthUser.name
+        ),
         password: Math.random().toString(36).slice(2),
-        verified: true,
-        provider: 'google',
-        avatarUrl: googleUser.avatarUrl,
+        // Google affirme l'email vérifié ; Discord expose l'état explicitement.
+        verified: provider === 'google' || oauthUser.emailVerificationState === 'verified',
+        provider,
+        avatarUrl: oauthUser.avatarUrl,
+      })
+      await UserProvider.create({
+        userId: user.id,
+        provider,
+        providerUserId: String(oauthUser.id),
+        confirmedAt: DateTime.now(),
       })
     }
 
-    if (user.provider !== 'google')
-      return response.badRequest({ message: i18n.t('messages.auth.cannotLoginWithProvider') })
+    const link = await UserProvider.query()
+      .where('user_id', user.id)
+      .where('provider', provider)
+      .first()
+
+    if (!link?.confirmedAt) {
+      // Même pattern que le reset de mot de passe : token brut fort dans le mail,
+      // seul son hash SHA-256 est persisté, valide 1h.
+      const rawToken = randomBytes(32).toString('base64url')
+      await UserProvider.updateOrCreate(
+        { userId: user.id, provider },
+        {
+          providerUserId: String(oauthUser.id),
+          linkTokenHash: createHash('sha256').update(rawToken).digest('hex'),
+          linkTokenExpiresAt: DateTime.now().plus({ hours: 1 }),
+        }
+      )
+      await mail.sendLater(new ProviderLinkNotification(user, provider, rawToken, i18n.locale))
+      return response.accepted({
+        status: 'link_email_sent',
+        message: i18n.t('messages.auth.providerLinkEmailSent'),
+      })
+    }
 
     await this.rehostProviderAvatar(user)
 

--- a/backend/app/controllers/user_providers_controller.ts
+++ b/backend/app/controllers/user_providers_controller.ts
@@ -1,0 +1,104 @@
+import User from '#models/user'
+import UserProvider from '#models/user_provider'
+import { LinkProviderValidator } from '#validators/user'
+import type { HttpContext } from '@adonisjs/core/http'
+import { DateTime } from 'luxon'
+import { createHash } from 'node:crypto'
+
+export default class UserProvidersController {
+  /**
+   * @confirm
+   * @operationId confirmProviderLink
+   * @tag AUTH
+   * @summary Confirm adding an OAuth provider to an existing account
+   * @description Validates the token from the confirmation email sent when an OAuth login matched an existing account (see googleCallback/discordCallback), marks the provider link as confirmed and clears the token. Clicking the emailed link proves ownership of the address, so the account is also marked verified and the user is signed in directly (user + fresh access token returned). Invalid and expired tokens return the same generic error to avoid leaking token state.
+   * @requestBody <LinkProviderValidator>
+   * @responseBody 200 - {"user": {"id": 1, "username": "player", "verified": true, "provider": "", "role": "user", "avatarUrl": "", "createdAt": "2026-05-28T12:00:00.000Z", "updatedAt": "2026-05-28T12:00:00.000Z"}, "accessToken": {"type": "bearer", "token": "oat_...", "expiresAt": "2026-06-27T12:00:00.000Z"}}
+   * @responseBody 400 - {"message": "This confirmation link is invalid or has expired."}
+   * @responseBody 422 - {"errors": [{"message": "The token field must be defined", "rule": "required", "field": "token"}]}
+   */
+  async confirm({ request, response, i18n }: HttpContext) {
+    const { token } = await LinkProviderValidator.validate(request.only(['token']))
+
+    const tokenHash = createHash('sha256').update(token).digest('hex')
+    const link = await UserProvider.query()
+      .where('link_token_hash', tokenHash)
+      .preload('user')
+      .first()
+
+    // Message unique pour token inconnu OU expiré : on ne distingue pas les deux.
+    if (!link || !link.linkTokenExpiresAt || link.linkTokenExpiresAt < DateTime.now()) {
+      return response.badRequest({ message: i18n.t('messages.auth.invalidProviderLinkToken') })
+    }
+
+    link.confirmedAt = DateTime.now()
+    link.linkTokenHash = null
+    link.linkTokenExpiresAt = null
+    await link.save()
+
+    // Cliquer le lien reçu par email prouve la possession de l'adresse : on en
+    // profite pour vérifier un compte local qui ne l'aurait jamais été.
+    const user = link.user
+    if (!user.verified) {
+      user.verified = true
+      await user.save()
+    }
+
+    return {
+      user,
+      accessToken: await User.accessTokens.create(user),
+    }
+  }
+
+  /**
+   * @index
+   * @operationId listLinkedProviders
+   * @tag AUTH
+   * @summary List the OAuth providers linked to the authenticated account
+   * @description Returns the confirmed OAuth sign-in methods of the current user, with the date each one was linked. Pending (unconfirmed) links are not included. Requires authentication.
+   * @responseBody 200 - {"providers": [{"provider": "google", "linkedAt": "2026-05-28T12:00:00.000Z"}]}
+   * @responseBody 401 - {"errors": [{"message": "Unauthorized access"}]}
+   */
+  async index({ auth }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const links = await UserProvider.query()
+      .where('user_id', user.id)
+      .whereNotNull('confirmed_at')
+      .orderBy('confirmed_at', 'asc')
+
+    return {
+      providers: links.map((link) => ({ provider: link.provider, linkedAt: link.confirmedAt })),
+    }
+  }
+
+  /**
+   * @destroy
+   * @operationId unlinkProvider
+   * @tag AUTH
+   * @summary Unlink an OAuth provider from the authenticated account
+   * @description Removes a confirmed OAuth sign-in method from the current user. Refused when it is the account's last usable sign-in method (accounts created via OAuth have no usable password). Requires authentication.
+   * @paramPath provider - The OAuth provider to unlink - @type(string) @enum(google,discord) @required
+   * @responseBody 200 - {"message": "Sign-in method removed"}
+   * @responseBody 400 - {"message": "You cannot remove your only sign-in method"}
+   * @responseBody 404 - {"message": "This provider is not linked to your account"}
+   * @responseBody 401 - {"errors": [{"message": "Unauthorized access"}]}
+   */
+  async destroy({ auth, request, response, i18n }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const provider = request.param('provider')
+
+    const links = await UserProvider.query().where('user_id', user.id).whereNotNull('confirmed_at')
+    const link = links.find((candidate) => candidate.provider === provider)
+    if (!link) return response.notFound({ message: i18n.t('messages.auth.providerNotLinked') })
+
+    // Garde-fou : ne jamais laisser un compte sans méthode de connexion. Les
+    // comptes créés via OAuth (users.provider non nul) ont un mot de passe
+    // aléatoire inutilisable — il leur faut au moins un autre provider confirmé.
+    const hasPassword = user.provider === null
+    if (!hasPassword && links.length <= 1)
+      return response.badRequest({ message: i18n.t('messages.auth.cannotUnlinkLastMethod') })
+
+    await link.delete()
+    return response.ok({ message: i18n.t('messages.auth.providerUnlinked') })
+  }
+}

--- a/backend/app/mails/provider_link_notification.ts
+++ b/backend/app/mails/provider_link_notification.ts
@@ -1,0 +1,45 @@
+import type User from '#models/user'
+import { BaseMail } from '@adonisjs/mail'
+import i18nManager from '@adonisjs/i18n/services/main'
+
+export default class ProviderLinkNotification extends BaseMail {
+  from = 'no-reply@minecraft-stats.fr'
+  subject: string
+
+  private t: ReturnType<typeof i18nManager.locale>
+
+  constructor(
+    public user: User,
+    public provider: 'google' | 'discord',
+    public linkToken: string,
+    public locale: string = 'en'
+  ) {
+    super()
+    this.t = i18nManager.locale(locale)
+    this.subject = this.t.t('emails.providerLink.subject', { provider: this.providerName })
+  }
+
+  private get providerName() {
+    return this.provider === 'google' ? 'Google' : 'Discord'
+  }
+
+  /**
+   * The "prepare" method is called automatically when
+   * the email is sent or queued.
+   */
+  prepare() {
+    const provider = this.providerName
+    this.message.to(this.user.email)
+    this.message.htmlView('emails/provider_link_html', {
+      link_url: `${process.env.WEBSITE_URL}/link-provider/${this.linkToken}`,
+      title: this.t.t('emails.providerLink.title', { provider }),
+      greeting: this.t.t('emails.providerLink.greeting', { username: this.user.username }),
+      intro: this.t.t('emails.providerLink.intro', { provider }),
+      cta: this.t.t('emails.providerLink.cta', { provider }),
+      expiry: this.t.t('emails.providerLink.expiry'),
+      ignore: this.t.t('emails.providerLink.ignore'),
+      footerReason: this.t.t('emails.providerLink.footerReason'),
+      copyright: this.t.t('emails.providerLink.copyright'),
+    })
+  }
+}

--- a/backend/app/models/user.ts
+++ b/backend/app/models/user.ts
@@ -7,6 +7,7 @@ import type { HasMany } from '@adonisjs/lucid/types/relations'
 import { DateTime } from 'luxon'
 import { randomBytes } from 'node:crypto'
 import Post from '#models/post'
+import UserProvider from '#models/user_provider'
 
 const AuthFinder = withAuthFinder(() => hash.use('scrypt'), {
   uids: ['email'],
@@ -58,6 +59,9 @@ export default class User extends compose(BaseModel, AuthFinder) {
 
   @hasMany(() => Post)
   declare posts: HasMany<typeof Post>
+
+  @hasMany(() => UserProvider)
+  declare providers: HasMany<typeof UserProvider>
 
   static readonly accessTokens = DbAccessTokensProvider.forModel(User, {
     expiresIn: '30 days',

--- a/backend/app/models/user_provider.ts
+++ b/backend/app/models/user_provider.ts
@@ -1,0 +1,41 @@
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
+import * as relations from '@adonisjs/lucid/types/relations'
+import { DateTime } from 'luxon'
+import User from './user.js'
+
+/**
+ * Méthode de connexion OAuth liée à un compte. Une ligne n'autorise la connexion
+ * qu'une fois confirmée (`confirmedAt` non nul) : avant cela elle ne porte que le
+ * hash du token de confirmation envoyé par email.
+ */
+export default class UserProvider extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @belongsTo(() => User)
+  declare user: relations.BelongsTo<typeof User>
+
+  @column({ columnName: 'user_id' })
+  declare userId: number
+
+  @column()
+  declare provider: 'google' | 'discord'
+
+  @column({ columnName: 'provider_user_id' })
+  declare providerUserId: string | null
+
+  @column({ columnName: 'link_token_hash', serializeAs: null })
+  declare linkTokenHash: string | null
+
+  @column.dateTime({ columnName: 'link_token_expires_at', serializeAs: null })
+  declare linkTokenExpiresAt: DateTime | null
+
+  @column.dateTime({ columnName: 'confirmed_at' })
+  declare confirmedAt: DateTime | null
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/backend/app/validators/user.ts
+++ b/backend/app/validators/user.ts
@@ -54,3 +54,9 @@ export const ResetPasswordValidator = vine.compile(
     password: vine.string().maxLength(72).minLength(8),
   })
 )
+
+export const LinkProviderValidator = vine.compile(
+  vine.object({
+    token: vine.string().trim(),
+  })
+)

--- a/backend/database/migrations/1784206472386_create_user_providers_table.ts
+++ b/backend/database/migrations/1784206472386_create_user_providers_table.ts
@@ -1,0 +1,43 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'user_providers'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('user_id').unsigned().references('users.id').onDelete('CASCADE').notNullable()
+      table.enum('provider', ['google', 'discord']).notNullable()
+
+      // Id du compte côté fournisseur (sub Google, id Discord) : plus stable que
+      // l'email, qui peut changer chez le fournisseur. Nullable car inconnu pour
+      // les liens rétro-remplis depuis l'ancienne colonne users.provider.
+      table.string('provider_user_id').nullable()
+
+      // Lien en attente de confirmation par email : on ne stocke que le hash
+      // SHA-256 du token (même principe que le reset de mot de passe). Le lien
+      // n'autorise la connexion qu'une fois `confirmed_at` renseigné.
+      table.string('link_token_hash').nullable().index()
+      table.timestamp('link_token_expires_at', { useTz: true }).nullable()
+      table.timestamp('confirmed_at', { useTz: true }).nullable()
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+
+      table.unique(['user_id', 'provider'])
+    })
+
+    // Rétro-remplissage : chaque compte créé via OAuth garde sa méthode de
+    // connexion actuelle, confirmée d'office (elle était déjà la seule autorisée).
+    this.defer(async (db) => {
+      await db.rawQuery(
+        `INSERT INTO user_providers (user_id, provider, confirmed_at, created_at, updated_at)
+         SELECT id, provider, now(), now(), now() FROM users WHERE provider IS NOT NULL`
+      )
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/database/migrations/1784208513122_create_fix_users_provider_checks_table.ts
+++ b/backend/database/migrations/1784208513122_create_fix_users_provider_checks_table.ts
@@ -1,0 +1,26 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+/**
+ * La migration de création de `users` a été éditée après coup ('github' → 'google'
+ * dans l'enum provider) sans migration corrective : les bases ayant exécuté la
+ * version d'origine gardent un CHECK qui refuse 'google', ce qui fait échouer
+ * toute création de compte via Google OAuth. On recrée la contrainte à
+ * l'identique du fichier actuel, quel que soit l'état de départ.
+ */
+export default class extends BaseSchema {
+  protected tableName = 'users'
+
+  async up() {
+    this.defer(async (db) => {
+      await db.rawQuery('ALTER TABLE users DROP CONSTRAINT IF EXISTS users_provider_check')
+      await db.rawQuery(
+        `ALTER TABLE users ADD CONSTRAINT users_provider_check
+         CHECK (provider = ANY (ARRAY['google'::text, 'discord'::text]))`
+      )
+    })
+  }
+
+  async down() {
+    // Pas de retour à l'ancienne contrainte ('github') : elle était erronée.
+  }
+}

--- a/backend/database/schema.ts
+++ b/backend/database/schema.ts
@@ -576,6 +576,39 @@ export class TrafficDailySchema extends BaseModel {
   declare updatedAt: DateTime
 }
 
+export class UserProviderSchema extends BaseModel {
+  static $columns = [
+    'confirmedAt',
+    'createdAt',
+    'id',
+    'linkTokenExpiresAt',
+    'linkTokenHash',
+    'provider',
+    'providerUserId',
+    'updatedAt',
+    'userId',
+  ] as const
+  $columns = UserProviderSchema.$columns
+  @column.dateTime()
+  declare confirmedAt: DateTime | null
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime | null
+  @column({ isPrimary: true })
+  declare id: number
+  @column.dateTime()
+  declare linkTokenExpiresAt: DateTime | null
+  @column()
+  declare linkTokenHash: string | null
+  @column()
+  declare provider: string
+  @column()
+  declare providerUserId: string | null
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime | null
+  @column()
+  declare userId: number
+}
+
 export class UserSchema extends BaseModel {
   static $columns = [
     'avatarUrl',

--- a/backend/resources/lang/en/emails.json
+++ b/backend/resources/lang/en/emails.json
@@ -20,5 +20,16 @@
     "viewInBrowser": "View this email in your browser",
     "footerReason": "You are receiving this email because a password reset was requested for your Minecraft-Stats.fr account.",
     "copyright": "© Minecraft-Stats.fr, All Rights Reserved."
+  },
+  "providerLink": {
+    "subject": "Confirm adding {provider} to your account",
+    "title": "Add {provider} to your Minecraft-Stats.fr account",
+    "greeting": "Hi {username},",
+    "intro": "Someone tried to sign in to your account using {provider}. If it was you, click the button below to add {provider} as a sign-in method — you'll then be able to sign in with it at any time.",
+    "cta": "Add {provider} to my account",
+    "expiry": "This link will expire in 1 hour for your security.",
+    "ignore": "If you didn't try to sign in with {provider}, you can safely ignore this email — nothing will change on your account.",
+    "footerReason": "You are receiving this email because a sign-in with a new provider was attempted on your Minecraft-Stats.fr account.",
+    "copyright": "© Minecraft-Stats.fr, All Rights Reserved."
   }
 }

--- a/backend/resources/lang/en/messages.json
+++ b/backend/resources/lang/en/messages.json
@@ -24,7 +24,11 @@
     "oauthCancelled": "You have cancelled the login process",
     "oauthStateMismatch": "We are unable to verify the request. Please try again",
     "oauthError": "An error occurred while logging in. Please try again",
-    "cannotLoginWithProvider": "Cannot login with this third-party provider"
+    "providerLinkEmailSent": "We sent you an email to confirm adding this sign-in method to your account.",
+    "invalidProviderLinkToken": "This confirmation link is invalid or has expired.",
+    "providerNotLinked": "This provider is not linked to your account",
+    "cannotUnlinkLastMethod": "You cannot remove your only sign-in method",
+    "providerUnlinked": "Sign-in method removed"
   },
   "servers": {
     "unauthorized": "Unauthorized",

--- a/backend/resources/lang/fr/emails.json
+++ b/backend/resources/lang/fr/emails.json
@@ -20,5 +20,16 @@
     "viewInBrowser": "Afficher cet e-mail dans votre navigateur",
     "footerReason": "Vous recevez cet e-mail car une réinitialisation de mot de passe a été demandée pour votre compte Minecraft-Stats.fr.",
     "copyright": "© Minecraft-Stats.fr, Tous droits réservés."
+  },
+  "providerLink": {
+    "subject": "Confirmez l'ajout de {provider} à votre compte",
+    "title": "Ajoutez {provider} à votre compte Minecraft-Stats.fr",
+    "greeting": "Bonjour {username},",
+    "intro": "Quelqu'un a tenté de se connecter à votre compte via {provider}. Si c'était vous, cliquez sur le bouton ci-dessous pour ajouter {provider} comme méthode de connexion — vous pourrez ensuite l'utiliser à tout moment.",
+    "cta": "Ajouter {provider} à mon compte",
+    "expiry": "Ce lien expirera dans 1 heure pour votre sécurité.",
+    "ignore": "Si vous n'êtes pas à l'origine de cette tentative, vous pouvez ignorer cet e-mail : rien ne changera sur votre compte.",
+    "footerReason": "Vous recevez cet e-mail car une connexion avec un nouveau fournisseur a été tentée sur votre compte Minecraft-Stats.fr.",
+    "copyright": "© Minecraft-Stats.fr, Tous droits réservés."
   }
 }

--- a/backend/resources/lang/fr/messages.json
+++ b/backend/resources/lang/fr/messages.json
@@ -24,7 +24,11 @@
     "oauthCancelled": "Vous avez annulé le processus de connexion",
     "oauthStateMismatch": "Nous ne parvenons pas à vérifier la requête. Veuillez réessayer",
     "oauthError": "Une erreur est survenue lors de la connexion. Veuillez réessayer",
-    "cannotLoginWithProvider": "Connexion impossible avec ce fournisseur tiers"
+    "providerLinkEmailSent": "Nous vous avons envoyé un e-mail pour confirmer l'ajout de cette méthode de connexion à votre compte.",
+    "invalidProviderLinkToken": "Ce lien de confirmation est invalide ou a expiré.",
+    "providerNotLinked": "Ce fournisseur n'est pas lié à votre compte",
+    "cannotUnlinkLastMethod": "Vous ne pouvez pas supprimer votre seule méthode de connexion",
+    "providerUnlinked": "Méthode de connexion supprimée"
   },
   "servers": {
     "unauthorized": "Non autorisé",

--- a/backend/resources/views/emails/provider_link_html.edge
+++ b/backend/resources/views/emails/provider_link_html.edge
@@ -1,0 +1,63 @@
+@mjml()
+<mjml>
+  <mj-head>
+    <mj-title>Minecraft Stats</mj-title>
+    <mj-preview>{{ title }}</mj-preview>
+    <mj-font name="DM Sans" href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" />
+    <mj-attributes>
+      <mj-all font-family="'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"></mj-all>
+      <mj-text color="#3f3f46" font-size="15px" line-height="24px" align="center"></mj-text>
+    </mj-attributes>
+    <mj-style inline="inline">
+      .card { box-shadow: 0 1px 3px rgba(9, 9, 11, 0.08); }
+    </mj-style>
+  </mj-head>
+  <mj-body background-color="#f4f4f5">
+    <mj-section padding="32px 0 0"></mj-section>
+
+    <!-- En-tête : bande sombre + logo blanc -->
+    <mj-section background-color="#0f1115" border-radius="14px 14px 0 0" padding="26px 24px">
+      <mj-column>
+        <mj-image src="https://i.imgur.com/HOiiE3C.png" alt="Minecraft Stats" width="168px" align="center" padding="0" />
+      </mj-column>
+    </mj-section>
+
+    <!-- Corps -->
+    <mj-section background-color="#ffffff" border-radius="0 0 14px 14px" padding="8px 32px 34px" css-class="card">
+      <mj-column>
+        <mj-text color="#09090b" font-size="22px" font-weight="700" padding-top="28px" padding-bottom="10px">
+          {{ title }}
+        </mj-text>
+        <mj-text padding-bottom="4px">
+          {{ greeting }}
+        </mj-text>
+        <mj-text padding-bottom="28px">
+          {{ intro }}
+        </mj-text>
+        <mj-button href="{{ link_url }}" background-color="#0074c2" color="#ffffff" font-size="15px" font-weight="600" border-radius="8px" inner-padding="14px 34px" align="center" padding="0">
+          {{ cta }}
+        </mj-button>
+        <mj-divider border-width="1px" border-color="#ececef" padding="30px 0 22px"></mj-divider>
+        <mj-text color="#71717a" font-size="13px" line-height="20px" padding="0">
+          {{ expiry }}
+        </mj-text>
+        <mj-text color="#71717a" font-size="13px" line-height="20px" padding="8px 0 0">
+          {{ ignore }}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Pied -->
+    <mj-section padding="22px 24px 12px">
+      <mj-column>
+        <mj-text color="#a1a1aa" font-size="12px" line-height="18px" padding="2px 0">
+          {{ footerReason }}
+        </mj-text>
+        <mj-text color="#a1a1aa" font-size="12px" line-height="18px" padding="2px 0">
+          {{ copyright }}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>
+@end

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -164,6 +164,20 @@ router
       .get('/callback/discord', '#controllers/auth_controller.discordCallback')
       .use([throttleLight('discord-callback', 5), NO_STORE])
 
+    // Liaison de providers OAuth (multi-méthodes de connexion par compte)
+    router
+      .post('/link-provider', '#controllers/user_providers_controller.confirm')
+      .use([throttleLight('link-provider', 5), NO_STORE])
+    router
+      .get('/account/providers', '#controllers/user_providers_controller.index')
+      .use(middleware.auth())
+      .use([throttleLight('account.providers.index', 20), NO_STORE])
+    router
+      .delete('/account/providers/:provider', '#controllers/user_providers_controller.destroy')
+      .where('provider', /google|discord/)
+      .use(middleware.auth())
+      .use([throttleLight('account.providers.destroy', 10), NO_STORE])
+
     // Blog - Posts publics
     router.get('posts', '#controllers/posts_controller.index').use(throttleLight('posts.index', 50))
 

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -103,7 +103,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 521
+            "example": 354
           },
           "name": {
             "type": "string",
@@ -123,7 +123,7 @@
           },
           "weight": {
             "type": "number",
-            "example": 297
+            "example": 898
           },
           "show_on_home": {
             "type": "boolean",
@@ -176,11 +176,11 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 249
+            "example": 928
           },
           "advertisement_id": {
             "type": "number",
-            "example": 900
+            "example": 999
           },
           "type": {
             "$ref": "#/components/schemas/'impression'",
@@ -192,7 +192,7 @@
           },
           "server_id": {
             "type": "number",
-            "example": 564
+            "example": 435
           },
           "target_url": {
             "type": "string",
@@ -216,7 +216,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 424
+            "example": 461
           },
           "name": {
             "type": "string",
@@ -241,7 +241,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 183
+            "example": 30
           },
           "code": {
             "$ref": "#/components/schemas/LanguageCode",
@@ -274,7 +274,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 235
+            "example": 973
           },
           "uuid": {
             "type": "string",
@@ -316,15 +316,15 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 408
+            "example": 62
           },
           "visitor_id": {
             "type": "number",
-            "example": 24
+            "example": 971
           },
           "user_id": {
             "type": "number",
-            "example": 386
+            "example": 474
           },
           "path": {
             "type": "string",
@@ -340,7 +340,7 @@
           },
           "duration_ms": {
             "type": "number",
-            "example": 105
+            "example": 169
           },
           "created_at": {
             "type": "string",
@@ -364,7 +364,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 644
+            "example": 515
           },
           "cover_image": {
             "type": "string",
@@ -376,7 +376,7 @@
           },
           "view_count": {
             "type": "number",
-            "example": 599
+            "example": 892
           },
           "default_locale": {
             "type": "string",
@@ -389,7 +389,7 @@
           },
           "user_id": {
             "type": "number",
-            "example": 524
+            "example": 323
           },
           "author": {
             "$ref": "#/components/schemas/User",
@@ -421,15 +421,15 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 999
+            "example": 633
           },
           "post_id": {
             "type": "number",
-            "example": 135
+            "example": 739
           },
           "user_id": {
             "type": "number",
-            "example": 954
+            "example": 465
           },
           "visitor_id": {
             "type": "string",
@@ -466,11 +466,11 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 538
+            "example": 816
           },
           "post_id": {
             "type": "number",
-            "example": 242
+            "example": 935
           },
           "locale": {
             "type": "string",
@@ -515,7 +515,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 134
+            "example": 410
           },
           "name": {
             "type": "string",
@@ -527,7 +527,7 @@
           },
           "port": {
             "type": "number",
-            "example": 365
+            "example": 533
           },
           "type": {
             "$ref": "#/components/schemas/ServerType",
@@ -567,7 +567,7 @@
           },
           "user_id": {
             "type": "number",
-            "example": 413
+            "example": 248
           },
           "user": {
             "$ref": "#/components/schemas/User",
@@ -586,7 +586,7 @@
           },
           "vote_count": {
             "type": "number",
-            "example": 635
+            "example": 95
           },
           "categories": {
             "type": "array",
@@ -609,11 +609,11 @@
           },
           "last_player_count": {
             "type": "number",
-            "example": 143
+            "example": 104
           },
           "last_max_count": {
             "type": "number",
-            "example": 15
+            "example": 157
           },
           "last_stats_at": {
             "type": "string",
@@ -622,7 +622,7 @@
           },
           "peak_player_count": {
             "type": "number",
-            "example": 912
+            "example": 215
           },
           "peak_player_at": {
             "type": "string",
@@ -653,27 +653,27 @@
         "properties": {
           "server_id": {
             "type": "number",
-            "example": 158
+            "example": 264
           },
           "weekly_growth": {
             "type": "number",
-            "example": 286
+            "example": 528
           },
           "monthly_growth": {
             "type": "number",
-            "example": 260
+            "example": 0
           },
           "last_week_average": {
             "type": "number",
-            "example": 98
+            "example": 590
           },
           "previous_week_average": {
             "type": "number",
-            "example": 784
+            "example": 188
           },
           "last_month_average": {
             "type": "number",
-            "example": 223
+            "example": 171
           },
           "last_updated": {
             "type": "string",
@@ -689,7 +689,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 497
+            "example": 62
           },
           "server": {
             "$ref": "#/components/schemas/Server",
@@ -697,15 +697,15 @@
           },
           "server_id": {
             "type": "number",
-            "example": 825
+            "example": 171
           },
           "player_count": {
             "type": "number",
-            "example": 137
+            "example": 133
           },
           "max_count": {
             "type": "number",
-            "example": 630
+            "example": 586
           },
           "created_at": {
             "type": "string",
@@ -721,7 +721,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 497
+            "example": 207
           },
           "server": {
             "$ref": "#/components/schemas/Server",
@@ -729,11 +729,11 @@
           },
           "server_id": {
             "type": "number",
-            "example": 123
+            "example": 624
           },
           "visitor_id": {
             "type": "number",
-            "example": 51
+            "example": 736
           },
           "user": {
             "$ref": "#/components/schemas/User",
@@ -741,7 +741,7 @@
           },
           "user_id": {
             "type": "number",
-            "example": 60
+            "example": 669
           },
           "username": {
             "type": "string",
@@ -778,7 +778,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 388
+            "example": 646
           },
           "date": {
             "type": "string",
@@ -787,15 +787,15 @@
           },
           "http_requests": {
             "type": "number",
-            "example": 772
+            "example": 197
           },
           "http_errors": {
             "type": "number",
-            "example": 343
+            "example": 604
           },
           "unique_visitors": {
             "type": "number",
-            "example": 899
+            "example": 63
           },
           "countries": {
             "$ref": "#/components/schemas/Record<string, number>",
@@ -820,7 +820,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 557
+            "example": 670
           },
           "username": {
             "type": "string",
@@ -863,9 +863,58 @@
               "$ref": "#/components/schemas/Post",
               "example": null
             }
+          },
+          "providers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserProvider",
+              "example": null
+            }
           }
         },
         "description": "User (Model)"
+      },
+      "UserProvider": {
+        "type": "object",
+        "required": [],
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 507
+          },
+          "user": {
+            "$ref": "#/components/schemas/User",
+            "example": null
+          },
+          "user_id": {
+            "type": "number",
+            "example": 973
+          },
+          "provider": {
+            "$ref": "#/components/schemas/'google'",
+            "example": null
+          },
+          "provider_user_id": {
+            "type": "string",
+            "example": "Lorem Ipsum"
+          },
+          "confirmed_at": {
+            "type": "string",
+            "example": "2021-03-23T16:13:08.489+01:00",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "example": "2021-03-23T16:13:08.489+01:00",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "example": "2021-03-23T16:13:08.489+01:00",
+            "format": "date-time"
+          }
+        },
+        "description": "UserProvider (Model)"
       },
       "Visitor": {
         "type": "object",
@@ -873,7 +922,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 611
+            "example": 878
           },
           "uuid": {
             "type": "string",
@@ -924,15 +973,15 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 992
+            "example": 972
           },
           "visitor_id": {
             "type": "number",
-            "example": 107
+            "example": 935
           },
           "user_id": {
             "type": "number",
-            "example": 429
+            "example": 30
           },
           "linked_at": {
             "type": "string",
@@ -967,7 +1016,7 @@
           },
           "type": {
             "type": "number",
-            "example": 244,
+            "example": 447,
             "choices": [
               "custom",
               "network"
@@ -1010,13 +1059,13 @@
             "type": "array",
             "items": {
               "type": "number",
-              "example": 943
+              "example": 984
             }
           }
         },
         "example": {
           "name": "Lorem Ipsum",
-          "type": 244,
+          "type": 447,
           "htmlContent": "Lorem Ipsum",
           "enabled": true,
           "weight": 1,
@@ -1025,7 +1074,7 @@
           "startsAt": "Lorem Ipsum",
           "endsAt": "Lorem Ipsum",
           "categoryIds": [
-            943
+            984
           ]
         },
         "description": "CreateAdvertisementValidator (Validator)"
@@ -1041,7 +1090,7 @@
           },
           "type": {
             "type": "number",
-            "example": 589,
+            "example": 638,
             "choices": [
               "custom",
               "network"
@@ -1083,13 +1132,13 @@
             "type": "array",
             "items": {
               "type": "number",
-              "example": 79
+              "example": 572
             }
           }
         },
         "example": {
           "name": "Lorem Ipsum",
-          "type": 589,
+          "type": 638,
           "htmlContent": "Lorem Ipsum",
           "enabled": true,
           "weight": 1,
@@ -1098,7 +1147,7 @@
           "startsAt": "Lorem Ipsum",
           "endsAt": "Lorem Ipsum",
           "categoryIds": [
-            79
+            572
           ]
         },
         "description": "UpdateAdvertisementValidator (Validator)"
@@ -1144,7 +1193,7 @@
           },
           "durationMs": {
             "type": "number",
-            "example": 18,
+            "example": 354,
             "maximum": 86400000
           }
         },
@@ -1153,7 +1202,7 @@
           "path": "Lorem Ipsum",
           "referrer": "Lorem Ipsum",
           "title": "Lorem Ipsum",
-          "durationMs": 18
+          "durationMs": 354
         },
         "description": "TrackPageViewValidator (Validator)"
       },
@@ -1169,13 +1218,13 @@
           },
           "expiresInDays": {
             "type": "number",
-            "example": 982,
+            "example": 319,
             "maximum": 3650
           }
         },
         "example": {
           "name": "Lorem Ipsum",
-          "expiresInDays": 982
+          "expiresInDays": 319
         },
         "description": "CreateApiTokenValidator (Validator)"
       },
@@ -1184,12 +1233,12 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 959,
+            "example": 629,
             "required": true
           }
         },
         "example": {
-          "id": 959
+          "id": 629
         },
         "description": "CategoryIdValidator (Validator)"
       },
@@ -1212,7 +1261,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 473,
+            "example": 232,
             "required": true
           },
           "name": {
@@ -1222,7 +1271,7 @@
           }
         },
         "example": {
-          "id": 473,
+          "id": 232,
           "name": "Lorem Ipsum"
         },
         "description": "UpdateCategoryValidator (Validator)"
@@ -1232,39 +1281,39 @@
         "properties": {
           "fromDate": {
             "type": "number",
-            "example": 186
+            "example": 698
           },
           "toDate": {
             "type": "number",
-            "example": 952
+            "example": 589
           },
           "interval": {
             "type": "number",
-            "example": 499,
+            "example": 581,
             "choices": [
               "30 minutes",
               "1 hour",
-              "1 day",
               "2 hours",
               "6 hours",
+              "1 day",
               "1 week"
             ]
           },
           "categoryId": {
             "type": "number",
-            "example": 359
+            "example": 894
           },
           "languageId": {
             "type": "number",
-            "example": 439
+            "example": 66
           }
         },
         "example": {
-          "fromDate": 186,
-          "toDate": 952,
-          "interval": 499,
-          "categoryId": 359,
-          "languageId": 439
+          "fromDate": 698,
+          "toDate": 589,
+          "interval": 581,
+          "categoryId": 894,
+          "languageId": 66
         },
         "description": "GlobalStatValidator (Validator)"
       },
@@ -1273,7 +1322,7 @@
         "properties": {
           "defaultLocale": {
             "type": "number",
-            "example": 120,
+            "example": 320,
             "choices": [
               "fr",
               "en",
@@ -1293,7 +1342,7 @@
               "properties": {
                 "locale": {
                   "type": "number",
-                  "example": 934,
+                  "example": 352,
                   "choices": [
                     "fr",
                     "en",
@@ -1322,7 +1371,7 @@
                 },
                 "excerpt": {
                   "type": "number",
-                  "example": 39,
+                  "example": 601,
                   "maximum": 500
                 }
               }
@@ -1351,11 +1400,11 @@
           }
         },
         "example": {
-          "defaultLocale": 120,
+          "defaultLocale": 320,
           "coverImage": "Lorem Ipsum",
           "translations": [
             {
-              "locale": 934,
+              "locale": 352,
               "title": "Lorem Ipsum",
               "slug": "Lorem Ipsum",
               "content": "Lorem Ipsum",
@@ -1375,13 +1424,13 @@
           },
           "serverId": {
             "type": "number",
-            "example": 130,
+            "example": 473,
             "required": true
           }
         },
         "example": {
           "placeholderName": "Lorem Ipsum",
-          "serverId": 130
+          "serverId": 473
         },
         "description": "PreviewPlaceholderValidator (Validator)"
       },
@@ -1439,7 +1488,7 @@
         "properties": {
           "defaultLocale": {
             "type": "number",
-            "example": 714,
+            "example": 332,
             "choices": [
               "fr",
               "en",
@@ -1458,7 +1507,7 @@
               "properties": {
                 "locale": {
                   "type": "number",
-                  "example": 67,
+                  "example": 713,
                   "choices": [
                     "fr",
                     "en",
@@ -1485,7 +1534,7 @@
                 },
                 "excerpt": {
                   "type": "number",
-                  "example": 305,
+                  "example": 694,
                   "maximum": 500
                 }
               }
@@ -1513,11 +1562,11 @@
           }
         },
         "example": {
-          "defaultLocale": 714,
+          "defaultLocale": 332,
           "coverImage": "Lorem Ipsum",
           "translations": [
             {
-              "locale": 67,
+              "locale": 713,
               "title": "Lorem Ipsum",
               "slug": "Lorem Ipsum",
               "content": "Lorem Ipsum",
@@ -1549,7 +1598,7 @@
           },
           "type": {
             "type": "number",
-            "example": 702,
+            "example": 245,
             "choices": [
               "java",
               "bedrock"
@@ -1563,7 +1612,7 @@
             "type": "array",
             "items": {
               "type": "number",
-              "example": 412
+              "example": 865
             },
             "required": true,
             "properties": {
@@ -1589,7 +1638,7 @@
             "type": "array",
             "items": {
               "type": "number",
-              "example": 739
+              "example": 371
             },
             "required": true
           }
@@ -1598,7 +1647,7 @@
           "name": "Lorem Ipsum",
           "address": "Lorem Ipsum",
           "port": 1,
-          "type": 702,
+          "type": 245,
           "imageUrl": "Lorem Ipsum",
           "categories": [
             "Lorem Ipsum"
@@ -1607,7 +1656,7 @@
           "website": "Lorem Ipsum",
           "motd": "Lorem Ipsum",
           "languages": [
-            739
+            371
           ]
         },
         "description": "CreateServerValidator (Validator)"
@@ -1631,7 +1680,7 @@
           },
           "type": {
             "type": "number",
-            "example": 843,
+            "example": 366,
             "choices": [
               "java",
               "bedrock"
@@ -1645,7 +1694,7 @@
             "type": "array",
             "items": {
               "type": "number",
-              "example": 60
+              "example": 55
             },
             "properties": {
               "items": {
@@ -1670,7 +1719,7 @@
             "type": "array",
             "items": {
               "type": "number",
-              "example": 922
+              "example": 912
             }
           }
         },
@@ -1678,7 +1727,7 @@
           "name": "Lorem Ipsum",
           "address": "Lorem Ipsum",
           "port": 1,
-          "type": 843,
+          "type": 366,
           "imageUrl": "Lorem Ipsum",
           "categories": [
             "Lorem Ipsum"
@@ -1687,7 +1736,7 @@
           "website": "Lorem Ipsum",
           "motd": "Lorem Ipsum",
           "languages": [
-            922
+            912
           ]
         },
         "description": "UpdateServerValidator (Validator)"
@@ -1697,18 +1746,18 @@
         "properties": {
           "serverId": {
             "type": "number",
-            "example": 505,
+            "example": 870,
             "required": true
           },
           "categoryId": {
             "type": "number",
-            "example": 110,
+            "example": 998,
             "required": true
           }
         },
         "example": {
-          "serverId": 505,
-          "categoryId": 110
+          "serverId": 870,
+          "categoryId": 998
         },
         "description": "attachServerCategoryValidator (Validator)"
       },
@@ -1762,40 +1811,40 @@
         "properties": {
           "server_id": {
             "type": "number",
-            "example": 275,
+            "example": 417,
             "required": true
           },
           "exactTime": {
             "type": "number",
-            "example": 498
+            "example": 642
           },
           "fromDate": {
             "type": "number",
-            "example": 970
+            "example": 913
           },
           "toDate": {
             "type": "number",
-            "example": 354
+            "example": 144
           },
           "interval": {
             "type": "number",
-            "example": 609,
+            "example": 157,
             "choices": [
               "30 minutes",
               "1 hour",
-              "1 day",
               "2 hours",
               "6 hours",
+              "1 day",
               "1 week"
             ]
           }
         },
         "example": {
-          "server_id": 275,
-          "exactTime": 498,
-          "fromDate": 970,
-          "toDate": 354,
-          "interval": 609
+          "server_id": 417,
+          "exactTime": 642,
+          "fromDate": 913,
+          "toDate": 144,
+          "interval": 157
         },
         "description": "StatValidator (Validator)"
       },
@@ -1884,6 +1933,20 @@
           "email": "Lorem Ipsum"
         },
         "description": "ForgotPasswordValidator (Validator)"
+      },
+      "LinkProviderValidator": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "example": "Lorem Ipsum",
+            "required": true
+          }
+        },
+        "example": {
+          "token": "Lorem Ipsum"
+        },
+        "description": "LinkProviderValidator (Validator)"
       },
       "LoginUserValidator": {
         "type": "object",
@@ -2035,10 +2098,10 @@
                 "example": [
                   {
                     "server": {
-                      "id": 134,
+                      "id": 410,
                       "name": "John Doe",
                       "address": "1028 Farland Street",
-                      "port": 365,
+                      "port": 533,
                       "type": {},
                       "version": "Lorem Ipsum",
                       "website": "Lorem Ipsum",
@@ -2048,13 +2111,13 @@
                       "resolved_endpoint": "Lorem Ipsum",
                       "motd_hash": "Lorem Ipsum",
                       "host_domain": "Lorem Ipsum",
-                      "user_id": 413,
-                      "vote_count": 635,
+                      "user_id": 248,
+                      "vote_count": 95,
                       "last_online_at": "2021-03-23T16:13:08.489+01:00",
-                      "last_player_count": 143,
-                      "last_max_count": 15,
+                      "last_player_count": 104,
+                      "last_max_count": 157,
                       "last_stats_at": "2021-03-23T16:13:08.489+01:00",
-                      "peak_player_count": 912,
+                      "peak_player_count": 215,
                       "peak_player_at": "2021-03-23T16:13:08.489+01:00",
                       "next_ping_at": "2021-03-23T16:13:08.489+01:00",
                       "created_at": "2021-03-23T16:13:08.489+01:00",
@@ -2064,12 +2127,12 @@
                       "<Category>"
                     ],
                     "growthStat": {
-                      "server_id": 158,
-                      "weekly_growth": 286,
-                      "monthly_growth": 260,
-                      "last_week_average": 98,
-                      "previous_week_average": 784,
-                      "last_month_average": 223,
+                      "server_id": 264,
+                      "weekly_growth": 528,
+                      "monthly_growth": 0,
+                      "last_week_average": 590,
+                      "previous_week_average": 188,
+                      "last_month_average": 171,
                       "last_updated": "2021-03-23T16:13:08.489+01:00"
                     }
                   }
@@ -4613,7 +4676,7 @@
               },
               "example": {
                 "name": "Lorem Ipsum",
-                "expiresInDays": 982
+                "expiresInDays": 319
               }
             }
           }
@@ -4835,17 +4898,35 @@
             },
             "description": "Returns **200** (OK) as **application/json**"
           },
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": "link_email_sent",
+                    "message": "We sent you an email to confirm adding this sign-in method to your account."
+                  }
+                },
+                "example": {
+                  "status": "link_email_sent",
+                  "message": "We sent you an email to confirm adding this sign-in method to your account."
+                }
+              }
+            },
+            "description": "Returns **202** (Accepted) as **application/json**"
+          },
           "400": {
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "message": "Cannot login with this third-party provider"
+                    "message": "An error occurred while logging in. Please try again"
                   }
                 },
                 "example": {
-                  "message": "Cannot login with this third-party provider"
+                  "message": "An error occurred while logging in. Please try again"
                 }
               }
             },
@@ -4915,17 +4996,35 @@
             },
             "description": "Returns **200** (OK) as **application/json**"
           },
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": "link_email_sent",
+                    "message": "We sent you an email to confirm adding this sign-in method to your account."
+                  }
+                },
+                "example": {
+                  "status": "link_email_sent",
+                  "message": "We sent you an email to confirm adding this sign-in method to your account."
+                }
+              }
+            },
+            "description": "Returns **202** (Accepted) as **application/json**"
+          },
           "400": {
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "message": "Cannot login with this third-party provider"
+                    "message": "An error occurred while logging in. Please try again"
                   }
                 },
                 "example": {
-                  "message": "Cannot login with this third-party provider"
+                  "message": "An error occurred while logging in. Please try again"
                 }
               }
             },
@@ -4933,6 +5032,333 @@
           }
         },
         "security": []
+      }
+    },
+    "/api/v1/link-provider": {
+      "post": {
+        "summary": "Confirm adding an OAuth provider to an existing account (confirm)",
+        "description": "Validates the token from the confirmation email sent when an OAuth login matched an existing account (see googleCallback/discordCallback), marks the provider link as confirmed and clears the token. Clicking the emailed link proves ownership of the address, so the account is also marked verified and the user is signed in directly (user + fresh access token returned). Invalid and expired tokens return the same generic error to avoid leaking token state.\n\n _app/controllers/user_providers_controller.ts_ - **confirm**",
+        "operationId": "confirmProviderLink",
+        "parameters": [],
+        "tags": [
+          "AUTH"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": 1,
+                        "username": "player",
+                        "verified": true,
+                        "provider": "",
+                        "role": "user",
+                        "avatarUrl": "",
+                        "createdAt": "2026-05-28T12:00:00.000Z",
+                        "updatedAt": "2026-05-28T12:00:00.000Z"
+                      }
+                    },
+                    "accessToken": {
+                      "type": "object",
+                      "properties": {
+                        "type": "bearer",
+                        "token": "oat_...",
+                        "expiresAt": "2026-06-27T12:00:00.000Z"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "user": {
+                    "id": 1,
+                    "username": "player",
+                    "verified": true,
+                    "provider": "",
+                    "role": "user",
+                    "avatarUrl": "",
+                    "createdAt": "2026-05-28T12:00:00.000Z",
+                    "updatedAt": "2026-05-28T12:00:00.000Z"
+                  },
+                  "accessToken": {
+                    "type": "bearer",
+                    "token": "oat_...",
+                    "expiresAt": "2026-06-27T12:00:00.000Z"
+                  }
+                }
+              }
+            },
+            "description": "Returns **200** (OK) as **application/json**"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": "This confirmation link is invalid or has expired."
+                  }
+                },
+                "example": {
+                  "message": "This confirmation link is invalid or has expired."
+                }
+              }
+            },
+            "description": "Returns **400** (Bad Request) as **application/json**"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "object",
+                      "properties": {
+                        "0": {
+                          "type": "object",
+                          "properties": {
+                            "message": "The token field must be defined",
+                            "rule": "required",
+                            "field": "token"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "message": "The token field must be defined",
+                      "rule": "required",
+                      "field": "token"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Returns **422** (Unprocessable Entity) as **application/json**"
+          }
+        },
+        "security": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LinkProviderValidator"
+              },
+              "example": {
+                "token": "Lorem Ipsum"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/account/providers": {
+      "get": {
+        "summary": "List the OAuth providers linked to the authenticated account (index)",
+        "description": "Returns **200** (OK) as **application/json**\n\n _app/controllers/user_providers_controller.ts_ - **index**",
+        "operationId": "listLinkedProviders",
+        "parameters": [],
+        "tags": [
+          "AUTH"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "providers": {
+                      "type": "object",
+                      "properties": {
+                        "0": {
+                          "type": "object",
+                          "properties": {
+                            "provider": "google",
+                            "linkedAt": "2026-05-28T12:00:00.000Z"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "providers": [
+                    {
+                      "provider": "google",
+                      "linkedAt": "2026-05-28T12:00:00.000Z"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Returns **200** (OK) as **application/json**"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "object",
+                      "properties": {
+                        "0": {
+                          "type": "object",
+                          "properties": {
+                            "message": "Unauthorized access"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "message": "Unauthorized access"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Returns **401** (Unauthorized) as **application/json**"
+          },
+          "403": {
+            "description": "Returns **403** (Forbidden)"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": [
+              "access"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/v1/account/providers/{provider}": {
+      "delete": {
+        "summary": "Unlink an OAuth provider from the authenticated account (destroy)",
+        "description": "Removes a confirmed OAuth sign-in method from the current user. Refused when it is the account's last usable sign-in method (accounts created via OAuth have no usable password). Requires authentication.\n\n _app/controllers/user_providers_controller.ts_ - **destroy**",
+        "operationId": "unlinkProvider",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider",
+            "description": "The OAuth provider to unlink",
+            "schema": {
+              "example": "google",
+              "type": "string",
+              "enum": [
+                "google",
+                "discord"
+              ]
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "AUTH"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": "Sign-in method removed"
+                  }
+                },
+                "example": {
+                  "message": "Sign-in method removed"
+                }
+              }
+            },
+            "description": "Returns **200** (OK) as **application/json**"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": "You cannot remove your only sign-in method"
+                  }
+                },
+                "example": {
+                  "message": "You cannot remove your only sign-in method"
+                }
+              }
+            },
+            "description": "Returns **400** (Bad Request) as **application/json**"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "object",
+                      "properties": {
+                        "0": {
+                          "type": "object",
+                          "properties": {
+                            "message": "Unauthorized access"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "message": "Unauthorized access"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Returns **401** (Unauthorized) as **application/json**"
+          },
+          "403": {
+            "description": "Returns **403** (Forbidden)"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": "This provider is not linked to your account"
+                  }
+                },
+                "example": {
+                  "message": "This provider is not linked to your account"
+                }
+              }
+            },
+            "description": "Returns **404** (Not Found) as **application/json**"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": [
+              "access"
+            ]
+          }
+        ]
       }
     },
     "/api/v1/posts": {
@@ -6238,6 +6664,18 @@
     {
       "name": "API TOKENS",
       "description": "Everything related to API TOKENS"
+    },
+    {
+      "name": "AUTH",
+      "description": "Everything related to AUTH"
+    },
+    {
+      "name": "AUTH",
+      "description": "Everything related to AUTH"
+    },
+    {
+      "name": "AUTH",
+      "description": "Everything related to AUTH"
     },
     {
       "name": "AUTH",

--- a/backend/swagger.yml
+++ b/backend/swagger.yml
@@ -78,7 +78,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 521
+          example: 354
         name:
           type: "string"
           example: "John Doe"
@@ -93,7 +93,7 @@ components:
           example: true
         weight:
           type: "number"
-          example: 297
+          example: 898
         show_on_home:
           type: "boolean"
           example: true
@@ -133,10 +133,10 @@ components:
       properties:
         id:
           type: "number"
-          example: 249
+          example: 928
         advertisement_id:
           type: "number"
-          example: 900
+          example: 999
         type:
           $ref: "#/components/schemas/'impression'"
           example: null
@@ -145,7 +145,7 @@ components:
           example: "Lorem Ipsum"
         server_id:
           type: "number"
-          example: 564
+          example: 435
         target_url:
           type: "string"
           example: "Lorem Ipsum"
@@ -163,7 +163,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 424
+          example: 461
         name:
           type: "string"
           example: "John Doe"
@@ -182,7 +182,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 183
+          example: 30
         code:
           $ref: "#/components/schemas/LanguageCode"
           example: null
@@ -207,7 +207,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 235
+          example: 973
         uuid:
           type: "string"
           example: "Lorem Ipsum"
@@ -239,13 +239,13 @@ components:
       properties:
         id:
           type: "number"
-          example: 408
+          example: 62
         visitor_id:
           type: "number"
-          example: 24
+          example: 971
         user_id:
           type: "number"
-          example: 386
+          example: 474
         path:
           type: "string"
           example: "Lorem Ipsum"
@@ -257,7 +257,7 @@ components:
           example: "Lorem Ipsum"
         duration_ms:
           type: "number"
-          example: 105
+          example: 169
         created_at:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
@@ -275,7 +275,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 644
+          example: 515
         cover_image:
           type: "string"
           example: "Lorem Ipsum"
@@ -284,7 +284,7 @@ components:
           example: true
         view_count:
           type: "number"
-          example: 599
+          example: 892
         default_locale:
           type: "string"
           example: "Lorem Ipsum"
@@ -294,7 +294,7 @@ components:
           format: "date-time"
         user_id:
           type: "number"
-          example: 524
+          example: 323
         author:
           $ref: "#/components/schemas/User"
           example: null
@@ -318,13 +318,13 @@ components:
       properties:
         id:
           type: "number"
-          example: 999
+          example: 633
         post_id:
           type: "number"
-          example: 135
+          example: 739
         user_id:
           type: "number"
-          example: 954
+          example: 465
         visitor_id:
           type: "string"
           example: "Lorem Ipsum"
@@ -352,10 +352,10 @@ components:
       properties:
         id:
           type: "number"
-          example: 538
+          example: 816
         post_id:
           type: "number"
-          example: 242
+          example: 935
         locale:
           type: "string"
           example: "Lorem Ipsum"
@@ -389,7 +389,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 134
+          example: 410
         name:
           type: "string"
           example: "John Doe"
@@ -398,7 +398,7 @@ components:
           example: "1028 Farland Street"
         port:
           type: "number"
-          example: 365
+          example: 533
         type:
           $ref: "#/components/schemas/ServerType"
           example: null
@@ -428,7 +428,7 @@ components:
           example: "Lorem Ipsum"
         user_id:
           type: "number"
-          example: 413
+          example: 248
         user:
           $ref: "#/components/schemas/User"
           example: null
@@ -442,7 +442,7 @@ components:
             example: null
         vote_count:
           type: "number"
-          example: 635
+          example: 95
         categories:
           type: "array"
           items:
@@ -459,17 +459,17 @@ components:
           format: "date-time"
         last_player_count:
           type: "number"
-          example: 143
+          example: 104
         last_max_count:
           type: "number"
-          example: 15
+          example: 157
         last_stats_at:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
           format: "date-time"
         peak_player_count:
           type: "number"
-          example: 912
+          example: 215
         peak_player_at:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
@@ -493,22 +493,22 @@ components:
       properties:
         server_id:
           type: "number"
-          example: 158
+          example: 264
         weekly_growth:
           type: "number"
-          example: 286
+          example: 528
         monthly_growth:
           type: "number"
-          example: 260
+          example: 0
         last_week_average:
           type: "number"
-          example: 98
+          example: 590
         previous_week_average:
           type: "number"
-          example: 784
+          example: 188
         last_month_average:
           type: "number"
-          example: 223
+          example: 171
         last_updated:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
@@ -520,19 +520,19 @@ components:
       properties:
         id:
           type: "number"
-          example: 497
+          example: 62
         server:
           $ref: "#/components/schemas/Server"
           example: null
         server_id:
           type: "number"
-          example: 825
+          example: 171
         player_count:
           type: "number"
-          example: 137
+          example: 133
         max_count:
           type: "number"
-          example: 630
+          example: 586
         created_at:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
@@ -544,22 +544,22 @@ components:
       properties:
         id:
           type: "number"
-          example: 497
+          example: 207
         server:
           $ref: "#/components/schemas/Server"
           example: null
         server_id:
           type: "number"
-          example: 123
+          example: 624
         visitor_id:
           type: "number"
-          example: 51
+          example: 736
         user:
           $ref: "#/components/schemas/User"
           example: null
         user_id:
           type: "number"
-          example: 60
+          example: 669
         username:
           type: "string"
           example: "Lorem Ipsum"
@@ -587,20 +587,20 @@ components:
       properties:
         id:
           type: "number"
-          example: 388
+          example: 646
         date:
           type: "string"
           example: "2021-03-23"
           format: "date-time"
         http_requests:
           type: "number"
-          example: 772
+          example: 197
         http_errors:
           type: "number"
-          example: 343
+          example: 604
         unique_visitors:
           type: "number"
-          example: 899
+          example: 63
         countries:
           $ref: "#/components/schemas/Record<string, number>"
           example: null
@@ -619,7 +619,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 557
+          example: 670
         username:
           type: "string"
           example: "Lorem Ipsum"
@@ -652,14 +652,51 @@ components:
           items:
             $ref: "#/components/schemas/Post"
             example: null
+        providers:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/UserProvider"
+            example: null
       description: "User (Model)"
+    UserProvider:
+      type: "object"
+      required: []
+      properties:
+        id:
+          type: "number"
+          example: 507
+        user:
+          $ref: "#/components/schemas/User"
+          example: null
+        user_id:
+          type: "number"
+          example: 973
+        provider:
+          $ref: "#/components/schemas/'google'"
+          example: null
+        provider_user_id:
+          type: "string"
+          example: "Lorem Ipsum"
+        confirmed_at:
+          type: "string"
+          example: "2021-03-23T16:13:08.489+01:00"
+          format: "date-time"
+        created_at:
+          type: "string"
+          example: "2021-03-23T16:13:08.489+01:00"
+          format: "date-time"
+        updated_at:
+          type: "string"
+          example: "2021-03-23T16:13:08.489+01:00"
+          format: "date-time"
+      description: "UserProvider (Model)"
     Visitor:
       type: "object"
       required: []
       properties:
         id:
           type: "number"
-          example: 611
+          example: 878
         uuid:
           type: "string"
           example: "Lorem Ipsum"
@@ -697,13 +734,13 @@ components:
       properties:
         id:
           type: "number"
-          example: 992
+          example: 972
         visitor_id:
           type: "number"
-          example: 107
+          example: 935
         user_id:
           type: "number"
-          example: 429
+          example: 30
         linked_at:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
@@ -730,7 +767,7 @@ components:
           maxLength: 255
         type:
           type: "number"
-          example: 244
+          example: 447
           choices:
             - "custom"
             - "network"
@@ -764,10 +801,10 @@ components:
           type: "array"
           items:
             type: "number"
-            example: 943
+            example: 984
       example:
         name: "Lorem Ipsum"
-        type: 244
+        type: 447
         htmlContent: "Lorem Ipsum"
         enabled: true
         weight: 1
@@ -776,7 +813,7 @@ components:
         startsAt: "Lorem Ipsum"
         endsAt: "Lorem Ipsum"
         categoryIds:
-          - 943
+          - 984
       description: "CreateAdvertisementValidator (Validator)"
     UpdateAdvertisementValidator:
       type: "object"
@@ -788,7 +825,7 @@ components:
           maxLength: 255
         type:
           type: "number"
-          example: 589
+          example: 638
           choices:
             - "custom"
             - "network"
@@ -821,10 +858,10 @@ components:
           type: "array"
           items:
             type: "number"
-            example: 79
+            example: 572
       example:
         name: "Lorem Ipsum"
-        type: 589
+        type: 638
         htmlContent: "Lorem Ipsum"
         enabled: true
         weight: 1
@@ -833,7 +870,7 @@ components:
         startsAt: "Lorem Ipsum"
         endsAt: "Lorem Ipsum"
         categoryIds:
-          - 79
+          - 572
       description: "UpdateAdvertisementValidator (Validator)"
     IdentifyVisitorValidator:
       type: "object"
@@ -868,14 +905,14 @@ components:
           maxLength: 512
         durationMs:
           type: "number"
-          example: 18
+          example: 354
           maximum: 86400000
       example:
         visitorId: "Lorem Ipsum"
         path: "Lorem Ipsum"
         referrer: "Lorem Ipsum"
         title: "Lorem Ipsum"
-        durationMs: 18
+        durationMs: 354
       description: "TrackPageViewValidator (Validator)"
     CreateApiTokenValidator:
       type: "object"
@@ -888,21 +925,21 @@ components:
           maxLength: 100
         expiresInDays:
           type: "number"
-          example: 982
+          example: 319
           maximum: 3650
       example:
         name: "Lorem Ipsum"
-        expiresInDays: 982
+        expiresInDays: 319
       description: "CreateApiTokenValidator (Validator)"
     CategoryIdValidator:
       type: "object"
       properties:
         id:
           type: "number"
-          example: 959
+          example: 629
           required: true
       example:
-        id: 959
+        id: 629
       description: "CategoryIdValidator (Validator)"
     CreateCategoryValidator:
       type: "object"
@@ -919,14 +956,14 @@ components:
       properties:
         id:
           type: "number"
-          example: 473
+          example: 232
           required: true
         name:
           type: "string"
           example: "Lorem Ipsum"
           required: true
       example:
-        id: 473
+        id: 232
         name: "Lorem Ipsum"
       description: "UpdateCategoryValidator (Validator)"
     GlobalStatValidator:
@@ -934,39 +971,39 @@ components:
       properties:
         fromDate:
           type: "number"
-          example: 186
+          example: 698
         toDate:
           type: "number"
-          example: 952
+          example: 589
         interval:
           type: "number"
-          example: 499
+          example: 581
           choices:
             - "30 minutes"
             - "1 hour"
-            - "1 day"
             - "2 hours"
             - "6 hours"
+            - "1 day"
             - "1 week"
         categoryId:
           type: "number"
-          example: 359
+          example: 894
         languageId:
           type: "number"
-          example: 439
+          example: 66
       example:
-        fromDate: 186
-        toDate: 952
-        interval: 499
-        categoryId: 359
-        languageId: 439
+        fromDate: 698
+        toDate: 589
+        interval: 581
+        categoryId: 894
+        languageId: 66
       description: "GlobalStatValidator (Validator)"
     CreatePostValidator:
       type: "object"
       properties:
         defaultLocale:
           type: "number"
-          example: 120
+          example: 320
           choices:
             - "fr"
             - "en"
@@ -983,7 +1020,7 @@ components:
             properties:
               locale:
                 type: "number"
-                example: 934
+                example: 352
                 choices:
                   - "fr"
                   - "en"
@@ -1007,7 +1044,7 @@ components:
                 required: true
               excerpt:
                 type: "number"
-                example: 39
+                example: 601
                 maximum: 500
           required: true
           properties:
@@ -1025,10 +1062,10 @@ components:
                 type: "string"
                 example: "Lorem Ipsum"
       example:
-        defaultLocale: 120
+        defaultLocale: 320
         coverImage: "Lorem Ipsum"
         translations:
-          - locale: 934
+          - locale: 352
             title: "Lorem Ipsum"
             slug: "Lorem Ipsum"
             content: "Lorem Ipsum"
@@ -1043,11 +1080,11 @@ components:
           required: true
         serverId:
           type: "number"
-          example: 130
+          example: 473
           required: true
       example:
         placeholderName: "Lorem Ipsum"
-        serverId: 130
+        serverId: 473
       description: "PreviewPlaceholderValidator (Validator)"
     ResolvePlaceholdersValidator:
       type: "object"
@@ -1090,7 +1127,7 @@ components:
       properties:
         defaultLocale:
           type: "number"
-          example: 714
+          example: 332
           choices:
             - "fr"
             - "en"
@@ -1106,7 +1143,7 @@ components:
             properties:
               locale:
                 type: "number"
-                example: 67
+                example: 713
                 choices:
                   - "fr"
                   - "en"
@@ -1128,7 +1165,7 @@ components:
                 minimum: 10
               excerpt:
                 type: "number"
-                example: 305
+                example: 694
                 maximum: 500
           properties:
             items:
@@ -1145,10 +1182,10 @@ components:
                 type: "string"
                 example: "Lorem Ipsum"
       example:
-        defaultLocale: 714
+        defaultLocale: 332
         coverImage: "Lorem Ipsum"
         translations:
-          - locale: 67
+          - locale: 713
             title: "Lorem Ipsum"
             slug: "Lorem Ipsum"
             content: "Lorem Ipsum"
@@ -1173,7 +1210,7 @@ components:
           required: true
         type:
           type: "number"
-          example: 702
+          example: 245
           choices:
             - "java"
             - "bedrock"
@@ -1184,7 +1221,7 @@ components:
           type: "array"
           items:
             type: "number"
-            example: 412
+            example: 865
           required: true
           properties:
             items:
@@ -1203,13 +1240,13 @@ components:
           type: "array"
           items:
             type: "number"
-            example: 739
+            example: 371
           required: true
       example:
         name: "Lorem Ipsum"
         address: "Lorem Ipsum"
         port: 1
-        type: 702
+        type: 245
         imageUrl: "Lorem Ipsum"
         categories:
           - "Lorem Ipsum"
@@ -1217,7 +1254,7 @@ components:
         website: "Lorem Ipsum"
         motd: "Lorem Ipsum"
         languages:
-          - 739
+          - 371
       description: "CreateServerValidator (Validator)"
     UpdateServerValidator:
       type: "object"
@@ -1235,7 +1272,7 @@ components:
           minimum: 1
         type:
           type: "number"
-          example: 843
+          example: 366
           choices:
             - "java"
             - "bedrock"
@@ -1246,7 +1283,7 @@ components:
           type: "array"
           items:
             type: "number"
-            example: 60
+            example: 55
           properties:
             items:
               type: "string"
@@ -1264,12 +1301,12 @@ components:
           type: "array"
           items:
             type: "number"
-            example: 922
+            example: 912
       example:
         name: "Lorem Ipsum"
         address: "Lorem Ipsum"
         port: 1
-        type: 843
+        type: 366
         imageUrl: "Lorem Ipsum"
         categories:
           - "Lorem Ipsum"
@@ -1277,22 +1314,22 @@ components:
         website: "Lorem Ipsum"
         motd: "Lorem Ipsum"
         languages:
-          - 922
+          - 912
       description: "UpdateServerValidator (Validator)"
     attachServerCategoryValidator:
       type: "object"
       properties:
         serverId:
           type: "number"
-          example: 505
+          example: 870
           required: true
         categoryId:
           type: "number"
-          example: 110
+          example: 998
           required: true
       example:
-        serverId: 505
-        categoryId: 110
+        serverId: 870
+        categoryId: 998
       description: "attachServerCategoryValidator (Validator)"
     CreateServerVoteValidator:
       type: "object"
@@ -1333,33 +1370,33 @@ components:
       properties:
         server_id:
           type: "number"
-          example: 275
+          example: 417
           required: true
         exactTime:
           type: "number"
-          example: 498
+          example: 642
         fromDate:
           type: "number"
-          example: 970
+          example: 913
         toDate:
           type: "number"
-          example: 354
+          example: 144
         interval:
           type: "number"
-          example: 609
+          example: 157
           choices:
             - "30 minutes"
             - "1 hour"
-            - "1 day"
             - "2 hours"
             - "6 hours"
+            - "1 day"
             - "1 week"
       example:
-        server_id: 275
-        exactTime: 498
-        fromDate: 970
-        toDate: 354
-        interval: 609
+        server_id: 417
+        exactTime: 642
+        fromDate: 913
+        toDate: 144
+        interval: 157
       description: "StatValidator (Validator)"
     ChangePasswordValidator:
       type: "object"
@@ -1428,6 +1465,16 @@ components:
       example:
         email: "Lorem Ipsum"
       description: "ForgotPasswordValidator (Validator)"
+    LinkProviderValidator:
+      type: "object"
+      properties:
+        token:
+          type: "string"
+          example: "Lorem Ipsum"
+          required: true
+      example:
+        token: "Lorem Ipsum"
+      description: "LinkProviderValidator (Validator)"
     LoginUserValidator:
       type: "object"
       properties:
@@ -1540,10 +1587,10 @@ paths:
                   type: "object"
               example:
                 - server:
-                    id: 134
+                    id: 410
                     name: "John Doe"
                     address: "1028 Farland Street"
-                    port: 365
+                    port: 533
                     type: {}
                     version: "Lorem Ipsum"
                     website: "Lorem Ipsum"
@@ -1553,13 +1600,13 @@ paths:
                     resolved_endpoint: "Lorem Ipsum"
                     motd_hash: "Lorem Ipsum"
                     host_domain: "Lorem Ipsum"
-                    user_id: 413
-                    vote_count: 635
+                    user_id: 248
+                    vote_count: 95
                     last_online_at: "2021-03-23T16:13:08.489+01:00"
-                    last_player_count: 143
-                    last_max_count: 15
+                    last_player_count: 104
+                    last_max_count: 157
                     last_stats_at: "2021-03-23T16:13:08.489+01:00"
-                    peak_player_count: 912
+                    peak_player_count: 215
                     peak_player_at: "2021-03-23T16:13:08.489+01:00"
                     next_ping_at: "2021-03-23T16:13:08.489+01:00"
                     created_at: "2021-03-23T16:13:08.489+01:00"
@@ -1567,12 +1614,12 @@ paths:
                   categories:
                     - "<Category>"
                   growthStat:
-                    server_id: 158
-                    weekly_growth: 286
-                    monthly_growth: 260
-                    last_week_average: 98
-                    previous_week_average: 784
-                    last_month_average: 223
+                    server_id: 264
+                    weekly_growth: 528
+                    monthly_growth: 0
+                    last_week_average: 590
+                    previous_week_average: 188
+                    last_month_average: 171
                     last_updated: "2021-03-23T16:13:08.489+01:00"
           description: "Returns **200** (OK) as **application/json**"
         401:
@@ -3203,7 +3250,7 @@ paths:
               $ref: "#/components/schemas/CreateApiTokenValidator"
             example:
               name: "Lorem Ipsum"
-              expiresInDays: 982
+              expiresInDays: 319
   /api/v1/account/api-tokens/{id}:
     delete:
       summary: "Revoke an API token (destroy)"
@@ -3346,15 +3393,27 @@ paths:
                   token: "oat_..."
                   expiresAt: "2026-06-27T12:00:00.000Z"
           description: "Returns **200** (OK) as **application/json**"
+        202:
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  status: "link_email_sent"
+                  message: "We sent you an email to confirm adding this sign-in method to your account."
+              example:
+                status: "link_email_sent"
+                message: "We sent you an email to confirm adding this sign-in method to your account."
+          description: "Returns **202** (Accepted) as **application/json**"
         400:
           content:
             application/json:
               schema:
                 type: "object"
                 properties:
-                  message: "Cannot login with this third-party provider"
+                  message: "An error occurred while logging in. Please try again"
               example:
-                message: "Cannot login with this third-party provider"
+                message: "An error occurred while logging in. Please try again"
           description: "Returns **400** (Bad Request) as **application/json**"
       security: []
   /api/v1/callback/discord:
@@ -3404,17 +3463,236 @@ paths:
                   token: "oat_..."
                   expiresAt: "2026-06-27T12:00:00.000Z"
           description: "Returns **200** (OK) as **application/json**"
+        202:
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  status: "link_email_sent"
+                  message: "We sent you an email to confirm adding this sign-in method to your account."
+              example:
+                status: "link_email_sent"
+                message: "We sent you an email to confirm adding this sign-in method to your account."
+          description: "Returns **202** (Accepted) as **application/json**"
         400:
           content:
             application/json:
               schema:
                 type: "object"
                 properties:
-                  message: "Cannot login with this third-party provider"
+                  message: "An error occurred while logging in. Please try again"
               example:
-                message: "Cannot login with this third-party provider"
+                message: "An error occurred while logging in. Please try again"
           description: "Returns **400** (Bad Request) as **application/json**"
       security: []
+  /api/v1/link-provider:
+    post:
+      summary: "Confirm adding an OAuth provider to an existing account (confirm)"
+      description: "Validates the token from the confirmation email sent when an OAuth login matched an existing account (see googleCallback/discordCallback), marks the provider link as confirmed and clears the token. Clicking the emailed link proves ownership of the address, so the account is also marked verified and the user is signed in directly (user + fresh access token returned). Invalid and expired tokens return the same generic error to avoid leaking token state.\n\n _app/controllers/user_providers_controller.ts_ - **confirm**"
+      operationId: "confirmProviderLink"
+      parameters: []
+      tags:
+        - "AUTH"
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  user:
+                    type: "object"
+                    properties:
+                      id: 1
+                      username: "player"
+                      verified: true
+                      provider: ""
+                      role: "user"
+                      avatarUrl: ""
+                      createdAt: "2026-05-28T12:00:00.000Z"
+                      updatedAt: "2026-05-28T12:00:00.000Z"
+                  accessToken:
+                    type: "object"
+                    properties:
+                      type: "bearer"
+                      token: "oat_..."
+                      expiresAt: "2026-06-27T12:00:00.000Z"
+              example:
+                user:
+                  id: 1
+                  username: "player"
+                  verified: true
+                  provider: ""
+                  role: "user"
+                  avatarUrl: ""
+                  createdAt: "2026-05-28T12:00:00.000Z"
+                  updatedAt: "2026-05-28T12:00:00.000Z"
+                accessToken:
+                  type: "bearer"
+                  token: "oat_..."
+                  expiresAt: "2026-06-27T12:00:00.000Z"
+          description: "Returns **200** (OK) as **application/json**"
+        400:
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  message: "This confirmation link is invalid or has expired."
+              example:
+                message: "This confirmation link is invalid or has expired."
+          description: "Returns **400** (Bad Request) as **application/json**"
+        422:
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  errors:
+                    type: "object"
+                    properties:
+                      0:
+                        type: "object"
+                        properties:
+                          message: "The token field must be defined"
+                          rule: "required"
+                          field: "token"
+              example:
+                errors:
+                  - message: "The token field must be defined"
+                    rule: "required"
+                    field: "token"
+          description: "Returns **422** (Unprocessable Entity) as **application/json**"
+      security: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LinkProviderValidator"
+            example:
+              token: "Lorem Ipsum"
+  /api/v1/account/providers:
+    get:
+      summary: "List the OAuth providers linked to the authenticated account (index)"
+      description: "Returns **200** (OK) as **application/json**\n\n _app/controllers/user_providers_controller.ts_ - **index**"
+      operationId: "listLinkedProviders"
+      parameters: []
+      tags:
+        - "AUTH"
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  providers:
+                    type: "object"
+                    properties:
+                      0:
+                        type: "object"
+                        properties:
+                          provider: "google"
+                          linkedAt: "2026-05-28T12:00:00.000Z"
+              example:
+                providers:
+                  - provider: "google"
+                    linkedAt: "2026-05-28T12:00:00.000Z"
+          description: "Returns **200** (OK) as **application/json**"
+        401:
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  errors:
+                    type: "object"
+                    properties:
+                      0:
+                        type: "object"
+                        properties:
+                          message: "Unauthorized access"
+              example:
+                errors:
+                  - message: "Unauthorized access"
+          description: "Returns **401** (Unauthorized) as **application/json**"
+        403:
+          description: "Returns **403** (Forbidden)"
+      security:
+        - BearerAuth:
+            - "access"
+  /api/v1/account/providers/{provider}:
+    delete:
+      summary: "Unlink an OAuth provider from the authenticated account (destroy)"
+      description: "Removes a confirmed OAuth sign-in method from the current user. Refused when it is the account's last usable sign-in method (accounts created via OAuth have no usable password). Requires authentication.\n\n _app/controllers/user_providers_controller.ts_ - **destroy**"
+      operationId: "unlinkProvider"
+      parameters:
+        - in: "path"
+          name: "provider"
+          description: "The OAuth provider to unlink"
+          schema:
+            example: "google"
+            type: "string"
+            enum:
+              - "google"
+              - "discord"
+          required: true
+      tags:
+        - "AUTH"
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  message: "Sign-in method removed"
+              example:
+                message: "Sign-in method removed"
+          description: "Returns **200** (OK) as **application/json**"
+        400:
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  message: "You cannot remove your only sign-in method"
+              example:
+                message: "You cannot remove your only sign-in method"
+          description: "Returns **400** (Bad Request) as **application/json**"
+        401:
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  errors:
+                    type: "object"
+                    properties:
+                      0:
+                        type: "object"
+                        properties:
+                          message: "Unauthorized access"
+              example:
+                errors:
+                  - message: "Unauthorized access"
+          description: "Returns **401** (Unauthorized) as **application/json**"
+        403:
+          description: "Returns **403** (Forbidden)"
+        404:
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  message: "This provider is not linked to your account"
+              example:
+                message: "This provider is not linked to your account"
+          description: "Returns **404** (Not Found) as **application/json**"
+      security:
+        - BearerAuth:
+            - "access"
   /api/v1/posts:
     get:
       summary: "Get a list of posts (index)"
@@ -4210,6 +4488,12 @@ tags:
     description: "Everything related to API TOKENS"
   - name: "API TOKENS"
     description: "Everything related to API TOKENS"
+  - name: "AUTH"
+    description: "Everything related to AUTH"
+  - name: "AUTH"
+    description: "Everything related to AUTH"
+  - name: "AUTH"
+    description: "Everything related to AUTH"
   - name: "AUTH"
     description: "Everything related to AUTH"
   - name: "AUTH"

--- a/backend/tests/functional/provider_links.spec.ts
+++ b/backend/tests/functional/provider_links.spec.ts
@@ -1,0 +1,174 @@
+import User from '#models/user'
+import UserProvider from '#models/user_provider'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { test } from '@japa/runner'
+import { DateTime } from 'luxon'
+import { createHash, randomBytes, randomUUID } from 'node:crypto'
+
+async function createUser(overrides: Partial<Parameters<typeof User.create>[0]> = {}) {
+  const suffix = randomUUID().replace(/-/g, '').slice(0, 8)
+  return User.create({
+    email: `link_${suffix}@example.com`,
+    username: `link_${suffix}`,
+    password: 'password123',
+    verified: true,
+    ...overrides,
+  })
+}
+
+/** Crée un lien en attente et renvoie le token brut (celui qui partirait par email). */
+async function createPendingLink(user: User, provider: 'google' | 'discord' = 'google') {
+  const rawToken = randomBytes(32).toString('base64url')
+  await UserProvider.create({
+    userId: user.id,
+    provider,
+    linkTokenHash: createHash('sha256').update(rawToken).digest('hex'),
+    linkTokenExpiresAt: DateTime.now().plus({ hours: 1 }),
+  })
+  return rawToken
+}
+
+async function createConfirmedLink(user: User, provider: 'google' | 'discord') {
+  return UserProvider.create({ userId: user.id, provider, confirmedAt: DateTime.now() })
+}
+
+async function bearerFor(user: User) {
+  const token = await User.accessTokens.create(user)
+  return token.value!.release()
+}
+
+test.group('Provider links', (group) => {
+  // Chaque test tourne dans une transaction annulée à la fin : rien n'est persisté.
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('confirme un lien en attente et connecte directement', async ({ client, assert }) => {
+    const user = await createUser()
+    const rawToken = await createPendingLink(user)
+
+    const response = await client.post('/api/v1/link-provider').json({ token: rawToken })
+
+    response.assertStatus(200)
+    assert.equal(response.body().user.id, user.id)
+    assert.isString(response.body().accessToken.token)
+
+    const link = await UserProvider.findByOrFail('user_id', user.id)
+    assert.isNotNull(link.confirmedAt)
+    assert.isNull(link.linkTokenHash)
+  })
+
+  test('marque le compte vérifié à la confirmation (preuve de possession de l’email)', async ({
+    client,
+    assert,
+  }) => {
+    const user = await createUser({ verified: false })
+    const rawToken = await createPendingLink(user)
+
+    const response = await client.post('/api/v1/link-provider').json({ token: rawToken })
+
+    response.assertStatus(200)
+    await user.refresh()
+    assert.isTrue(user.verified)
+  })
+
+  test('refuse un token expiré', async ({ client }) => {
+    const user = await createUser()
+    const rawToken = randomBytes(32).toString('base64url')
+    await UserProvider.create({
+      userId: user.id,
+      provider: 'google',
+      linkTokenHash: createHash('sha256').update(rawToken).digest('hex'),
+      linkTokenExpiresAt: DateTime.now().minus({ minutes: 1 }),
+    })
+
+    const response = await client.post('/api/v1/link-provider').json({ token: rawToken })
+
+    response.assertStatus(400)
+  })
+
+  test('refuse un token inconnu', async ({ client }) => {
+    const response = await client
+      .post('/api/v1/link-provider')
+      .json({ token: randomBytes(32).toString('base64url') })
+
+    response.assertStatus(400)
+  })
+
+  test('un token confirmé ne peut pas être rejoué', async ({ client }) => {
+    const user = await createUser()
+    const rawToken = await createPendingLink(user)
+
+    const first = await client.post('/api/v1/link-provider').json({ token: rawToken })
+    first.assertStatus(200)
+
+    const replay = await client.post('/api/v1/link-provider').json({ token: rawToken })
+    replay.assertStatus(400)
+  })
+
+  test('liste uniquement les providers confirmés', async ({ client, assert }) => {
+    const user = await createUser()
+    await createConfirmedLink(user, 'google')
+    await createPendingLink(user, 'discord')
+
+    const response = await client
+      .get('/api/v1/account/providers')
+      .bearerToken(await bearerFor(user))
+
+    response.assertStatus(200)
+    const providers = response.body().providers
+    assert.lengthOf(providers, 1)
+    assert.equal(providers[0].provider, 'google')
+  })
+
+  test('refuse de délier la seule méthode de connexion d’un compte OAuth', async ({ client }) => {
+    // Compte créé via OAuth : mot de passe aléatoire inutilisable, google est sa
+    // seule méthode de connexion.
+    const user = await createUser({ provider: 'google' })
+    await createConfirmedLink(user, 'google')
+
+    const response = await client
+      .delete('/api/v1/account/providers/google')
+      .bearerToken(await bearerFor(user))
+
+    response.assertStatus(400)
+  })
+
+  test('délie un provider quand une autre méthode reste', async ({ client, assert }) => {
+    const user = await createUser({ provider: 'google' })
+    await createConfirmedLink(user, 'google')
+    await createConfirmedLink(user, 'discord')
+
+    const response = await client
+      .delete('/api/v1/account/providers/discord')
+      .bearerToken(await bearerFor(user))
+
+    response.assertStatus(200)
+    const remaining = await UserProvider.query().where('user_id', user.id)
+    assert.lengthOf(remaining, 1)
+    assert.equal(remaining[0].provider, 'google')
+  })
+
+  test('un compte local peut délier son unique provider (le mot de passe reste)', async ({
+    client,
+    assert,
+  }) => {
+    const user = await createUser()
+    await createConfirmedLink(user, 'google')
+
+    const response = await client
+      .delete('/api/v1/account/providers/google')
+      .bearerToken(await bearerFor(user))
+
+    response.assertStatus(200)
+    assert.lengthOf(await UserProvider.query().where('user_id', user.id), 0)
+  })
+
+  test('délier un provider non lié renvoie 404', async ({ client }) => {
+    const user = await createUser()
+
+    const response = await client
+      .delete('/api/v1/account/providers/google')
+      .bearerToken(await bearerFor(user))
+
+    response.assertStatus(404)
+  })
+})

--- a/frontend/messages/en/account.json
+++ b/frontend/messages/en/account.json
@@ -82,6 +82,19 @@
     "removing": "Removing…",
     "remove": "Remove server"
   },
+  "signInMethods": {
+    "title": "Sign-in methods",
+    "subtitle": "Link Google or Discord (using {email}) to sign in with one click. We'll email you a confirmation before anything is added.",
+    "linkedSince": "Connected since {date}",
+    "notLinked": "Not connected",
+    "link": "Connect",
+    "unlink": "Disconnect",
+    "unlinking": "Disconnecting…",
+    "unlinkConfirm": "Disconnect {provider}? You will no longer be able to sign in with it.",
+    "unlinkedTitle": "Sign-in method removed",
+    "unlinkedDescription": "{provider} has been disconnected from your account.",
+    "lastMethodHint": "You can't remove your only sign-in method."
+  },
   "settings": {
     "roles": {
       "user": "Member",

--- a/frontend/messages/en/auth.json
+++ b/frontend/messages/en/auth.json
@@ -50,7 +50,23 @@
   "callback": {
     "connecting": "Connecting with {provider}",
     "errorTitle": "Failed to connect with {provider}",
-    "errorDescription": "Please try again"
+    "errorDescription": "Please try again",
+    "linkEmailSentTitle": "Check your inbox",
+    "linkEmailSentSubtitle": "This {provider} account matches an existing Minecraft Stats account.",
+    "linkEmailSentDescription": "To protect your account, we've sent you an email to confirm adding {provider} as a sign-in method. Once confirmed, you'll be signed in automatically.",
+    "linkEmailSentExpiry": "The confirmation link expires in 1 hour.",
+    "backToSignIn": "Back to sign in"
+  },
+  "linkProvider": {
+    "title": "Add sign-in method",
+    "subtitle": "Confirming your new sign-in method — hang on a moment.",
+    "checking": "Checking your link...",
+    "successTitle": "Sign-in method added",
+    "successDescription": "You're signed in, and you can use this method to sign in from now on.",
+    "continue": "Continue to Minecraft Stats",
+    "errorTitle": "Confirmation failed",
+    "errorDescription": "We couldn't confirm this link. It may have expired.",
+    "backToSignIn": "Back to sign in"
   },
   "divider": {
     "orWithEmail": "Or with email"

--- a/frontend/messages/es/account.json
+++ b/frontend/messages/es/account.json
@@ -82,6 +82,19 @@
     "removing": "Eliminando…",
     "remove": "Eliminar servidor"
   },
+  "signInMethods": {
+    "title": "Métodos de inicio de sesión",
+    "subtitle": "Vincula Google o Discord (con {email}) para iniciar sesión con un clic. Te enviaremos un correo de confirmación antes de añadir nada.",
+    "linkedSince": "Conectado desde el {date}",
+    "notLinked": "No conectado",
+    "link": "Conectar",
+    "unlink": "Desconectar",
+    "unlinking": "Desconectando…",
+    "unlinkConfirm": "¿Desconectar {provider}? Ya no podrás iniciar sesión con él.",
+    "unlinkedTitle": "Método de inicio de sesión eliminado",
+    "unlinkedDescription": "{provider} ha sido desconectado de tu cuenta.",
+    "lastMethodHint": "No puedes eliminar tu único método de inicio de sesión."
+  },
   "settings": {
     "roles": {
       "user": "Miembro",

--- a/frontend/messages/es/auth.json
+++ b/frontend/messages/es/auth.json
@@ -50,7 +50,23 @@
   "callback": {
     "connecting": "Conectando con {provider}",
     "errorTitle": "Error al conectar con {provider}",
-    "errorDescription": "Por favor, inténtalo de nuevo"
+    "errorDescription": "Por favor, inténtalo de nuevo",
+    "linkEmailSentTitle": "Revisa tu bandeja de entrada",
+    "linkEmailSentSubtitle": "Esta cuenta de {provider} coincide con una cuenta existente de Minecraft Stats.",
+    "linkEmailSentDescription": "Para proteger tu cuenta, te hemos enviado un correo para confirmar la adición de {provider} como método de inicio de sesión. Una vez confirmado, iniciarás sesión automáticamente.",
+    "linkEmailSentExpiry": "El enlace de confirmación expira en 1 hora.",
+    "backToSignIn": "Volver al inicio de sesión"
+  },
+  "linkProvider": {
+    "title": "Añadir método de inicio de sesión",
+    "subtitle": "Confirmando tu nuevo método de inicio de sesión — un momento.",
+    "checking": "Comprobando tu enlace...",
+    "successTitle": "Método de inicio de sesión añadido",
+    "successDescription": "Has iniciado sesión y podrás usar este método para conectarte a partir de ahora.",
+    "continue": "Continuar a Minecraft Stats",
+    "errorTitle": "Error de confirmación",
+    "errorDescription": "No pudimos confirmar este enlace. Puede que haya expirado.",
+    "backToSignIn": "Volver al inicio de sesión"
   },
   "divider": {
     "orWithEmail": "O con correo electrónico"

--- a/frontend/messages/fr/account.json
+++ b/frontend/messages/fr/account.json
@@ -82,6 +82,19 @@
     "removing": "Suppression…",
     "remove": "Supprimer le serveur"
   },
+  "signInMethods": {
+    "title": "Méthodes de connexion",
+    "subtitle": "Liez Google ou Discord (avec {email}) pour vous connecter en un clic. Un e-mail de confirmation vous sera envoyé avant tout ajout.",
+    "linkedSince": "Connecté depuis le {date}",
+    "notLinked": "Non connecté",
+    "link": "Connecter",
+    "unlink": "Déconnecter",
+    "unlinking": "Déconnexion…",
+    "unlinkConfirm": "Déconnecter {provider} ? Vous ne pourrez plus vous connecter avec.",
+    "unlinkedTitle": "Méthode de connexion supprimée",
+    "unlinkedDescription": "{provider} a été déconnecté de votre compte.",
+    "lastMethodHint": "Impossible de supprimer votre seule méthode de connexion."
+  },
   "settings": {
     "roles": {
       "user": "Membre",

--- a/frontend/messages/fr/auth.json
+++ b/frontend/messages/fr/auth.json
@@ -50,7 +50,23 @@
   "callback": {
     "connecting": "Connexion avec {provider}",
     "errorTitle": "Échec de la connexion avec {provider}",
-    "errorDescription": "Veuillez réessayer"
+    "errorDescription": "Veuillez réessayer",
+    "linkEmailSentTitle": "Vérifiez votre boîte mail",
+    "linkEmailSentSubtitle": "Ce compte {provider} correspond à un compte Minecraft Stats existant.",
+    "linkEmailSentDescription": "Pour protéger votre compte, nous vous avons envoyé un e-mail pour confirmer l'ajout de {provider} comme méthode de connexion. Une fois confirmé, vous serez connecté automatiquement.",
+    "linkEmailSentExpiry": "Le lien de confirmation expire dans 1 heure.",
+    "backToSignIn": "Retour à la connexion"
+  },
+  "linkProvider": {
+    "title": "Ajouter une méthode de connexion",
+    "subtitle": "Confirmation de votre nouvelle méthode de connexion — un instant.",
+    "checking": "Vérification de votre lien...",
+    "successTitle": "Méthode de connexion ajoutée",
+    "successDescription": "Vous êtes connecté, et vous pourrez désormais utiliser cette méthode pour vous connecter.",
+    "continue": "Continuer vers Minecraft Stats",
+    "errorTitle": "Échec de la confirmation",
+    "errorDescription": "Nous n'avons pas pu confirmer ce lien. Il a peut-être expiré.",
+    "backToSignIn": "Retour à la connexion"
   },
   "divider": {
     "orWithEmail": "Ou avec l'e-mail"

--- a/frontend/src/app/[locale]/(pages)/(auth)/callback/[provider]/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/(auth)/callback/[provider]/page.tsx
@@ -1,29 +1,44 @@
 "use client";
 import { fetcher, getBaseUrl } from "@/app/_cheatcode";
+import AuthCard from "@/components/form/auth-card";
 import Loader from "@/components/loader";
 import { useToast } from "@/components/ui/use-toast";
 import { useAuth } from "@/contexts/auth";
 import { AccessToken, User } from "@/types/auth";
+import { Icon } from "@iconify/react/dist/iconify.js";
+import { Link } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
 import { useParams, useSearchParams } from "next/navigation";
 import { useRouter } from "@/i18n/navigation";
 import { useEffect } from "react";
 import useSWR from "swr";
 
+type CallbackResponse =
+  | { user: User; accessToken: AccessToken }
+  // Un compte existe avec cet email mais ce provider n'y est pas encore lié :
+  // le backend a envoyé un email de confirmation au lieu de connecter.
+  | { status: "link_email_sent"; message: string };
+
 const CallbackPage = () => {
   const t = useTranslations("Auth");
   const provider = useParams().provider;
   const code = useSearchParams().get("code");
+  const providerName = provider === "google" ? "Google" : "Discord";
 
-  const { data, isLoading } = useSWR<{user: User, accessToken: AccessToken}>(`${getBaseUrl()}/callback/${provider}?code=${code}`, fetcher);
+  const { data, isLoading } = useSWR<CallbackResponse>(
+    `${getBaseUrl()}/callback/${provider}?code=${code}`,
+    fetcher
+  );
   const { setUser, saveToken, setIsLoggedIn } = useAuth();
 
   const router = useRouter();
-  const {toast} = useToast();
+  const { toast } = useToast();
+
+  const isLinkEmailSent = data !== undefined && "status" in data;
 
   useEffect(() => {
-    if(isLoading) return;
-    if (data?.user?.username) {
+    if (isLoading || isLinkEmailSent) return;
+    if (data && "user" in data && data.user.username) {
       setUser(data.user);
       saveToken(data.accessToken.token);
       setIsLoggedIn(true);
@@ -36,7 +51,35 @@ const CallbackPage = () => {
         description: t("callback.errorDescription"),
       });
     }
-  }, [data, router, setUser, saveToken, setIsLoggedIn, toast, provider, isLoading, t]);
+  }, [data, router, setUser, saveToken, setIsLoggedIn, toast, provider, isLoading, isLinkEmailSent, t]);
+
+  if (isLinkEmailSent) {
+    return (
+      <AuthCard
+        icon={<Icon icon="lucide:mail-check" className="h-[18px] w-[18px]" />}
+        title={t("callback.linkEmailSentTitle")}
+        subtitle={t("callback.linkEmailSentSubtitle", { provider: providerName })}
+      >
+        <div className="space-y-5 text-center">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-secondary text-muted-foreground">
+            <Icon icon="lucide:mail" className="h-7 w-7" />
+          </div>
+          <div className="space-y-1.5">
+            <p className="text-sm text-muted-foreground">
+              {t("callback.linkEmailSentDescription", { provider: providerName })}
+            </p>
+            <p className="text-sm text-muted-foreground">{t("callback.linkEmailSentExpiry")}</p>
+          </div>
+          <Link
+            href="/login"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {t("callback.backToSignIn")}
+          </Link>
+        </div>
+      </AuthCard>
+    );
+  }
 
   return (
     <div>

--- a/frontend/src/app/[locale]/(pages)/(auth)/link-provider/[token]/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/(auth)/link-provider/[token]/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+import AuthCard from "@/components/form/auth-card";
+import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "@/contexts/auth";
+import { confirmProviderLink } from "@/http/auth";
+import { Icon } from "@iconify/react/dist/iconify.js";
+import { Link } from "@/i18n/navigation";
+import { useTranslations } from "next-intl";
+import { useParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+const LinkProvider = () => {
+  const t = useTranslations("Auth");
+  const { token } = useParams();
+  const decodedToken = decodeURIComponent(token as string);
+  const { setUser, saveToken, setIsLoggedIn } = useAuth();
+
+  const [status, setStatus] = useState<"loading" | "linked" | "error">("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Le token est à usage unique : le double-invoke des effets en dev (StrictMode)
+  // rejouerait la confirmation et afficherait une erreur après un succès.
+  const hasRun = useRef(false);
+
+  useEffect(() => {
+    if (hasRun.current) return;
+    hasRun.current = true;
+
+    const run = async () => {
+      try {
+        const response = await confirmProviderLink({ token: decodedToken });
+        // Le clic sur le lien email prouve la possession du compte : le backend
+        // renvoie une session, on connecte directement.
+        setUser(response.user);
+        saveToken(response.accessToken.token);
+        setIsLoggedIn(true);
+        setStatus("linked");
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          setErrorMessage(error.message);
+        }
+        setStatus("error");
+      }
+    };
+
+    run();
+  }, [decodedToken, setUser, saveToken, setIsLoggedIn]);
+
+  return (
+    <AuthCard
+      icon={<Icon icon="lucide:link" className="h-[18px] w-[18px]" />}
+      title={t("linkProvider.title")}
+      subtitle={t("linkProvider.subtitle")}
+    >
+      <div className="space-y-5 text-center">
+        {status === "loading" && (
+          <>
+            <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-secondary text-muted-foreground">
+              <Spinner size="lg" />
+            </div>
+            <p className="text-sm text-muted-foreground">{t("linkProvider.checking")}</p>
+          </>
+        )}
+
+        {status === "linked" && (
+          <>
+            <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-success/10 text-success">
+              <Icon icon="material-symbols:check-circle" className="h-7 w-7" />
+            </div>
+            <div className="space-y-1.5">
+              <p className="text-base font-semibold text-foreground">{t("linkProvider.successTitle")}</p>
+              <p className="text-sm text-muted-foreground">{t("linkProvider.successDescription")}</p>
+            </div>
+            <Link
+              href="/"
+              className="inline-flex h-11 w-full items-center justify-center rounded-md bg-accent px-4 text-[15px] font-semibold text-accent-foreground shadow-xs transition-colors hover:bg-accent/90"
+            >
+              {t("linkProvider.continue")}
+            </Link>
+          </>
+        )}
+
+        {status === "error" && (
+          <>
+            <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-destructive/10 text-destructive">
+              <Icon icon="material-symbols:error-outline" className="h-7 w-7" />
+            </div>
+            <div className="space-y-1.5">
+              <p className="text-base font-semibold text-foreground">{t("linkProvider.errorTitle")}</p>
+              <p className="text-sm text-muted-foreground">
+                {errorMessage ?? t("linkProvider.errorDescription")}
+              </p>
+            </div>
+            <Link
+              href="/login"
+              className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {t("linkProvider.backToSignIn")}
+            </Link>
+          </>
+        )}
+      </div>
+    </AuthCard>
+  );
+};
+
+export default LinkProvider;

--- a/frontend/src/app/[locale]/(pages)/account/settings/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/account/settings/page.tsx
@@ -6,6 +6,7 @@ import DashboardLayout from "@/components/account/dashboard-layout";
 import DashboardHero from "@/components/account/dashboard-hero";
 import DangerZoneCard from "@/components/account/danger-zone-card";
 import InfoField from "@/components/account/info-field";
+import LinkedProviders from "@/components/account/linked-providers";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
 import { useAuth } from "@/contexts/auth";
@@ -116,6 +117,9 @@ const SettingsPage = () => {
           <ChangePasswordForm />
         </div>
       </section>
+
+      {/* Sign-in methods (OAuth providers) */}
+      <LinkedProviders />
 
       {/* Danger zone */}
       <DangerZoneCard

--- a/frontend/src/components/account/linked-providers.tsx
+++ b/frontend/src/components/account/linked-providers.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { DiscordGlyph, GoogleGlyph } from "@/components/form/auth-card/oauth-buttons";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+import { useAuth } from "@/contexts/auth";
+import { getLinkedProviders, unlinkProvider } from "@/http/auth";
+import { OAuthProvider } from "@/types/auth";
+import { Link2 } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
+import { useState } from "react";
+import useSWR from "swr";
+
+const PROVIDERS: { id: OAuthProvider; name: string; glyph: React.ReactNode }[] = [
+  { id: "google", name: "Google", glyph: <GoogleGlyph /> },
+  { id: "discord", name: "Discord", glyph: <DiscordGlyph /> },
+];
+
+/**
+ * Section "méthodes de connexion" du compte : liste Google/Discord avec leur état,
+ * permet d'en lier (via le flow OAuth + email de confirmation) ou d'en délier.
+ */
+const LinkedProviders = () => {
+  const t = useTranslations("Account");
+  const format = useFormatter();
+  const { user, getToken, loginWithDiscord, loginWithGoogle } = useAuth();
+  const { toast } = useToast();
+  const [unlinking, setUnlinking] = useState<OAuthProvider | null>(null);
+
+  const token = getToken();
+  const { data: linked, mutate } = useSWR(
+    token ? (["account-providers", token] as const) : null,
+    ([, accessToken]) => getLinkedProviders(accessToken)
+  );
+
+  // Un compte créé par email/mot de passe garde toujours ce moyen de connexion ;
+  // un compte créé via OAuth doit conserver au moins un provider lié. Le backend
+  // applique la même règle — ceci évite juste un aller-retour voué à l'échec.
+  const hasPassword = user?.provider === null;
+  const canUnlink = hasPassword || (linked?.length ?? 0) >= 2;
+
+  const connect: Record<OAuthProvider, () => void> = {
+    discord: loginWithDiscord,
+    google: loginWithGoogle,
+  };
+
+  const handleUnlink = async (provider: OAuthProvider, name: string) => {
+    if (!token) return;
+    if (!window.confirm(t("signInMethods.unlinkConfirm", { provider: name }))) return;
+    setUnlinking(provider);
+    try {
+      await unlinkProvider(provider, token);
+      await mutate();
+      toast({
+        title: t("signInMethods.unlinkedTitle"),
+        description: t("signInMethods.unlinkedDescription", { provider: name }),
+        variant: "success",
+      });
+    } catch (error) {
+      toast({
+        title: t("common.error"),
+        description: error instanceof Error ? error.message : t("common.somethingWentWrong"),
+        variant: "error",
+      });
+    } finally {
+      setUnlinking(null);
+    }
+  };
+
+  return (
+    <section className="overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-xs">
+      <div className="flex items-center gap-2.5 border-b border-border px-6 py-4">
+        <Link2 className="h-5 w-5 shrink-0 text-muted-foreground" />
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold tracking-tight text-foreground">
+            {t("signInMethods.title")}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {t("signInMethods.subtitle", { email: user?.email ?? "" })}
+          </p>
+        </div>
+      </div>
+
+      {linked === undefined ? (
+        <p className="px-6 py-5 text-sm text-muted-foreground">{t("common.loading")}</p>
+      ) : (
+        <div className="divide-y divide-border px-6">
+          {PROVIDERS.map(({ id, name, glyph }) => {
+            const link = linked.find((candidate) => candidate.provider === id);
+            return (
+              <div key={id} className="flex items-center justify-between gap-4 py-4">
+                <div className="flex min-w-0 items-center gap-3">
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-secondary/50">
+                    {glyph}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-foreground">{name}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {link
+                        ? t("signInMethods.linkedSince", {
+                            date: format.dateTime(new Date(link.linkedAt), { dateStyle: "medium" }),
+                          })
+                        : t("signInMethods.notLinked")}
+                    </p>
+                  </div>
+                </div>
+                {link ? (
+                  <Button
+                    variant="outline"
+                    className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    disabled={!canUnlink || unlinking === id}
+                    title={canUnlink ? undefined : t("signInMethods.lastMethodHint")}
+                    onClick={() => handleUnlink(id, name)}
+                  >
+                    {unlinking === id ? t("signInMethods.unlinking") : t("signInMethods.unlink")}
+                  </Button>
+                ) : (
+                  <Button variant="outline" onClick={connect[id]}>
+                    {t("signInMethods.link")}
+                  </Button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default LinkedProviders;

--- a/frontend/src/components/form/auth-card/oauth-buttons.tsx
+++ b/frontend/src/components/form/auth-card/oauth-buttons.tsx
@@ -6,14 +6,14 @@ interface OAuthButtonsProps {
 }
 
 /** Discord brand glyph (single-color). */
-const DiscordGlyph = () => (
+export const DiscordGlyph = () => (
   <svg width="17" height="17" viewBox="0 0 24 24" fill="#5865F2" aria-hidden="true">
     <path d="M19.27 5.33A16.6 16.6 0 0 0 15.1 4l-.2.4a15.4 15.4 0 0 1 3.71 1.2 13.3 13.3 0 0 0-11.22 0A15.4 15.4 0 0 1 11.1 4.4L10.9 4a16.6 16.6 0 0 0-4.17 1.33C3.4 9.3 2.5 13.16 2.95 16.96a16.7 16.7 0 0 0 5.1 2.58l.4-.56a11 11 0 0 1-1.62-.78l.13-.1a11.9 11.9 0 0 0 10.1 0l.13.1c-.5.3-1.05.56-1.62.78l.4.56a16.7 16.7 0 0 0 5.1-2.58c.5-4.4-.86-8.23-3.13-11.63zM9.3 14.84c-.8 0-1.45-.74-1.45-1.65s.64-1.66 1.45-1.66c.81 0 1.46.75 1.45 1.66 0 .91-.65 1.65-1.45 1.65zm5.4 0c-.8 0-1.45-.74-1.45-1.65s.64-1.66 1.45-1.66c.81 0 1.46.75 1.45 1.66 0 .91-.64 1.65-1.45 1.65z" />
   </svg>
 );
 
 /** Google brand glyph (4-color G). */
-const GoogleGlyph = () => (
+export const GoogleGlyph = () => (
   <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
     <path
       fill="#4285F4"

--- a/frontend/src/http/auth.ts
+++ b/frontend/src/http/auth.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { localeHeaders } from "@/app/_cheatcode";
-import { AccessToken, User } from "@/types/auth";
+import { AccessToken, LinkedProvider, OAuthProvider, User } from "@/types/auth";
 import { apiFetch } from "./client";
 
 export const registerUser = (credentials: {
@@ -77,6 +77,28 @@ export const uploadUserAvatar = async (file: File, token: string) => {
   });
   return body.user;
 };
+
+export const confirmProviderLink = (credentials: { token: string }) =>
+  apiFetch<{ accessToken: AccessToken; user: User }>("/link-provider", {
+    method: "POST",
+    body: credentials,
+    headers: localeHeaders(),
+  });
+
+export const getLinkedProviders = async (token: string) => {
+  const body = await apiFetch<{ providers: LinkedProvider[] }>("/account/providers", {
+    token,
+    headers: localeHeaders(),
+  });
+  return body.providers;
+};
+
+export const unlinkProvider = (provider: OAuthProvider, token: string) =>
+  apiFetch<{ message: string }>(`/account/providers/${provider}`, {
+    method: "DELETE",
+    token,
+    headers: localeHeaders(),
+  });
 
 export const logoutUser = (token: string) =>
   apiFetch<{ message: string }>("/logout", { method: "POST", token, headers: localeHeaders() });

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,25 +1,34 @@
+/** How a user signed up: `null` means email & password, otherwise the OAuth provider. */
+export type RegistrationProvider = "discord" | "google" | null;
+
+/** OAuth providers that can be linked to an account as sign-in methods. */
+export type OAuthProvider = "discord" | "google";
+
 export type User = {
   id: number;
   username: string;
   email: string;
   role: 'user' | 'writer' | 'admin';
+  provider: RegistrationProvider;
   verificationTokenExpires: Date;
   avatarUrl: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
 
-/** How a user signed up: `null` means email & password, otherwise the OAuth provider. */
-export type RegistrationProvider = "discord" | "google" | null;
+/** A confirmed OAuth sign-in method on the current account. */
+export type LinkedProvider = {
+  provider: OAuthProvider;
+  linkedAt: string;
+};
 
 /**
  * Full profile exposed to admins. Builds on the public `User` shape (minus the
- * transient verification-token expiry) and adds fields hidden from the public
- * API: the registration `provider` and email `verified` status.
+ * transient verification-token expiry) and adds the email `verified` status,
+ * hidden from the public API.
  */
 export type AdminUserProfile = Omit<User, "verificationTokenExpires"> & {
   verified: boolean;
-  provider: RegistrationProvider;
 };
 
 export type Error = {


### PR DESCRIPTION
## Summary
Signing in with Google/Discord on an email that already has an account no longer dead-ends with "Cannot login with this third-party provider". The callback now emails the account owner a confirmation link; once confirmed, the provider becomes a permanent sign-in method and the user is signed in directly. Accounts can hold several sign-in methods (password + Google + Discord) and manage them from account settings.

## Changes
- **`user_providers` table** (backfilled from `users.provider`): confirmed sign-in methods per account, plus pending-link state (SHA-256 token hash, 1h expiry) — same pattern as password reset
- **OAuth callbacks**: the two near-identical handlers merged into `handleProviderCallback`; unlinked-provider case returns `202 {status: "link_email_sent"}` and sends an MJML confirmation email (fr/en) instead of auto-linking — email match alone must not prove account ownership (pre-account takeover)
- **`POST /api/v1/link-provider`**: confirms the token (single-use), marks the account verified (clicking the emailed link proves address ownership) and returns `user` + `accessToken`
- **`GET/DELETE /api/v1/account/providers`**: list/unlink confirmed methods; unlinking the last usable sign-in method is refused
- **Frontend**: `link_email_sent` state on the callback page, `/link-provider/[token]` confirmation page with auto sign-in, "Sign-in methods" section in account settings (connect/disconnect), fr/en/es translations
- **`fix(migration)`** (separate commit): the original `create_users_table` migration was edited in place ('github' → 'google'), so databases that ran the old version still have a CHECK constraint rejecting `provider = 'google'` — every Google signup failed on insert. The new migration recreates the constraint idempotently. **Worth checking production for this one.**

## Testing
- 10 new functional tests (`provider_links.spec.ts`): confirm/expired/unknown/replayed token, verified-on-confirm, confirmed-only listing, unlink guards — full backend suite green (35/35)
- Backend + frontend typecheck and lint clean; swagger regenerated; migrations + backfill verified on a local database (72 OAuth accounts backfilled)
- Not covered: the live OAuth handshake itself (needs real provider credentials + browser)

## Notes
- Linking a provider whose email differs from the account email is not supported (it would create a separate account) — the settings UI states the same-email requirement; intent-based linking can be a follow-up
- `messages.auth.cannotLoginWithProvider` is gone from the lang files (no longer reachable)