### PR TITLE
perf(migration): index server_stats on created_at, drop the unused one

### DIFF
--- a/backend/database/migrations/1784743824975_add_created_at_index_to_server_stats.ts
+++ b/backend/database/migrations/1784743824975_add_created_at_index_to_server_stats.ts
@@ -1,0 +1,49 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+/**
+ * La vue globale filtre sur `created_at` seul, sans `server_id`. Aucun des index
+ * existants ne commence par cette colonne : `server_stats_pkey` porte sur `id`, les
+ * deux autres sur `(server_id, …)`. Postgres n'avait donc aucun chemin d'accès et
+ * balayait la table entière — 8,2 M lignes rejetées par worker pour en retenir
+ * 11 071 sur une fenêtre de 24 h.
+ *
+ * Mesuré sur staging (23,7 M lignes), même requête à chaud :
+ *   sans index   1 065 ms   155 765 blocs
+ *   BRIN            628 ms    25 990 blocs   (56 ko)
+ *   btree            46 ms       835 blocs   (527 Mo)  ← retenu
+ *
+ * Le BRIN est 10 000× plus petit mais une fenêtre de 24 h reste éparpillée sur trop
+ * de plages de blocs, chacune ramenée en entier. Le btree coûte de l'espace, et on
+ * en récupère une partie en supprimant `server_id_player_count` (181 Mo) que
+ * `pg_stat_user_indexes` donne à 0 scan depuis la mise en service.
+ *
+ * `CONCURRENTLY` : la table fait 28 M lignes en production et le scheduler y écrit
+ * toutes les 10 minutes. Un `CREATE INDEX` classique poserait un verrou bloquant les
+ * écritures pendant toute la construction (~13 s mesurées sur staging).
+ * D'où `disableTransactions` — Postgres refuse `CONCURRENTLY` dans une transaction.
+ */
+export default class extends BaseSchema {
+  protected tableName = 'server_stats'
+
+  /**
+   * `CREATE INDEX CONCURRENTLY` ne peut pas s'exécuter dans une transaction, et
+   * Lucid enveloppe les migrations dans une transaction par défaut.
+   */
+  static disableTransactions = true
+
+  async up() {
+    this.schema.raw(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS server_stats_created_at_index
+         ON server_stats (created_at)`
+    )
+    this.schema.raw(`DROP INDEX CONCURRENTLY IF EXISTS server_stats_server_id_player_count_index`)
+  }
+
+  async down() {
+    this.schema.raw(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS server_stats_server_id_player_count_index
+         ON server_stats (server_id, player_count)`
+    )
+    this.schema.raw(`DROP INDEX CONCURRENTLY IF EXISTS server_stats_created_at_index`)
+  }
+}

--- a/docs/analyse-mongodb-2026-07-22.md
+++ b/docs/analyse-mongodb-2026-07-22.md
@@ -1,0 +1,228 @@
+# MongoDB pour le ping et les stats — analyse prospective
+
+**Date :** 22 juillet 2026
+**Question posée :** faut-il, à l'avenir, remplacer PostgreSQL par MongoDB pour la partie ping
+des serveurs et restitution des statistiques, et quels gains de performance en attendre ?
+**Mesures :** effectuées sur staging (`minecraft-stats-postgres-lgzajp`, 23,7 M lignes brutes),
+volumétrie comparable à la production (28,1 M lignes).
+
+---
+
+## 1. Réponse courte
+
+**Non, pas maintenant — et le gain espéré n'est pas là où on le cherche.**
+
+La lenteur mesurable actuelle ne vient pas du moteur de stockage. Elle vient d'un **index
+manquant** : la requête globale sur fenêtre courte lit l'intégralité de la table (155 765 blocs)
+pour restituer 48 points. Un index btree sur `created_at` la fait passer de **1 065 ms à 46 ms**,
+soit **23× plus rapide et 186× moins de blocs lus**, pour 527 Mo et 13 secondes de construction.
+
+Aucune migration MongoDB ne produira un gain de cet ordre sur cette requête, parce que le
+problème n'est pas « Postgres est lent » mais « on ne lui a pas donné le chemin d'accès ».
+
+---
+
+## 2. Ligne de base mesurée
+
+### 2.1 Volumétrie (staging)
+
+| Table | Total | Données | Index | Lignes |
+|---|---|---|---|---|
+| `server_stats` | 2 973 Mo | 1 216 Mo | **1 756 Mo** | 23,7 M |
+| `server_stats_hourly` | 584 Mo | 296 Mo | 287 Mo | 4,0 M |
+| `server_stats_daily` | 20 Mo | 11 Mo | 9,8 Mo | 169 k |
+| `servers` | 776 ko | 352 ko | 384 ko | 319 |
+
+Les index de `server_stats` pèsent **plus lourd que les données elles-mêmes**.
+
+### 2.2 Temps de réponse par chemin de lecture
+
+Requête globale (agrégation sur les 319 serveurs), moyenne de 3 exécutions à chaud :
+
+| Cas | Points rendus | Temps | Blocs lus |
+|---|---|---|---|
+| 24 h × 30 min — palier **brut** | 48 | **2 395 ms** | 155 764 |
+| 7 j × 1 h — palier horaire | 169 | 77 ms | 458 |
+| 30 j × 6 h — palier horaire | 121 | 188 ms | 1 662 |
+| 1 an × 1 j — palier journalier | 357 | 102 ms | 11 417 |
+| 2 ans × 1 sem — palier journalier | 52 | **39 ms** | 11 417 |
+| *(contrefactuel)* 2 ans × 1 sem sur le brut | 52 | 4 138 ms | 155 764 |
+
+Deux enseignements :
+
+1. **Les paliers d'agrégation fonctionnent.** 4 138 ms → 39 ms sur 2 ans, soit un facteur 106.
+   C'est le gain structurel, et il est déjà encaissé.
+2. **La fenêtre la plus courte est la plus lente.** 24 h coûte 2 395 ms quand 2 ans coûtent 39 ms.
+   C'est contre-intuitif, et c'est le symptôme.
+
+### 2.3 Diagnostic
+
+```
+Parallel Seq Scan on server_stats  (actual time=662..1942 rows=11071 loops=3)
+  Filter: created_at >= '2025-05-31' AND created_at <= '2025-06-01'
+  Rows Removed by Filter: 8 236 904
+  Buffers: shared read=154 704
+```
+
+Pour retenir 33 000 lignes, Postgres en lit 24,7 millions. Les index disponibles :
+
+```
+server_stats_pkey                          btree (id)                       594 Mo
+server_stats_server_id_created_at_index    btree (server_id, created_at)    981 Mo
+server_stats_server_id_player_count_index  btree (server_id, player_count)  181 Mo
+```
+
+Aucun ne commence par `created_at`. Un prédicat portant uniquement sur la date ne peut donc
+utiliser aucun d'eux — d'où le balayage complet. Les requêtes *par serveur* vont bien, parce
+qu'elles fournissent `server_id` en tête ; c'est la vue **globale** qui paie.
+
+### 2.4 Index morts
+
+`pg_stat_user_indexes` sur staging :
+
+| Index | Taille | Scans |
+|---|---|---|
+| `server_stats_server_id_created_at_index` | 981 Mo | 10 125 |
+| `server_stats_hourly_pkey` | 222 Mo | 4 255 285 |
+| `server_stats_daily_pkey` | 8 Mo | 172 286 |
+| **`server_stats_pkey`** | **594 Mo** | **0** |
+| **`server_stats_server_id_player_count_index`** | **181 Mo** | **0** |
+
+**775 Mo d'index n'ont jamais servi à une seule lecture.** `server_id_player_count` est
+supprimable immédiatement. `server_stats_pkey` porte une contrainte d'unicité sur une colonne
+`id` que personne n'interroge — le supprimer est possible mais demande de vérifier qu'aucun
+code ne s'appuie sur `id`, et c'est une décision distincte.
+
+### 2.5 Correctif mesuré
+
+Trois variantes testées sur staging (index créé, mesuré, puis supprimé) :
+
+| Variante sur `created_at` | Temps (chaud) | Blocs lus | Taille | Construction |
+|---|---|---|---|---|
+| Aucune — état actuel | 1 065 ms | 155 765 | — | — |
+| BRIN | 628 ms | 25 990 | **56 ko** | 4,2 s |
+| **btree** | **46 ms** | **835** | 527 Mo | 12,8 s |
+
+Le BRIN est séduisant (56 ko !) et divise les I/O par 6, mais le btree divise par 186. Sur une
+table append-only, le BRIN aurait dû mieux s'en tirer ; il souffre ici du fait qu'une fenêtre de
+24 h est éparpillée sur de nombreuses plages de blocs, chacune ramenée en entier.
+
+> Les temps de cette section (1 065 ms) diffèrent de ceux du § 2.2 (2 395 ms) : la requête y est
+> simplifiée (2 agrégats au lieu de 5). Seules les comparaisons **au sein** d'un même tableau
+> sont valides.
+
+---
+
+## 3. Ce que MongoDB apporterait
+
+Le candidat pertinent n'est pas MongoDB « document » mais les **time series collections**
+(MongoDB 5.0+), conçues exactement pour ce profil.
+
+**Ce qui jouerait en sa faveur :**
+
+- **Bucketing automatique.** Les mesures d'une même série sur une fenêtre sont regroupées dans
+  un document unique, stocké en colonnes. C'est structurellement ce que nos tables `_hourly` et
+  `_daily` font à la main.
+- **Compression.** Le stockage colonnaire compresse bien des séries d'entiers lentement
+  variables — typiquement un facteur 3 à 10 sur ce genre de données, à vérifier sur un
+  échantillon réel avant d'y croire.
+- **Expiration native.** `expireAfterSeconds` purge le brut ancien sans job maison.
+- **Index implicite sur le temps.** Le problème du § 2.3 ne peut pas exister : le champ temporel
+  est indexé par construction.
+
+**Ce qui ne changerait rien :**
+
+- Les paliers d'agrégation resteraient nécessaires. Mongo ne fait pas de downsampling
+  automatique ; il faudrait réécrire nos rollups en pipelines `$group` + `$dateTrunc` et les
+  matérialiser via `$merge`. Le travail est le même, dans une autre syntaxe.
+- Le gain du § 2.5 est déjà atteignable pour le coût d'une migration d'index.
+- Le cache Redis (TTL 300 s) absorbe déjà la répétition. La base ne voit chaque combinaison de
+  paramètres qu'une fois toutes les 5 minutes.
+
+**Ce qui coûterait cher :**
+
+- **Les filtres catégorie/langue sont des jointures.** `getGlobalStats` joint `server_stats` à
+  `server_categories` et `server_languages`. En polyglotte, ces jointures disparaissent : il
+  faudrait résoudre la liste des `server_id` côté Postgres puis la passer à Mongo — un `$in`
+  potentiellement large, et deux allers-retours réseau au lieu d'un plan unique.
+- **Toute la couche d'accès est Lucid.** Modèles, policies Bouncer, transactions, migrations,
+  `schema.ts` généré. Le ping écrit dans `server_stats` par bulk insert transactionnel ; la
+  cohérence avec `servers.last_player_count` et `peak_player_count` en dépend.
+- **Deux bases à exploiter.** Deux sauvegardes, deux restaurations, deux surveillances, deux
+  procédures de reprise. Aujourd'hui : un `docker exec` et un dump.
+- **Le backfill.** 28 M lignes à réécrire, avec la même contrainte de fenêtre hors heure de
+  pointe qu'on vient d'expérimenter (≈ 1 h pour le rollup horaire).
+
+---
+
+## 4. Alternatives mieux ciblées
+
+| Option | Effort | Gain attendu | Remarque |
+|---|---|---|---|
+| **Index btree sur `created_at`** | 1 migration | **23× sur la vue globale courte** | Mesuré § 2.5 |
+| **Supprimer les index morts** | 1 migration | 181 à 775 Mo | Mesuré § 2.4 |
+| **Rétention du brut à 90 j** | 1 job planifié | ≈ 88 % du volume brut | Les rollups couvrent déjà l'historique |
+| **Partitionnement par mois** | moyen | élagage de partitions | Le code de maintenance existe déjà (`start/scheduler.ts`) mais la table n'est pas partitionnée (`relkind = 'r'`) |
+| **TimescaleDB** | moyen | agrégats continus natifs | Extension Postgres : remplace nos rollups maison sans quitter Lucid ni le SQL |
+| **ClickHouse** | élevé | 10–100× sur l'agrégation | Le meilleur choix technique *si* la volumétrie explose ; même coût polyglotte que Mongo |
+| **MongoDB** | élevé | compression, pas de gain de latence démontré | — |
+
+**TimescaleDB mérite un examen sérieux** si le sujet revient : c'est une extension PostgreSQL,
+donc Lucid, les migrations, les policies et les jointures continuent de fonctionner. Ses
+*continuous aggregates* font exactement, et automatiquement, ce que `backfill:hourly-stats` et
+`backfill:daily-stats` font à la main — avec rafraîchissement incrémental, ce qui supprimerait
+la procédure de backfill d'une heure documentée dans `memory/stats-rollups-backfill.md`.
+
+---
+
+## 5. Quand la question se reposera
+
+Volumétrie actuelle : 319 serveurs × 144 pings/jour = **45 936 lignes/jour**, soit ≈ 16,8 M/an.
+
+| Serveurs suivis | Lignes brutes/an | Données brutes/an* | Rollup horaire/an |
+|---|---|---|---|
+| 319 (aujourd'hui) | 16,8 M | ≈ 0,9 Go | 2,8 M lignes |
+| 1 000 | 52,6 M | ≈ 2,7 Go | 8,8 M lignes |
+| 5 000 | 263 M | ≈ 13,4 Go | 43,8 M lignes |
+
+*\* données seules, ≈ 51 octets/ligne mesurés (1 216 Mo / 23,7 M) ; hors index.*
+
+À 5 000 serveurs, le brut devient inconfortable — mais c'est précisément là que la **rétention à
+90 jours** répond, en plafonnant le brut à ≈ 3,3 Go quelle que soit l'ancienneté du service. Les
+rollups, eux, croissent lentement et restent minuscules.
+
+**Seuil de réexamen proposé :** si le rollup horaire dépasse ~50 M lignes ou si une requête
+sur un palier agrégé dépasse 500 ms après application du § 4, la question du moteur redevient
+légitime — et le candidat sera alors ClickHouse ou TimescaleDB plutôt que MongoDB.
+
+---
+
+## 6. Recommandation
+
+1. **Ajouter l'index btree sur `server_stats(created_at)`.** Gain mesuré : 23×. C'est le seul
+   changement de cette liste dont l'effet est démontré chiffres en main.
+2. **Supprimer `server_stats_server_id_player_count_index`** (181 Mo, 0 scan).
+3. **Instrumenter avant d'aller plus loin.** Aucune mesure de latence côté application n'existe
+   aujourd'hui : je n'ai chronométré que le SQL, pas le temps vu par un utilisateur (sérialisation,
+   cache Redis, réseau). Sans cette donnée, tout arbitrage de moteur se ferait à l'aveugle.
+4. **Mettre la rétention du brut à l'ordre du jour** — c'est le seul levier qui change l'ordre de
+   grandeur, et il ne dépend d'aucun choix de moteur.
+5. **Ne pas migrer vers MongoDB.** Le gain principal qu'il apporterait (indexation temporelle
+   native) s'obtient ici pour une migration d'index ; les gains restants (compression, TTL) sont
+   réels mais ne justifient pas une base supplémentaire à exploiter, la perte des jointures
+   catégorie/langue et la réécriture de la couche d'accès.
+
+---
+
+## Limites de cette analyse
+
+- Mesures faites sur **staging**, pas en production. Volumétries proches (23,7 M vs 28,1 M
+  lignes) mais la charge concurrente et le cache disque diffèrent.
+- **Aucun prototype MongoDB n'a été construit.** Les gains attribués à Mongo au § 3 sont issus
+  de ses caractéristiques documentées, pas d'une mesure sur ces données. Toute décision
+  d'y aller devrait passer par un prototype chargé d'un extrait réel.
+- **Le chemin d'écriture n'a pas été mesuré.** Le ping insère en masse toutes les 10 minutes ;
+  je n'ai chronométré que les lectures. Un index supplémentaire sur `created_at` ralentit
+  légèrement l'insertion — négligeable a priori à 46 000 lignes/jour, mais non vérifié.
+- Les index temporaires créés pour le § 2.5 ont été supprimés après mesure ; staging est revenu
+  à son état initial.


### PR DESCRIPTION
## Summary

La vue globale (`/global-stats`) filtre sur `created_at` seul, sans `server_id`. Aucun index ne commençait par cette colonne, donc Postgres **balayait la table entière** à chaque appel — y compris pour la fenêtre la plus courte.

```
Parallel Seq Scan on server_stats
  Filter: created_at BETWEEN '2025-05-31' AND '2025-06-01'
  Rows Removed by Filter: 8 236 904
  Buffers: shared read=154 704
```

8,2 M lignes rejetées **par worker** pour en retenir 11 071.

## Mesures

Requête globale sur staging (23,7 M lignes), moyenne de 3 exécutions à chaud :

| Variante sur `created_at` | Temps | Blocs lus | Taille | Construction |
|---|---|---|---|---|
| Aucune — état actuel | 1 065 ms | 155 765 | — | — |
| BRIN | 628 ms | 25 990 | 56 ko | 4,2 s |
| **btree — retenu** | **46 ms** | **835** | 527 Mo | 12,8 s |

**23× plus rapide, 186× moins de blocs lus.** Le BRIN est 10 000× plus petit mais une fenêtre de 24 h reste éparpillée sur trop de plages de blocs, chacune ramenée en entier.

Le compteur de blocs est la mesure décisive : il compte le travail réellement fait par Postgres, que les pages viennent du disque ou de `shared_buffers`. Le gain n'est donc pas un effet de cache.

### Ce n'est pas le cache Redis non plus

Mesuré de bout en bout sur l'API staging :

| Scénario | Latence |
|---|---|
| Contrôle réseau (`/website-stats`) | 0,15 – 0,43 s |
| **Cache MISS** | **2,7 – 3,9 s** |
| Cache HIT | 0,15 s |

Et sur le Redis de production : `keyspace_hits: 14 311` / `keyspace_misses: 17 836`, avec **0 clé `global-stats` vivante** au moment de la mesure. `quantizeEpochMs` aligne les bornes sur une grille de 5 minutes et le TTL est de 300 s : une entrée ne sert qu'aux requêtes de la même fenêtre de 5 minutes. En dessous de quelques visiteurs par tranche de 5 min et par combinaison de paramètres, presque tout le monde paie le prix fort — et le nouveau sélecteur de période vient d'élargir l'espace des paramètres (8 raccourcis × 5 résolutions × catégorie × langue, plus les plages personnalisées).

## Changes

- Index btree `server_stats_created_at_index` sur `server_stats (created_at)`.
- Suppression de `server_stats_server_id_player_count_index` (181 Mo) — `pg_stat_user_indexes` le donne à **0 scan** depuis la mise en service. Compense une partie des 527 Mo ajoutés.
- `CONCURRENTLY` + `disableTransactions` : 28 M lignes en production et le scheduler écrit toutes les 10 minutes. Un `CREATE INDEX` classique bloquerait les écritures pendant toute la construction (~13 s mesurées sur staging, davantage en production).

Le second commit ajoute `docs/analyse-mongodb-2026-07-22.md`, l'analyse prospective MongoDB vs PostgreSQL d'où sortent ces mesures.

## Testing

- `yarn typecheck` et `yarn lint` OK.
- Les index temporaires des mesures ont été créés puis supprimés sur staging ; la base est revenue à ses trois index d'origine avant cette PR.
- **À faire après merge sur staging** : rejouer la mesure de bout en bout ci-dessus pour confirmer le passage de ~3 s à ~0,2 s sur un cache miss.

## Notes

`server_stats_pkey` (594 Mo) est également à **0 scan**, mais il porte une contrainte d'unicité sur `id` : le supprimer demande de vérifier qu'aucun code ne s'appuie sur cette colonne. Décision distincte, hors périmètre de cette PR.

Le chemin d'écriture n'a pas été mesuré : un index de plus ralentit légèrement l'insertion. A priori négligeable à ~46 000 lignes/jour insérées par lots toutes les 10 minutes, mais non vérifié.