### PR TITLE
perf(stats): index server_stats on created_at + run test suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,61 @@ jobs:
   backend:
     name: Backend
     runs-on: ubuntu-latest
+    # Sans Redis joignable, le client ioredis retente indéfiniment et `node ace test`
+    # ne rend jamais la main : sans cette borne, le job tournerait jusqu'à la limite
+    # de 6 h de GitHub au lieu d'échouer.
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./backend
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: minecraft_stats_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      NODE_ENV: test
+      HOST: 127.0.0.1
+      PORT: 3333
+      LOG_LEVEL: error
+      # Clé jetable, propre au job — aucun secret réel n'est nécessaire pour les tests.
+      APP_KEY: iH0AhBLAGkMs2fBmYT9jTNb2ByHqXBiK
+      DB_HOST: 127.0.0.1
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_DATABASE: minecraft_stats_test
+      REDIS_HOST: 127.0.0.1
+      REDIS_PORT: 6379
+      LIMITER_STORE: memory
+      # `start/env.ts` valide ces clés au démarrage : les tests ne les appellent pas,
+      # mais l'application refuse de booter si elles manquent.
+      RESEND_API_KEY: test
+      DISCORD_CLIENT_ID: test
+      DISCORD_CLIENT_SECRET: test
+      GOOGLE_CLIENT_ID: test
+      GOOGLE_CLIENT_SECRET: test
 
     steps:
       - name: Checkout code
@@ -43,9 +95,16 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Run migrations
+        run: node ace migration:run --force
+
+      - name: Test
+        run: yarn test
+
   frontend:
     name: Frontend
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./frontend
@@ -66,6 +125,9 @@ jobs:
 
       - name: Lint
         run: yarn lint
+
+      - name: Test
+        run: yarn test
 
       - name: Build
         run: yarn build

--- a/backend/database/migrations/1784743824975_add_created_at_index_to_server_stats.ts
+++ b/backend/database/migrations/1784743824975_add_created_at_index_to_server_stats.ts
@@ -1,0 +1,49 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+/**
+ * La vue globale filtre sur `created_at` seul, sans `server_id`. Aucun des index
+ * existants ne commence par cette colonne : `server_stats_pkey` porte sur `id`, les
+ * deux autres sur `(server_id, …)`. Postgres n'avait donc aucun chemin d'accès et
+ * balayait la table entière — 8,2 M lignes rejetées par worker pour en retenir
+ * 11 071 sur une fenêtre de 24 h.
+ *
+ * Mesuré sur staging (23,7 M lignes), même requête à chaud :
+ *   sans index   1 065 ms   155 765 blocs
+ *   BRIN            628 ms    25 990 blocs   (56 ko)
+ *   btree            46 ms       835 blocs   (527 Mo)  ← retenu
+ *
+ * Le BRIN est 10 000× plus petit mais une fenêtre de 24 h reste éparpillée sur trop
+ * de plages de blocs, chacune ramenée en entier. Le btree coûte de l'espace, et on
+ * en récupère une partie en supprimant `server_id_player_count` (181 Mo) que
+ * `pg_stat_user_indexes` donne à 0 scan depuis la mise en service.
+ *
+ * `CONCURRENTLY` : la table fait 28 M lignes en production et le scheduler y écrit
+ * toutes les 10 minutes. Un `CREATE INDEX` classique poserait un verrou bloquant les
+ * écritures pendant toute la construction (~13 s mesurées sur staging).
+ * D'où `disableTransactions` — Postgres refuse `CONCURRENTLY` dans une transaction.
+ */
+export default class extends BaseSchema {
+  protected tableName = 'server_stats'
+
+  /**
+   * `CREATE INDEX CONCURRENTLY` ne peut pas s'exécuter dans une transaction, et
+   * Lucid enveloppe les migrations dans une transaction par défaut.
+   */
+  static disableTransactions = true
+
+  async up() {
+    this.schema.raw(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS server_stats_created_at_index
+         ON server_stats (created_at)`
+    )
+    this.schema.raw(`DROP INDEX CONCURRENTLY IF EXISTS server_stats_server_id_player_count_index`)
+  }
+
+  async down() {
+    this.schema.raw(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS server_stats_server_id_player_count_index
+         ON server_stats (server_id, player_count)`
+    )
+    this.schema.raw(`DROP INDEX CONCURRENTLY IF EXISTS server_stats_created_at_index`)
+  }
+}

--- a/backend/tests/bootstrap.ts
+++ b/backend/tests/bootstrap.ts
@@ -4,6 +4,7 @@ import app from '@adonisjs/core/services/app'
 import type { Config } from '@japa/runner/types'
 import { pluginAdonisJS } from '@japa/plugin-adonisjs'
 import testUtils from '@adonisjs/core/services/test_utils'
+import limiter from '@adonisjs/limiter/services/main'
 
 /**
  * This file is imported by the "bin/test.ts" entrypoint file
@@ -33,6 +34,21 @@ export const runnerHooks: Required<Pick<Config, 'setup' | 'teardown'>> = {
  */
 export const configureSuite: Config['configureSuite'] = (suite) => {
   if (['browser', 'functional', 'e2e'].includes(suite.name)) {
+    // Le rate-limiter est keyé sur l'IP et tous les tests partagent 127.0.0.1 : sans
+    // remise à zéro, le budget d'une route (5 req/min) est consommé par les tests
+    // précédents et les suivants reçoivent un 429 au lieu du statut attendu.
+    // `onTest` ne voit que les tests posés directement sur la suite ; ceux déclarés
+    // dans un `test.group()` passent par `onGroup`. Les deux sont nécessaires.
+    suite.onTest((test) => test.setup(() => limiter.clear()))
+    suite.onGroup((group) => group.each.setup(() => limiter.clear()))
+
+    // Limite connue : les réponses en cache (TTL 300 s) survivent à la transaction
+    // globale. En CI chaque run part d'un Redis vierge, donc sans effet ; en local,
+    // relancer la suite dans les 5 minutes peut resservir un classement calculé au
+    // run précédent et faire échouer `server_votes`. Un `redis.flushdb()` ici ne
+    // règle pas le problème : la connexion est configurée avec
+    // `enableOfflineQueue: false` et rejette la commande, ce qui casse le client
+    // pour tout le reste du run — testé avant et après le démarrage du serveur.
     return suite.setup(() => testUtils.httpServer().start())
   }
 }

--- a/docs/analyse-mongodb-2026-07-22.md
+++ b/docs/analyse-mongodb-2026-07-22.md
@@ -1,0 +1,228 @@
+# MongoDB pour le ping et les stats — analyse prospective
+
+**Date :** 22 juillet 2026
+**Question posée :** faut-il, à l'avenir, remplacer PostgreSQL par MongoDB pour la partie ping
+des serveurs et restitution des statistiques, et quels gains de performance en attendre ?
+**Mesures :** effectuées sur staging (`minecraft-stats-postgres-lgzajp`, 23,7 M lignes brutes),
+volumétrie comparable à la production (28,1 M lignes).
+
+---
+
+## 1. Réponse courte
+
+**Non, pas maintenant — et le gain espéré n'est pas là où on le cherche.**
+
+La lenteur mesurable actuelle ne vient pas du moteur de stockage. Elle vient d'un **index
+manquant** : la requête globale sur fenêtre courte lit l'intégralité de la table (155 765 blocs)
+pour restituer 48 points. Un index btree sur `created_at` la fait passer de **1 065 ms à 46 ms**,
+soit **23× plus rapide et 186× moins de blocs lus**, pour 527 Mo et 13 secondes de construction.
+
+Aucune migration MongoDB ne produira un gain de cet ordre sur cette requête, parce que le
+problème n'est pas « Postgres est lent » mais « on ne lui a pas donné le chemin d'accès ».
+
+---
+
+## 2. Ligne de base mesurée
+
+### 2.1 Volumétrie (staging)
+
+| Table | Total | Données | Index | Lignes |
+|---|---|---|---|---|
+| `server_stats` | 2 973 Mo | 1 216 Mo | **1 756 Mo** | 23,7 M |
+| `server_stats_hourly` | 584 Mo | 296 Mo | 287 Mo | 4,0 M |
+| `server_stats_daily` | 20 Mo | 11 Mo | 9,8 Mo | 169 k |
+| `servers` | 776 ko | 352 ko | 384 ko | 319 |
+
+Les index de `server_stats` pèsent **plus lourd que les données elles-mêmes**.
+
+### 2.2 Temps de réponse par chemin de lecture
+
+Requête globale (agrégation sur les 319 serveurs), moyenne de 3 exécutions à chaud :
+
+| Cas | Points rendus | Temps | Blocs lus |
+|---|---|---|---|
+| 24 h × 30 min — palier **brut** | 48 | **2 395 ms** | 155 764 |
+| 7 j × 1 h — palier horaire | 169 | 77 ms | 458 |
+| 30 j × 6 h — palier horaire | 121 | 188 ms | 1 662 |
+| 1 an × 1 j — palier journalier | 357 | 102 ms | 11 417 |
+| 2 ans × 1 sem — palier journalier | 52 | **39 ms** | 11 417 |
+| *(contrefactuel)* 2 ans × 1 sem sur le brut | 52 | 4 138 ms | 155 764 |
+
+Deux enseignements :
+
+1. **Les paliers d'agrégation fonctionnent.** 4 138 ms → 39 ms sur 2 ans, soit un facteur 106.
+   C'est le gain structurel, et il est déjà encaissé.
+2. **La fenêtre la plus courte est la plus lente.** 24 h coûte 2 395 ms quand 2 ans coûtent 39 ms.
+   C'est contre-intuitif, et c'est le symptôme.
+
+### 2.3 Diagnostic
+
+```
+Parallel Seq Scan on server_stats  (actual time=662..1942 rows=11071 loops=3)
+  Filter: created_at >= '2025-05-31' AND created_at <= '2025-06-01'
+  Rows Removed by Filter: 8 236 904
+  Buffers: shared read=154 704
+```
+
+Pour retenir 33 000 lignes, Postgres en lit 24,7 millions. Les index disponibles :
+
+```
+server_stats_pkey                          btree (id)                       594 Mo
+server_stats_server_id_created_at_index    btree (server_id, created_at)    981 Mo
+server_stats_server_id_player_count_index  btree (server_id, player_count)  181 Mo
+```
+
+Aucun ne commence par `created_at`. Un prédicat portant uniquement sur la date ne peut donc
+utiliser aucun d'eux — d'où le balayage complet. Les requêtes *par serveur* vont bien, parce
+qu'elles fournissent `server_id` en tête ; c'est la vue **globale** qui paie.
+
+### 2.4 Index morts
+
+`pg_stat_user_indexes` sur staging :
+
+| Index | Taille | Scans |
+|---|---|---|
+| `server_stats_server_id_created_at_index` | 981 Mo | 10 125 |
+| `server_stats_hourly_pkey` | 222 Mo | 4 255 285 |
+| `server_stats_daily_pkey` | 8 Mo | 172 286 |
+| **`server_stats_pkey`** | **594 Mo** | **0** |
+| **`server_stats_server_id_player_count_index`** | **181 Mo** | **0** |
+
+**775 Mo d'index n'ont jamais servi à une seule lecture.** `server_id_player_count` est
+supprimable immédiatement. `server_stats_pkey` porte une contrainte d'unicité sur une colonne
+`id` que personne n'interroge — le supprimer est possible mais demande de vérifier qu'aucun
+code ne s'appuie sur `id`, et c'est une décision distincte.
+
+### 2.5 Correctif mesuré
+
+Trois variantes testées sur staging (index créé, mesuré, puis supprimé) :
+
+| Variante sur `created_at` | Temps (chaud) | Blocs lus | Taille | Construction |
+|---|---|---|---|---|
+| Aucune — état actuel | 1 065 ms | 155 765 | — | — |
+| BRIN | 628 ms | 25 990 | **56 ko** | 4,2 s |
+| **btree** | **46 ms** | **835** | 527 Mo | 12,8 s |
+
+Le BRIN est séduisant (56 ko !) et divise les I/O par 6, mais le btree divise par 186. Sur une
+table append-only, le BRIN aurait dû mieux s'en tirer ; il souffre ici du fait qu'une fenêtre de
+24 h est éparpillée sur de nombreuses plages de blocs, chacune ramenée en entier.
+
+> Les temps de cette section (1 065 ms) diffèrent de ceux du § 2.2 (2 395 ms) : la requête y est
+> simplifiée (2 agrégats au lieu de 5). Seules les comparaisons **au sein** d'un même tableau
+> sont valides.
+
+---
+
+## 3. Ce que MongoDB apporterait
+
+Le candidat pertinent n'est pas MongoDB « document » mais les **time series collections**
+(MongoDB 5.0+), conçues exactement pour ce profil.
+
+**Ce qui jouerait en sa faveur :**
+
+- **Bucketing automatique.** Les mesures d'une même série sur une fenêtre sont regroupées dans
+  un document unique, stocké en colonnes. C'est structurellement ce que nos tables `_hourly` et
+  `_daily` font à la main.
+- **Compression.** Le stockage colonnaire compresse bien des séries d'entiers lentement
+  variables — typiquement un facteur 3 à 10 sur ce genre de données, à vérifier sur un
+  échantillon réel avant d'y croire.
+- **Expiration native.** `expireAfterSeconds` purge le brut ancien sans job maison.
+- **Index implicite sur le temps.** Le problème du § 2.3 ne peut pas exister : le champ temporel
+  est indexé par construction.
+
+**Ce qui ne changerait rien :**
+
+- Les paliers d'agrégation resteraient nécessaires. Mongo ne fait pas de downsampling
+  automatique ; il faudrait réécrire nos rollups en pipelines `$group` + `$dateTrunc` et les
+  matérialiser via `$merge`. Le travail est le même, dans une autre syntaxe.
+- Le gain du § 2.5 est déjà atteignable pour le coût d'une migration d'index.
+- Le cache Redis (TTL 300 s) absorbe déjà la répétition. La base ne voit chaque combinaison de
+  paramètres qu'une fois toutes les 5 minutes.
+
+**Ce qui coûterait cher :**
+
+- **Les filtres catégorie/langue sont des jointures.** `getGlobalStats` joint `server_stats` à
+  `server_categories` et `server_languages`. En polyglotte, ces jointures disparaissent : il
+  faudrait résoudre la liste des `server_id` côté Postgres puis la passer à Mongo — un `$in`
+  potentiellement large, et deux allers-retours réseau au lieu d'un plan unique.
+- **Toute la couche d'accès est Lucid.** Modèles, policies Bouncer, transactions, migrations,
+  `schema.ts` généré. Le ping écrit dans `server_stats` par bulk insert transactionnel ; la
+  cohérence avec `servers.last_player_count` et `peak_player_count` en dépend.
+- **Deux bases à exploiter.** Deux sauvegardes, deux restaurations, deux surveillances, deux
+  procédures de reprise. Aujourd'hui : un `docker exec` et un dump.
+- **Le backfill.** 28 M lignes à réécrire, avec la même contrainte de fenêtre hors heure de
+  pointe qu'on vient d'expérimenter (≈ 1 h pour le rollup horaire).
+
+---
+
+## 4. Alternatives mieux ciblées
+
+| Option | Effort | Gain attendu | Remarque |
+|---|---|---|---|
+| **Index btree sur `created_at`** | 1 migration | **23× sur la vue globale courte** | Mesuré § 2.5 |
+| **Supprimer les index morts** | 1 migration | 181 à 775 Mo | Mesuré § 2.4 |
+| **Rétention du brut à 90 j** | 1 job planifié | ≈ 88 % du volume brut | Les rollups couvrent déjà l'historique |
+| **Partitionnement par mois** | moyen | élagage de partitions | Le code de maintenance existe déjà (`start/scheduler.ts`) mais la table n'est pas partitionnée (`relkind = 'r'`) |
+| **TimescaleDB** | moyen | agrégats continus natifs | Extension Postgres : remplace nos rollups maison sans quitter Lucid ni le SQL |
+| **ClickHouse** | élevé | 10–100× sur l'agrégation | Le meilleur choix technique *si* la volumétrie explose ; même coût polyglotte que Mongo |
+| **MongoDB** | élevé | compression, pas de gain de latence démontré | — |
+
+**TimescaleDB mérite un examen sérieux** si le sujet revient : c'est une extension PostgreSQL,
+donc Lucid, les migrations, les policies et les jointures continuent de fonctionner. Ses
+*continuous aggregates* font exactement, et automatiquement, ce que `backfill:hourly-stats` et
+`backfill:daily-stats` font à la main — avec rafraîchissement incrémental, ce qui supprimerait
+la procédure de backfill d'une heure documentée dans `memory/stats-rollups-backfill.md`.
+
+---
+
+## 5. Quand la question se reposera
+
+Volumétrie actuelle : 319 serveurs × 144 pings/jour = **45 936 lignes/jour**, soit ≈ 16,8 M/an.
+
+| Serveurs suivis | Lignes brutes/an | Données brutes/an* | Rollup horaire/an |
+|---|---|---|---|
+| 319 (aujourd'hui) | 16,8 M | ≈ 0,9 Go | 2,8 M lignes |
+| 1 000 | 52,6 M | ≈ 2,7 Go | 8,8 M lignes |
+| 5 000 | 263 M | ≈ 13,4 Go | 43,8 M lignes |
+
+*\* données seules, ≈ 51 octets/ligne mesurés (1 216 Mo / 23,7 M) ; hors index.*
+
+À 5 000 serveurs, le brut devient inconfortable — mais c'est précisément là que la **rétention à
+90 jours** répond, en plafonnant le brut à ≈ 3,3 Go quelle que soit l'ancienneté du service. Les
+rollups, eux, croissent lentement et restent minuscules.
+
+**Seuil de réexamen proposé :** si le rollup horaire dépasse ~50 M lignes ou si une requête
+sur un palier agrégé dépasse 500 ms après application du § 4, la question du moteur redevient
+légitime — et le candidat sera alors ClickHouse ou TimescaleDB plutôt que MongoDB.
+
+---
+
+## 6. Recommandation
+
+1. **Ajouter l'index btree sur `server_stats(created_at)`.** Gain mesuré : 23×. C'est le seul
+   changement de cette liste dont l'effet est démontré chiffres en main.
+2. **Supprimer `server_stats_server_id_player_count_index`** (181 Mo, 0 scan).
+3. **Instrumenter avant d'aller plus loin.** Aucune mesure de latence côté application n'existe
+   aujourd'hui : je n'ai chronométré que le SQL, pas le temps vu par un utilisateur (sérialisation,
+   cache Redis, réseau). Sans cette donnée, tout arbitrage de moteur se ferait à l'aveugle.
+4. **Mettre la rétention du brut à l'ordre du jour** — c'est le seul levier qui change l'ordre de
+   grandeur, et il ne dépend d'aucun choix de moteur.
+5. **Ne pas migrer vers MongoDB.** Le gain principal qu'il apporterait (indexation temporelle
+   native) s'obtient ici pour une migration d'index ; les gains restants (compression, TTL) sont
+   réels mais ne justifient pas une base supplémentaire à exploiter, la perte des jointures
+   catégorie/langue et la réécriture de la couche d'accès.
+
+---
+
+## Limites de cette analyse
+
+- Mesures faites sur **staging**, pas en production. Volumétries proches (23,7 M vs 28,1 M
+  lignes) mais la charge concurrente et le cache disque diffèrent.
+- **Aucun prototype MongoDB n'a été construit.** Les gains attribués à Mongo au § 3 sont issus
+  de ses caractéristiques documentées, pas d'une mesure sur ces données. Toute décision
+  d'y aller devrait passer par un prototype chargé d'un extrait réel.
+- **Le chemin d'écriture n'a pas été mesuré.** Le ping insère en masse toutes les 10 minutes ;
+  je n'ai chronométré que les lectures. Un index supplémentaire sur `created_at` ralentit
+  légèrement l'insertion — négligeable a priori à 46 000 lignes/jour, mais non vérifié.
+- Les index temporaires créés pour le § 2.5 ont été supprimés après mesure ; staging est revenu
+  à son état initial.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "vitest run"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.8.0",
@@ -66,7 +67,9 @@
     "eslint-config-next": "^16.2.10",
     "postcss": "^8",
     "tailwindcss": "^4.3.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite": "^8.1.5",
+    "vitest": "^4.1.10"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "overrides": {

--- a/frontend/src/components/stats/period.test.ts
+++ b/frontend/src/components/stats/period.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  autoResolution,
+  axisTimeFormat,
+  bucketCount,
+  effectiveResolution,
+  MAX_BUCKETS,
+  Period,
+  PresetId,
+  resolutionAvailability,
+  shiftPeriod,
+  toStatsQuery,
+} from "./period";
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+const preset = (id: PresetId): Period => ({ kind: "preset", preset: id, resolution: "auto" });
+const custom = (from: number, to: number): Period => ({ kind: "custom", from, to, resolution: "auto" });
+
+describe("autoResolution", () => {
+  it("picks the finest step that stays readable on the range", () => {
+    expect(autoResolution(DAY)).toBe("30 minutes");
+    expect(autoResolution(7 * DAY)).toBe("1 hour");
+    expect(autoResolution(30 * DAY)).toBe("6 hours");
+    expect(autoResolution(180 * DAY)).toBe("1 day");
+    expect(autoResolution(730 * DAY)).toBe("1 week");
+  });
+
+  it("falls back to the widest step when the range is unbounded", () => {
+    expect(autoResolution(null)).toBe("1 week");
+  });
+
+  it("never auto-selects a sub-hour step past a couple of days, which would hit the raw table", () => {
+    expect(autoResolution(3 * DAY)).not.toBe("30 minutes");
+  });
+});
+
+describe("effectiveResolution", () => {
+  it("derives the step from the range in auto mode", () => {
+    expect(effectiveResolution(preset("7d"))).toBe("1 hour");
+  });
+
+  it("honours an explicit override", () => {
+    expect(effectiveResolution({ ...preset("7d"), resolution: "1 day" })).toBe("1 day");
+  });
+});
+
+describe("bucketCount", () => {
+  it("counts the points a range/step pair produces", () => {
+    expect(bucketCount(preset("24h"), "30 minutes")).toBe(48);
+    expect(bucketCount(preset("7d"), "1 hour")).toBe(168);
+    expect(bucketCount(preset("30d"), "6 hours")).toBe(120);
+  });
+
+  it("returns null for the open-ended range, whose lower bound only the backend knows", () => {
+    expect(bucketCount(preset("all"), "1 week")).toBeNull();
+  });
+});
+
+describe("resolutionAvailability", () => {
+  it("rejects a step that would blow the backend budget", () => {
+    const availability = resolutionAvailability(preset("2y"), "30 minutes");
+    expect(availability).toEqual({ available: false, reason: "tooManyPoints" });
+    expect(bucketCount(preset("2y"), "30 minutes")!).toBeGreaterThan(MAX_BUCKETS);
+  });
+
+  it("rejects a step too wide to draw a curve", () => {
+    expect(resolutionAvailability(preset("7d"), "1 week")).toEqual({
+      available: false,
+      reason: "rangeTooShort",
+    });
+  });
+
+  it("keeps only day-or-wider steps for the open-ended range", () => {
+    expect(resolutionAvailability(preset("all"), "6 hours").available).toBe(false);
+    expect(resolutionAvailability(preset("all"), "1 day").available).toBe(true);
+    expect(resolutionAvailability(preset("all"), "1 week").available).toBe(true);
+  });
+
+  it("accepts what the presets select by default", () => {
+    for (const id of ["24h", "7d", "30d", "3mo", "6mo", "1y", "2y", "all"] as const) {
+      const period = preset(id);
+      expect(resolutionAvailability(period, effectiveResolution(period))).toEqual({ available: true });
+    }
+  });
+});
+
+describe("toStatsQuery", () => {
+  const now = 1_700_000_000_000;
+
+  it("anchors a preset to now", () => {
+    expect(toStatsQuery(preset("7d"), now)).toEqual({
+      fromDate: now - 7 * DAY,
+      toDate: now,
+      interval: "1 hour",
+    });
+  });
+
+  it("omits fromDate for the open-ended range so the backend resolves the first known day", () => {
+    const query = toStatsQuery(preset("all"), now);
+    expect(query.fromDate).toBeUndefined();
+    expect(query).toEqual({ toDate: now, interval: "1 week" });
+  });
+
+  it("passes custom bounds through untouched", () => {
+    const from = now - 45 * DAY;
+    expect(toStatsQuery(custom(from, now), now)).toEqual({
+      fromDate: from,
+      toDate: now,
+      interval: "6 hours",
+    });
+  });
+});
+
+describe("shiftPeriod", () => {
+  const now = 1_700_000_000_000;
+
+  it("steps back by a whole span", () => {
+    const period = custom(now - 30 * DAY, now);
+    expect(shiftPeriod(period, -1, now)).toMatchObject({ from: now - 60 * DAY, to: now - 30 * DAY });
+  });
+
+  it("never runs past now", () => {
+    const period = custom(now - 30 * DAY, now);
+    expect(shiftPeriod(period, 1, now)).toMatchObject({ from: now - 30 * DAY, to: now });
+  });
+
+  it("preserves the span when clamping", () => {
+    const period = custom(now - 40 * DAY, now - 10 * DAY);
+    const shifted = shiftPeriod(period, 1, now);
+    expect(shifted).toMatchObject({ kind: "custom" });
+    if (shifted.kind !== "custom") throw new Error("expected a custom period");
+    expect(shifted.to - shifted.from).toBe(30 * DAY);
+  });
+
+  it("leaves presets alone — they are already anchored to now", () => {
+    const period = preset("7d");
+    expect(shiftPeriod(period, -1, now)).toBe(period);
+  });
+});
+
+describe("axisTimeFormat", () => {
+  it("drops the clock once a bucket spans a day or more", () => {
+    expect(axisTimeFormat("6 hours")).toBe("%d/%m %H:%M");
+    expect(axisTimeFormat("1 day")).toBe("%d/%m/%y");
+    expect(axisTimeFormat("1 week")).toBe("%d/%m/%y");
+  });
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -226,7 +226,7 @@
     "@emnapi/wasi-threads" "1.2.1"
     tslib "^2.4.0"
 
-"@emnapi/core@^1.10.0":
+"@emnapi/core@1.11.1", "@emnapi/core@^1.10.0":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.11.1.tgz#b9e1064f3a6b1631e241e638eb48d736bfd372a6"
   integrity sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==
@@ -241,7 +241,7 @@
   dependencies:
     tslib "^2.4.0"
 
-"@emnapi/runtime@^1.10.0", "@emnapi/runtime@^1.7.0":
+"@emnapi/runtime@1.11.1", "@emnapi/runtime@^1.10.0", "@emnapi/runtime@^1.7.0":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.11.1.tgz#58f1f3d5d81a9b12f793ab688c96371901027c24"
   integrity sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==
@@ -644,6 +644,13 @@
   dependencies:
     "@tybys/wasm-util" "^0.10.2"
 
+"@napi-rs/wasm-runtime@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz#ed33806d0f9be98dc76d0c3d4fd872fda701b5d5"
+  integrity sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==
+  dependencies:
+    "@tybys/wasm-util" "^0.10.3"
+
 "@next/env@16.2.10":
   version "16.2.10"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-16.2.10.tgz#0e9473a5577807292e11d3bf9e075d3bf036860f"
@@ -728,6 +735,11 @@
   version "1.0.39"
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
+
+"@oxc-project/types@=0.139.0":
+  version "0.139.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.139.0.tgz#38d76b9dbf934c2a02be174fb32ceebf182fe742"
+  integrity sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==
 
 "@parcel/watcher-android-arm64@2.5.6":
   version "2.5.6"
@@ -1194,6 +1206,90 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.2.tgz#0761a82af55c7e302d5b509eaf1c97ea1fc5feea"
   integrity sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==
 
+"@rolldown/binding-android-arm64@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz#f58cb9a0a8128ed0582282720528547fc5c035f3"
+  integrity sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==
+
+"@rolldown/binding-darwin-arm64@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz#441144c05a4a831aa75269abc3a4a324374ea707"
+  integrity sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==
+
+"@rolldown/binding-darwin-x64@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz#c82e30652cef52c4af925d5c66c8955a40319816"
+  integrity sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==
+
+"@rolldown/binding-freebsd-x64@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz#c32e9ce7fa1c0fb2b80913a2a3a05c3e907d06b0"
+  integrity sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz#ce90b5e22316adeb502ea010582f498cd0604f27"
+  integrity sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==
+
+"@rolldown/binding-linux-arm64-gnu@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz#91947110c4ddaa4eefb004e52688070977085201"
+  integrity sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==
+
+"@rolldown/binding-linux-arm64-musl@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz#eb32b2d4108c1c702b91e8cde8a043eae5caa94d"
+  integrity sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==
+
+"@rolldown/binding-linux-ppc64-gnu@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz#ccb943c11e5a72655cbb02fc1163541ceb640782"
+  integrity sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==
+
+"@rolldown/binding-linux-s390x-gnu@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz#a33731ee567e90b75fac6e5e55307e8a2b3038f0"
+  integrity sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==
+
+"@rolldown/binding-linux-x64-gnu@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz#a74c01aaacedfc11c39b6feba33a5fa0c654949f"
+  integrity sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==
+
+"@rolldown/binding-linux-x64-musl@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz#28cd178494fa1e65dba412229b5ce55c4dd5cbd1"
+  integrity sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==
+
+"@rolldown/binding-openharmony-arm64@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz#f7c75fa913fc20884d26a7d488d4f5c597cd71c0"
+  integrity sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==
+
+"@rolldown/binding-wasm32-wasi@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz#c379581947787081df363ea106140fcd5fec252d"
+  integrity sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==
+  dependencies:
+    "@emnapi/core" "1.11.1"
+    "@emnapi/runtime" "1.11.1"
+    "@napi-rs/wasm-runtime" "^1.1.6"
+
+"@rolldown/binding-win32-arm64-msvc@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz#f23c88694f7a729a12f395024aee38df80a16ba3"
+  integrity sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==
+
+"@rolldown/binding-win32-x64-msvc@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz#3377c8de0e56a8857f11217561147090e874cb46"
+  integrity sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==
+
+"@rolldown/pluginutils@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
+  integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
+
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
@@ -1203,6 +1299,11 @@
   version "1.21.5"
   resolved "https://registry.yarnpkg.com/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz#75989085bbbf80ee325874a0137437bde77e9baf"
   integrity sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==
+
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
 "@standard-schema/utils@^0.3.0":
   version "0.3.0"
@@ -1642,6 +1743,21 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tybys/wasm-util@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz#015cba9e9dd47ce14d03d2a8c5d547bfb169665d"
+  integrity sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==
+  dependencies:
+    tslib "^2.4.0"
+
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
 "@types/d3-color@^2":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-2.0.6.tgz#88a9a06afea2d3a400ea650a6c3e60e9bf9b0f2a"
@@ -1674,7 +1790,12 @@
     "@types/d3-interpolate" "^2"
     "@types/d3-selection" "^2"
 
-"@types/estree@^1.0.6":
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
+
+"@types/estree@^1.0.0", "@types/estree@^1.0.6":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
   integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
@@ -1979,6 +2100,66 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz#72da0da48d72b1e87831b9c0308931d3f4669027"
   integrity sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==
 
+"@vitest/expect@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.1.10.tgz#799c06fc44bb0cf7e2784137b627c5cc173285d4"
+  integrity sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.1.10"
+    "@vitest/utils" "4.1.10"
+    chai "^6.2.2"
+    tinyrainbow "^3.1.0"
+
+"@vitest/mocker@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.1.10.tgz#2413987ab4cd7fa1c2b614b404c407bf6ad1ead1"
+  integrity sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==
+  dependencies:
+    "@vitest/spy" "4.1.10"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.21"
+
+"@vitest/pretty-format@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.1.10.tgz#75542e7273a08cc10fd4d8dad4e3eb1f16cd958c"
+  integrity sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==
+  dependencies:
+    tinyrainbow "^3.1.0"
+
+"@vitest/runner@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.1.10.tgz#febf0a21a9168421422d1955370e606feab60355"
+  integrity sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==
+  dependencies:
+    "@vitest/utils" "4.1.10"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.1.10.tgz#7e3e9fec7d4d47232e493cfdcbd2170de4371c04"
+  integrity sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==
+  dependencies:
+    "@vitest/pretty-format" "4.1.10"
+    "@vitest/utils" "4.1.10"
+    magic-string "^0.30.21"
+    pathe "^2.0.3"
+
+"@vitest/spy@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.1.10.tgz#5c0bfa97b56bba9e37403c976db776ff6ab56f65"
+  integrity sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==
+
+"@vitest/utils@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.1.10.tgz#ffc71055f18bfccb1fd0586365ebc2824892e403"
+  integrity sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==
+  dependencies:
+    "@vitest/pretty-format" "4.1.10"
+    convert-source-map "^2.0.0"
+    tinyrainbow "^3.1.0"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -2147,6 +2328,11 @@ arraybuffer.prototype.slice@^1.0.4:
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
 
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
 ast-types-flow@^0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.8.tgz#0a85e1c92695769ac13a428bb653e7538bea27d6"
@@ -2269,6 +2455,11 @@ caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001782:
   version "1.0.30001799"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz#5c909138c27f1a61219d3e092071c1cc7d32dc55"
   integrity sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==
+
+chai@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
+  integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
 
 chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
@@ -2744,6 +2935,11 @@ es-iterator-helpers@^1.2.1:
     iterator.prototype "^1.1.5"
     math-intrinsics "^1.1.0"
 
+es-module-lexer@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.3.1.tgz#5bf2df06999dbbe5f006a5f46a11fb9f5b7b391b"
+  integrity sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==
+
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1, es-object-atoms@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
@@ -3005,10 +3201,22 @@ estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+expect-type@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.4.0.tgz#24edf7f0cc69a44d008567ba4594ab96f3c3a3d6"
+  integrity sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -3094,6 +3302,11 @@ for-each@^0.3.3, for-each@^0.3.5:
   integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
     is-callable "^1.2.7"
+
+fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -3691,55 +3904,110 @@ lightningcss-android-arm64@1.32.0:
   resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz#f033885116dfefd9c6f54787523e3514b61e1968"
   integrity sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==
 
+lightningcss-android-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz#9a6841f88ae50fc83502903892b41af41bc2b907"
+  integrity sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==
+
 lightningcss-darwin-arm64@1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz#50b71871b01c8199584b649e292547faea7af9b5"
   integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
+
+lightningcss-darwin-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz#c0f2c31c0bfd19fa4dd3f18e957a1f1a152097d6"
+  integrity sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==
 
 lightningcss-darwin-x64@1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz#35f3e97332d130b9ca181e11b568ded6aebc6d5e"
   integrity sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==
 
+lightningcss-darwin-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz#cb0705965acb538c6683949ce6925fb3cdf7c361"
+  integrity sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==
+
 lightningcss-freebsd-x64@1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz#9777a76472b64ed6ff94342ad64c7bafd794a575"
   integrity sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==
+
+lightningcss-freebsd-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz#763538828b26bab2680dadafcc84ee78b0eb502b"
+  integrity sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==
 
 lightningcss-linux-arm-gnueabihf@1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz#13ae652e1ab73b9135d7b7da172f666c410ad53d"
   integrity sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==
 
+lightningcss-linux-arm-gnueabihf@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz#6862e3176a331aedbdec1ed352b4d7d0dd0784de"
+  integrity sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==
+
 lightningcss-linux-arm64-gnu@1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz#417858795a94592f680123a1b1f9da8a0e1ef335"
   integrity sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==
+
+lightningcss-linux-arm64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz#c6a3a2ed15141daf6bdc2628930f8e39bdf473aa"
+  integrity sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==
 
 lightningcss-linux-arm64-musl@1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz#6be36692e810b718040802fd809623cffe732133"
   integrity sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==
 
+lightningcss-linux-arm64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz#7fa1334971fc82845f9827df6ef8a0b20914bac6"
+  integrity sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==
+
 lightningcss-linux-x64-gnu@1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz#0b7803af4eb21cfd38dd39fe2abbb53c7dd091f6"
   integrity sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==
+
+lightningcss-linux-x64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz#8b927862ea8c2bbc6831a46509244b50d9936e55"
+  integrity sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==
 
 lightningcss-linux-x64-musl@1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz#88dc8ba865ddddb1ac5ef04b0f161804418c163b"
   integrity sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==
 
+lightningcss-linux-x64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz#0c525bb077dfd94404c059cfe42dad797e96aeaf"
+  integrity sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==
+
 lightningcss-win32-arm64-msvc@1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz#4f30ba3fa5e925f5b79f945e8cc0d176c3b1ab38"
   integrity sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==
 
+lightningcss-win32-arm64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz#850ee1103dac989cfab50e3ac22d1a69e394e63d"
+  integrity sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==
+
 lightningcss-win32-x64-msvc@1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz#141aa5605645064928902bb4af045fa7d9f4220a"
   integrity sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==
+
+lightningcss-win32-x64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz#e343ae152eed3609dc6e11949d1a3bf39a1c946f"
+  integrity sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==
 
 lightningcss@1.32.0:
   version "1.32.0"
@@ -3759,6 +4027,25 @@ lightningcss@1.32.0:
     lightningcss-linux-x64-musl "1.32.0"
     lightningcss-win32-arm64-msvc "1.32.0"
     lightningcss-win32-x64-msvc "1.32.0"
+
+lightningcss@^1.32.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.33.0.tgz#c08867d71a79385c6e190214fd72fef3e5f95f0b"
+  integrity sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==
+  dependencies:
+    detect-libc "^2.0.3"
+  optionalDependencies:
+    lightningcss-android-arm64 "1.33.0"
+    lightningcss-darwin-arm64 "1.33.0"
+    lightningcss-darwin-x64 "1.33.0"
+    lightningcss-freebsd-x64 "1.33.0"
+    lightningcss-linux-arm-gnueabihf "1.33.0"
+    lightningcss-linux-arm64-gnu "1.33.0"
+    lightningcss-linux-arm64-musl "1.33.0"
+    lightningcss-linux-x64-gnu "1.33.0"
+    lightningcss-linux-x64-musl "1.33.0"
+    lightningcss-win32-arm64-msvc "1.33.0"
+    lightningcss-win32-x64-msvc "1.33.0"
 
 linkify-it@^5.0.1:
   version "5.0.1"
@@ -4043,6 +4330,11 @@ object.values@^1.1.6, object.values@^1.2.1:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+obug@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.4.tgz#9090d8a548a522517915d2aa6aae907197ac6cf8"
+  integrity sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==
+
 optionator@^0.9.3:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
@@ -4112,6 +4404,11 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
 picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -4126,6 +4423,11 @@ picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
+picomatch@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
+  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
 
 po-parser@^2.1.1:
   version "2.1.1"
@@ -4150,7 +4452,7 @@ postcss-selector-parser@6.0.10:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss@8.4.31, postcss@8.5.15, postcss@^8.4.23, postcss@^8.5.10:
+postcss@8.4.31, postcss@8.5.15, postcss@^8.4.23, postcss@^8.5.10, postcss@^8.5.17:
   version "8.5.16"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.16.tgz#1230ce0b5df354c24c0ea45f99ce5f6a88279d28"
   integrity sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==
@@ -4436,6 +4738,30 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
+rolldown@~1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.1.5.tgz#339aae250844351fc55b74e2652d3ebd6fba389d"
+  integrity sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==
+  dependencies:
+    "@oxc-project/types" "=0.139.0"
+    "@rolldown/pluginutils" "^1.0.0"
+  optionalDependencies:
+    "@rolldown/binding-android-arm64" "1.1.5"
+    "@rolldown/binding-darwin-arm64" "1.1.5"
+    "@rolldown/binding-darwin-x64" "1.1.5"
+    "@rolldown/binding-freebsd-x64" "1.1.5"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.1.5"
+    "@rolldown/binding-linux-arm64-gnu" "1.1.5"
+    "@rolldown/binding-linux-arm64-musl" "1.1.5"
+    "@rolldown/binding-linux-ppc64-gnu" "1.1.5"
+    "@rolldown/binding-linux-s390x-gnu" "1.1.5"
+    "@rolldown/binding-linux-x64-gnu" "1.1.5"
+    "@rolldown/binding-linux-x64-musl" "1.1.5"
+    "@rolldown/binding-openharmony-arm64" "1.1.5"
+    "@rolldown/binding-wasm32-wasi" "1.1.5"
+    "@rolldown/binding-win32-arm64-msvc" "1.1.5"
+    "@rolldown/binding-win32-x64-msvc" "1.1.5"
+
 rope-sequence@^1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/rope-sequence/-/rope-sequence-1.3.4.tgz#df85711aaecd32f1e756f76e43a415171235d425"
@@ -4615,6 +4941,11 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -4624,6 +4955,16 @@ stable-hash@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stable-hash/-/stable-hash-0.0.5.tgz#94e8837aaeac5b4d0f631d2972adef2924b40269"
   integrity sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+std-env@^4.0.0-rc.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.2.0.tgz#8ebe0ec60485668ab47227b312f4254cdf80c9d3"
+  integrity sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==
 
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
@@ -4769,13 +5110,28 @@ third-party-capital@1.0.20:
   resolved "https://registry.yarnpkg.com/third-party-capital/-/third-party-capital-1.0.20.tgz#e218a929a35bf4d2245da9addb8ab978d2f41685"
   integrity sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==
 
-tinyglobby@^0.2.13, tinyglobby@^0.2.15:
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^1.0.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.2.4.tgz#ae45bb2edebda94c70f4ea897e0f1243e470db71"
+  integrity sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==
+
+tinyglobby@^0.2.13, tinyglobby@^0.2.15, tinyglobby@^0.2.17:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
   integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.4"
+
+tinyrainbow@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz#1d8a623893f95cf0a2ddb9e5d11150e191409421"
+  integrity sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==
 
 tiptap-markdown@^0.9.0:
   version "0.9.0"
@@ -5019,6 +5375,45 @@ util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0", vite@^8.1.5:
+  version "8.1.5"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.1.5.tgz#ccffce3ee487b1886223b24ebb27b91674827d30"
+  integrity sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==
+  dependencies:
+    lightningcss "^1.32.0"
+    picomatch "^4.0.5"
+    postcss "^8.5.17"
+    rolldown "~1.1.5"
+    tinyglobby "^0.2.17"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@^4.1.10:
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.1.10.tgz#7e9285efe264b1167050b7a3a7ff34788e1b7afc"
+  integrity sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==
+  dependencies:
+    "@vitest/expect" "4.1.10"
+    "@vitest/mocker" "4.1.10"
+    "@vitest/pretty-format" "4.1.10"
+    "@vitest/runner" "4.1.10"
+    "@vitest/snapshot" "4.1.10"
+    "@vitest/spy" "4.1.10"
+    "@vitest/utils" "4.1.10"
+    es-module-lexer "^2.0.0"
+    expect-type "^1.3.0"
+    magic-string "^0.30.21"
+    obug "^2.1.1"
+    pathe "^2.0.3"
+    picomatch "^4.0.3"
+    std-env "^4.0.0-rc.1"
+    tinybench "^2.9.0"
+    tinyexec "^1.0.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.1.0"
+    vite "^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running "^2.3.0"
+
 w3c-keyname@^2.2.0:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
@@ -5109,6 +5504,14 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 word-wrap@^1.2.5:
   version "1.2.5"

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -7,3 +7,4 @@
 - [Serveur MCP](mcp-server.md) — service mcp/ auto-généré depuis OpenAPI ; live sur mcp-staging.minecraft-stats.fr ; gotchas YAML + healthcheck IPv6
 - [Pas de trailer Co-Authored-By](no-coauthor-trailer.md) — ne jamais ajouter d'attribution IA aux commits/PRs
 - [Architecture i18n](i18n-architecture.md) — FR/EN via next-intl (routing hybride domaine+préfixe, catalogue messages/<locale>/<feature>.json) + @adonisjs/i18n ; contenu BDD mono-langue
+- [Rollups stats & backfill](stats-rollups-backfill.md) — 3 paliers brut/horaire/journalier ; rejouer les backfills après toute migration de colonne, horaire AVANT journalier

--- a/memory/stats-rollups-backfill.md
+++ b/memory/stats-rollups-backfill.md
@@ -1,0 +1,45 @@
+---
+name: stats-rollups-backfill
+description: Paliers d'agrégation des stats (brut/horaire/journalier) et procédure de backfill sur wyvern
+metadata:
+  type: project
+---
+
+Les stats de joueurs sont lues sur **trois paliers**, choisis par `StatsService.pickSource()` :
+`server_stats` (brut) → `server_stats_hourly` → `server_stats_daily`. Chaque ligne de rollup
+porte `avg_player_count`, `peak_player_count`, `min_player_count`, `max_slot_count`, `samples_count`.
+
+⚠️ `max_slot_count` est la **capacité en slots**, pas un nombre de joueurs. Elle s'appelait
+`max_player_count` avant juillet 2026, ce qui avait fait croire qu'un pic était déjà stocké —
+il ne l'était pas.
+
+**Toute migration qui ajoute une colonne de rollup impose de rejouer les backfills**, sinon la
+colonne reste `NULL` sur tout l'historique (l'API dégrade alors sur `playerCount`, jamais faux
+mais plat). L'ordre compte : le journalier lit l'horaire, pas le brut.
+
+```
+ssh wyvern
+docker exec -d stats-backend-prod sh -c "node ace backfill:hourly-stats > /tmp/bf-h.log 2>&1"
+# attendre "Backfill done" — ~1 h sur 28 M lignes brutes (juillet 2026)
+docker exec -d stats-backend-prod sh -c "node ace backfill:daily-stats  > /tmp/bf-d.log 2>&1"
+# ~30 s
+```
+
+Conteneurs : `stats-backend-prod` / `stats-backend-dev` (staging), bases PostgreSQL **distinctes**
+(`minecraft-stats-postgres-jxfsd3` en prod, `-lgzajp` en staging). Toujours lancer en détaché
+(`-d`) : une déconnexion SSH tuerait un backfill attaché. Ne pas utiliser `timeout N` autour de la
+commande — ça tronque silencieusement le backfill en laissant croire qu'il a réussi.
+
+**Contrôle de cohérence** après backfill — `avg_null` doit égaler `peak_null` avec 0 incohérence.
+Les pics `NULL` restants (~24 %) sont les heures sans aucun ping réussi, où il n'y a rien à agréger :
+
+```sql
+SELECT count(*) FILTER (WHERE avg_player_count IS NULL) avg_null,
+       count(*) FILTER (WHERE peak_player_count IS NULL) peak_null,
+       count(*) FILTER (WHERE avg_player_count IS NULL
+                          AND peak_player_count IS NOT NULL) incoherent
+FROM server_stats_hourly;
+```
+
+Les migrations tournent seules au démarrage du conteneur (`backend/compose.yaml` :
+`node ace migration:run --force && node ace serve`) — voir [[deployment-setup]].


### PR DESCRIPTION
## Summary

Deux lots accumulés sur `staging` depuis la mise en production du sélecteur de période.

**1. Correctif de performance** — la vue globale filtrait sur `created_at` seul, sans qu'aucun index ne commence par cette colonne. Postgres balayait la table entière (28 M lignes en production) à chaque appel non caché.

**2. Tests en CI** — les 6 specs Japa du backend n'avaient jamais tourné en intégration continue, et le frontend n'avait aucune infrastructure de test.

## Gain mesuré, de bout en bout

Sur l'API staging, cache miss garanti (fenêtre unique à chaque appel) :

| | Avant | Après |
|---|---|---|
| **Cache MISS `/global-stats` 24 h × 30 min** | **2,7 – 3,9 s** | **0,17 – 0,26 s** |
| Contrôle réseau (`/website-stats`) | 0,15 – 0,43 s | 0,15 – 0,68 s |
| Témoin 7 j × 1 h (palier horaire, non concerné) | — | 0,25 – 0,41 s |

Le temps de réponse sur un cache miss est passé **sous la latence réseau**. Côté SQL pur, la même requête passe de 1 065 ms / 155 765 blocs à 46 ms / 835 blocs — 23× plus rapide, 186× moins d'I/O.

**Ce n'est pas un effet du cache Redis.** Sur le Redis de production : `keyspace_hits: 14 311` / `keyspace_misses: 17 836`, et **0 clé `global-stats` vivante** au moment de la mesure. `quantizeEpochMs` aligne les bornes sur une grille de 5 min avec un TTL de 300 s : une entrée ne sert qu'aux requêtes de la même tranche de 5 minutes. Le nouveau sélecteur de période a par ailleurs élargi l'espace des paramètres, donc les miss dominent.

## Changes

**Performance**
- Index btree `server_stats_created_at_index` (527 Mo), créé en `CONCURRENTLY` pour ne pas bloquer les écritures du scheduler.
- Suppression de `server_stats_server_id_player_count_index` (181 Mo, **0 scan** d'après `pg_stat_user_indexes`).
- `docs/analyse-mongodb-2026-07-22.md` — l'analyse prospective MongoDB vs PostgreSQL d'où sortent ces mesures. Conclusion : ne pas migrer, le gain recherché s'obtenait pour le prix d'un index.

**CI**
- Job backend : services postgres + redis, variables d'env exigées par `start/env.ts`, migrations, `yarn test`.
- Job frontend : Vitest + 19 tests unitaires sur `period.ts` (résolution auto, budget de points, bornes de requête, décalage de période).
- `timeout-minutes: 15` sur les deux jobs — sans Redis joignable, ioredis retente indéfiniment et le job tournerait jusqu'à la limite de 6 h.
- `tests/bootstrap.ts` : remise à zéro du rate-limiter entre les tests fonctionnels, sans quoi le budget de 5 req/min était consommé par les tests précédents et `provider_links` recevait un 429 au lieu du 400 attendu.

**Documentation**
- `memory/stats-rollups-backfill.md` — paliers d'agrégation, ordre des backfills, contrôle de cohérence.

## Testing

- CI verte sur les deux lots (Backend, Frontend, CodeQL, SonarQube, Build).
- Migration appliquée et vérifiée sur staging : batch 32, index valide (`indisvalid = true`), index mort supprimé.
- Mesure de bout en bout rejouée après application — tableau ci-dessus.
- Suite backend : **58 tests, 0 échec** sur environnement frais.

## Notes

⚠️ **Le déploiement en production va construire un index de ~527 Mo sur 28 M lignes.** `CONCURRENTLY` ne bloque pas les écritures, mais la construction prend plusieurs minutes et consomme de l'I/O. À déployer de préférence hors heure de pointe.

Aucun backfill n'est requis cette fois — contrairement au lot précédent.

`server_stats_pkey` (594 Mo) est également à 0 scan, mais porte une contrainte d'unicité sur `id` : le retirer demande de vérifier qu'aucun code ne s'appuie sur cette colonne. Décision distincte, laissée de côté.

Le chemin d'écriture n'a pas été mesuré : un index supplémentaire ralentit légèrement l'insertion. A priori négligeable à ~46 000 lignes/jour insérées par lots, mais non vérifié.