### PR TITLE
feat: add daily rhythm statistics feature

### DIFF
--- a/backend/app/controllers/stats_controller.ts
+++ b/backend/app/controllers/stats_controller.ts
@@ -1,6 +1,6 @@
 import CacheService from '#services/cache_service'
 import StatsService from '#services/stat_service'
-import { StatValidator } from '#validators/stat'
+import { DailyRhythmValidator, StatValidator } from '#validators/stat'
 import { GlobalStatValidator } from '#validators/global_stat'
 import type { HttpContext } from '@adonisjs/core/http'
 
@@ -47,6 +47,38 @@ export default class StatsController {
       key,
       300,
       () => StatsService.getStats(validatedData),
+      { bypass: CacheService.bypassAllowed(ctx) }
+    )
+    return response.status(200).json(results)
+  }
+
+  /**
+   * @dailyRhythm
+   * @operationId getServerDailyRhythm
+   * @tag STATS
+   * @summary Get the typical day of a server
+   * @description Folds the last `days` of history onto a single 24-hour day, in the caller's time zone. Answers "when is this server busiest" rather than "how did it grow". Windows of 31 days or less are built from raw samples and yield 48 half-hour slots; longer windows use the hourly rollup and yield 24 one-hour slots — read `slotMinutes` rather than assuming. Three series are returned in one payload so a client can switch between them without a round trip: `all`, `weekday` (Mon–Fri) and `weekend` (Sat–Sun), with day-of-week resolved in the same time zone. Slots with no successful ping are absent from the array, which is not the same as a slot averaging zero players.
+   * @paramPath server_id - Server id - @type(number) @example(125) @required
+   * @paramQuery days - Size of the observation window, in days back from now. Defaults to 30, capped at 730. - @type(number) @example(30)
+   * @paramQuery timezone - IANA time zone used to bucket slots and split weekdays from weekends. Defaults to UTC. - @type(string) @example(Europe/Paris)
+   * @responseBody 200 - {"timezone": "Europe/Paris", "slotMinutes": 30, "from": "2026-06-23T00:00:00.000+02:00", "to": "2026-07-23T00:00:00.000+02:00", "daysObserved": {"all": 30, "weekday": 22, "weekend": 8}, "series": {"all": [{"slot": 43, "minuteOfDay": 1290, "playerCount": 502, "peakPlayerCount": 806, "minPlayerCount": 341, "samplesCount": 90, "daysCount": 30}], "weekday": [], "weekend": []}}
+   * @responseBody 422 - {"errors": [{"message": "The timezone field must be a valid IANA time zone", "rule": "ianaTimezone", "field": "timezone"}]}
+   * @responseBody 500 - {"error": "Internal server error"}
+   */
+  async dailyRhythm(ctx: HttpContext) {
+    const { request, response } = ctx
+    const validatedData = await DailyRhythmValidator.validate({
+      ...request.params(),
+      ...request.qs(),
+    })
+
+    // Pas de `quantizeEpochMs` ici : la fenêtre est dérivée de `days` et de
+    // maintenant, donc la clé est déjà stable — c'est le TTL qui la fait glisser.
+    const key = `rhythm:${validatedData.server_id}:${validatedData.days}:${validatedData.timezone}`
+    const results = await CacheService.cacheOrFetch(
+      key,
+      300,
+      () => StatsService.getDailyRhythm(validatedData),
       { bypass: CacheService.bypassAllowed(ctx) }
     )
     return response.status(200).json(results)

--- a/backend/app/services/stat_service.ts
+++ b/backend/app/services/stat_service.ts
@@ -33,6 +33,25 @@ const ROLLUPS = {
 type RollupTier = keyof typeof ROLLUPS
 type StatsSource = RollupTier | 'raw'
 
+/**
+ * Journée type : au-delà de cette fenêtre, le brut ferait scanner ~150 lignes par
+ * jour et par serveur pour une seule page. On bascule sur le rollup horaire, dont
+ * la granularité plafonne les créneaux à 1 h au lieu de 30 min.
+ */
+const RHYTHM_RAW_MAX_DAYS = 31
+
+type DayType = 'weekday' | 'weekend'
+
+interface RhythmSlot {
+  slot: number
+  minuteOfDay: number
+  playerCount: number
+  peakPlayerCount: number
+  minPlayerCount: number
+  samplesCount: number
+  daysCount: number
+}
+
 export default class StatsService {
   static convertToCamelCase(input: {
     server_id: number
@@ -287,6 +306,179 @@ export default class StatsService {
       toDate: toDateSql,
     })
     return result.rows
+  }
+
+  /**
+   * Agrège les relevés par créneau horaire **local** et par type de jour.
+   *
+   * Le brut est normalisé sur les colonnes du rollup (un relevé = un sample) pour
+   * qu'une seule expression d'agrégat serve les deux sources. La sous-requête
+   * convertit une fois pour toutes en heure locale : `EXTRACT` et `::date` en aval
+   * raisonnent alors sur l'horloge du visiteur, pas sur UTC.
+   */
+  private static async getRhythmRows(params: {
+    source: 'raw' | 'hourly'
+    serverId: number
+    fromDateSql: string
+    toDateSql: string
+    timezone: string
+  }) {
+    const isRaw = params.source === 'raw'
+
+    // `CAST(... AS text)` plutôt que `::text` : un paramètre de type inconnu rendrait
+    // `timezone(unknown, timestamptz)` ambigu pour Postgres, et la syntaxe `::` entre
+    // en conflit avec les bindings d'identifiant de Knex (`:nom:`).
+    const localTime = (column: string) => `${column} AT TIME ZONE CAST(:timezone AS text)`
+
+    const localised = isRaw
+      ? `SELECT ${localTime('created_at')} AS local,
+                player_count AS avg_player_count,
+                player_count AS peak_player_count,
+                player_count AS min_player_count,
+                1 AS samples_count
+           FROM server_stats
+          WHERE server_id = :serverId
+            AND created_at >= :fromDate AND created_at < :toDate
+            AND player_count IS NOT NULL`
+      : `SELECT ${localTime('hour')} AS local,
+                avg_player_count, peak_player_count, min_player_count, samples_count
+           FROM server_stats_hourly
+          WHERE server_id = :serverId
+            AND hour >= :fromDate AND hour < :toDate
+            AND avg_player_count IS NOT NULL`
+
+    const slotExpr = isRaw
+      ? `EXTRACT(hour FROM local)::int * 2 + FLOOR(EXTRACT(minute FROM local) / 30)::int`
+      : `EXTRACT(hour FROM local)::int`
+
+    const query = `
+      SELECT
+        CASE WHEN EXTRACT(isodow FROM local) >= 6 THEN 'weekend' ELSE 'weekday' END AS day_type,
+        ${slotExpr} AS slot,
+        ROUND(
+          SUM(avg_player_count::bigint * samples_count)::numeric /
+          NULLIF(SUM(samples_count), 0)
+        )::int AS player_count,
+        MAX(COALESCE(peak_player_count, avg_player_count))::int AS peak_player_count,
+        MIN(COALESCE(min_player_count, avg_player_count))::int AS min_player_count,
+        SUM(samples_count)::int AS samples_count,
+        COUNT(DISTINCT local::date)::int AS days_count
+      FROM (${localised}) s
+      GROUP BY 1, 2
+      ORDER BY 1, 2
+    `
+
+    const result = await Database.rawQuery(query, {
+      serverId: params.serverId,
+      fromDate: params.fromDateSql,
+      toDate: params.toDateSql,
+      timezone: params.timezone,
+    })
+    return result.rows as Array<{
+      day_type: DayType
+      slot: number
+      player_count: number
+      peak_player_count: number
+      min_player_count: number
+      samples_count: number
+      days_count: number
+    }>
+  }
+
+  /**
+   * Fusionne semaine et week-end en une série « tous les jours ». Les deux portent
+   * des dates disjointes, donc sommer `daysCount` est exact ; la moyenne, elle,
+   * doit être repondérée par `samplesCount` — un week-end pèse deux jours sur sept.
+   */
+  private static mergeRhythmSeries(series: RhythmSlot[][]): RhythmSlot[] {
+    const bySlot = new Map<number, RhythmSlot>()
+
+    for (const slot of series.flat()) {
+      const known = bySlot.get(slot.slot)
+      if (!known) {
+        bySlot.set(slot.slot, { ...slot })
+        continue
+      }
+
+      const samplesCount = known.samplesCount + slot.samplesCount
+      bySlot.set(slot.slot, {
+        slot: slot.slot,
+        minuteOfDay: slot.minuteOfDay,
+        playerCount: Math.round(
+          (known.playerCount * known.samplesCount + slot.playerCount * slot.samplesCount) /
+            samplesCount
+        ),
+        peakPlayerCount: Math.max(known.peakPlayerCount, slot.peakPlayerCount),
+        minPlayerCount: Math.min(known.minPlayerCount, slot.minPlayerCount),
+        samplesCount,
+        daysCount: known.daysCount + slot.daysCount,
+      })
+    }
+
+    return [...bySlot.values()].sort((a, b) => a.slot - b.slot)
+  }
+
+  /**
+   * « Journée type » : l'historique replié sur 24 h. Chaque créneau porte la moyenne
+   * des relevés tombés à cette heure-là sur la fenêtre demandée, ce qui répond à une
+   * question que la chronologie ne sait pas poser — *quand* ce serveur est-il vivant.
+   *
+   * Le découpage se fait dans le fuseau de celui qui lit (`timezone`) et non en UTC :
+   * un pic « à 21 h » ne veut rien dire sans une horloge de référence.
+   */
+  static async getDailyRhythm(params: { server_id: number; days: number; timezone: string }) {
+    const toMs = Date.now()
+    const fromMs = toMs - params.days * DAY_SECONDS * 1000
+    const shared = {
+      serverId: params.server_id,
+      fromDateSql: DateTime.fromMillis(fromMs).toSQL()!,
+      toDateSql: DateTime.fromMillis(toMs).toSQL()!,
+      timezone: params.timezone,
+    }
+
+    let source: 'raw' | 'hourly' = params.days <= RHYTHM_RAW_MAX_DAYS ? 'raw' : 'hourly'
+    let rows = await this.getRhythmRows({ ...shared, source })
+
+    // Même repli transparent que `getStatsWithInterval` : tant que le backfill horaire
+    // n'a pas couvert la plage, mieux vaut un brut coûteux qu'une réponse vide.
+    if (source === 'hourly' && rows.length === 0) {
+      logger.warn(shared, 'hourly rollup empty for rhythm range — falling back to server_stats')
+      source = 'raw'
+      rows = await this.getRhythmRows({ ...shared, source })
+    }
+
+    const slotMinutes = source === 'raw' ? 30 : 60
+    const toSlot = (row: (typeof rows)[number]): RhythmSlot => ({
+      slot: row.slot,
+      minuteOfDay: row.slot * slotMinutes,
+      playerCount: row.player_count,
+      peakPlayerCount: row.peak_player_count,
+      minPlayerCount: row.min_player_count,
+      samplesCount: row.samples_count,
+      daysCount: row.days_count,
+    })
+
+    const weekday = rows.filter((row) => row.day_type === 'weekday').map(toSlot)
+    const weekend = rows.filter((row) => row.day_type === 'weekend').map(toSlot)
+    const all = this.mergeRhythmSeries([weekday, weekend])
+
+    // Un serveur qui ne répond que le soir n'a de relevés que sur ses créneaux du
+    // soir : le maximum, et non la moyenne, donne le nombre de jours réellement vus.
+    const daysObserved = (series: RhythmSlot[]) =>
+      series.reduce((max, slot) => Math.max(max, slot.daysCount), 0)
+
+    return {
+      timezone: params.timezone,
+      slotMinutes,
+      from: DateTime.fromMillis(fromMs).toISO(),
+      to: DateTime.fromMillis(toMs).toISO(),
+      daysObserved: {
+        all: daysObserved(all),
+        weekday: daysObserved(weekday),
+        weekend: daysObserved(weekend),
+      },
+      series: { all, weekday, weekend },
+    }
   }
 
   /**

--- a/backend/app/validators/stat.ts
+++ b/backend/app/validators/stat.ts
@@ -1,4 +1,5 @@
 import vine from '@vinejs/vine'
+import { DateTime } from 'luxon'
 import { epochMsField } from './helpers.js'
 import { STAT_INTERVALS } from '../constants/intervals.js'
 
@@ -9,5 +10,33 @@ export const StatValidator = vine.compile(
     fromDate: epochMsField().optional(),
     toDate: epochMsField().optional(),
     interval: vine.enum(STAT_INTERVALS).optional(),
+  })
+)
+
+/**
+ * Le fuseau part directement dans `AT TIME ZONE` et entre dans la clé de cache :
+ * un identifiant inconnu ferait remonter une erreur Postgres en 500. On tranche
+ * donc en amont, avec la base de données de fuseaux de Luxon.
+ */
+const ianaTimezoneRule = vine.createRule((value: unknown, _options: undefined, field) => {
+  if (typeof value !== 'string') return
+  if (!DateTime.local().setZone(value).isValid) {
+    field.report('The {{ field }} field must be a valid IANA time zone', 'ianaTimezone', field)
+  }
+})
+
+export const DailyRhythmValidator = vine.compile(
+  vine.object({
+    server_id: vine.number(),
+    days: vine
+      .number()
+      .min(1)
+      .max(730)
+      .parse((value) => value ?? 30),
+    timezone: vine
+      .string()
+      .maxLength(64)
+      .use(ianaTimezoneRule())
+      .parse((value) => value ?? 'UTC'),
   })
 )

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -104,6 +104,10 @@ router
       .use('*', throttleLight('servers.stats', 40))
 
     router
+      .get('servers/:server_id/stats/daily-rhythm', '#controllers/stats_controller.dailyRhythm')
+      .use([throttleLight('servers.stats.rhythm', 40), PUBLIC_STATS])
+
+    router
       .get('global-stats', '#controllers/stats_controller.globalStats')
       .use([throttleLight('global-stats', 40), PUBLIC_STATS])
 

--- a/backend/tests/functional/daily_rhythm.spec.ts
+++ b/backend/tests/functional/daily_rhythm.spec.ts
@@ -1,0 +1,210 @@
+import Server from '#models/server'
+import StatsService from '#services/stat_service'
+import testUtils from '@adonisjs/core/services/test_utils'
+import Database from '@adonisjs/lucid/services/db'
+import { test } from '@japa/runner'
+import { DateTime } from 'luxon'
+
+const PARIS = 'Europe/Paris'
+
+async function createServer() {
+  return Server.create({
+    name: 'Test Rhythm Server',
+    address: 'rhythm.test.example.com',
+    port: 25565,
+    type: 'java',
+  })
+}
+
+/**
+ * Sème un relevé par demi-heure sur `days` jours pleins, en heure de Paris, avec
+ * un profil journalier marqué : creux la nuit, pic en soirée. `playersAt` reste
+ * la seule source du profil attendu, pour que les assertions ne recopient pas la
+ * logique du service.
+ */
+function playersAt(hour: number) {
+  if (hour >= 20 && hour < 23) return 500
+  if (hour >= 2 && hour < 6) return 20
+  return 100
+}
+
+async function seedStats(serverId: number, days: number, endsAt: DateTime) {
+  const rows: Record<string, unknown>[] = []
+
+  for (let halfHour = 0; halfHour < days * 48; halfHour++) {
+    const at = endsAt.minus({ minutes: 30 * (halfHour + 1) })
+    rows.push({
+      server_id: serverId,
+      player_count: playersAt(at.hour),
+      max_count: 1000,
+      created_at: at.toSQL(),
+    })
+  }
+
+  await Database.table('server_stats').multiInsert(rows)
+}
+
+test.group('Daily rhythm', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('replie l’historique sur 48 créneaux dans le fuseau demandé', async ({ assert }) => {
+    const server = await createServer()
+    const endsAt = DateTime.now().setZone(PARIS).startOf('day')
+    await seedStats(server.id, 10, endsAt)
+
+    const rhythm = await StatsService.getDailyRhythm({
+      server_id: server.id,
+      days: 12,
+      timezone: PARIS,
+    })
+
+    assert.equal(rhythm.slotMinutes, 30)
+    assert.equal(rhythm.series.all.length, 48)
+    assert.equal(rhythm.timezone, PARIS)
+
+    // 21 h 00 en heure de Paris = créneau 42, et non ce que dirait une lecture UTC.
+    const evening = rhythm.series.all.find((slot) => slot.slot === 42)
+    const night = rhythm.series.all.find((slot) => slot.slot === 8)
+
+    assert.equal(evening?.playerCount, 500)
+    assert.equal(evening?.minuteOfDay, 1260)
+    assert.equal(night?.playerCount, 20)
+  })
+
+  test('compte les jours distincts, pas les relevés', async ({ assert }) => {
+    const server = await createServer()
+    await seedStats(server.id, 10, DateTime.now().setZone(PARIS).startOf('day'))
+
+    const rhythm = await StatsService.getDailyRhythm({
+      server_id: server.id,
+      days: 12,
+      timezone: PARIS,
+    })
+
+    const slot = rhythm.series.all.find((entry) => entry.slot === 42)
+    assert.equal(slot?.daysCount, 10)
+    assert.equal(slot?.samplesCount, 10)
+    assert.equal(rhythm.daysObserved.all, 10)
+  })
+
+  test('sépare semaine et week-end sur le calendrier local', async ({ assert }) => {
+    const server = await createServer()
+    // 14 jours pleins couvrent exactement deux week-ends, où qu’on démarre.
+    await seedStats(server.id, 14, DateTime.now().setZone(PARIS).startOf('day'))
+
+    const rhythm = await StatsService.getDailyRhythm({
+      server_id: server.id,
+      days: 16,
+      timezone: PARIS,
+    })
+
+    assert.equal(rhythm.daysObserved.weekend, 4)
+    assert.equal(rhythm.daysObserved.weekday, 10)
+    assert.equal(rhythm.daysObserved.all, 14)
+    assert.equal(rhythm.series.weekend.length, 48)
+  })
+
+  test('décale les créneaux quand le fuseau change', async ({ assert }) => {
+    const server = await createServer()
+    await seedStats(server.id, 10, DateTime.now().setZone(PARIS).startOf('day'))
+
+    const paris = await StatsService.getDailyRhythm({
+      server_id: server.id,
+      days: 12,
+      timezone: PARIS,
+    })
+    const utc = await StatsService.getDailyRhythm({
+      server_id: server.id,
+      days: 12,
+      timezone: 'UTC',
+    })
+
+    const parisPeak = paris.series.all.find((slot) => slot.playerCount === 500)!
+    const utcPeak = utc.series.all.find((slot) => slot.playerCount === 500)!
+    const offsetSlots = DateTime.now().setZone(PARIS).offset / 30
+
+    assert.equal(utcPeak.slot, parisPeak.slot - offsetSlots)
+  })
+
+  test('bascule sur le rollup horaire au-delà d’un mois de fenêtre', async ({ assert }) => {
+    const server = await createServer()
+    const endsAt = DateTime.now().setZone(PARIS).startOf('day')
+    const rows: Record<string, unknown>[] = []
+
+    for (let hour = 0; hour < 40 * 24; hour++) {
+      const at = endsAt.minus({ hours: hour + 1 })
+      rows.push({
+        server_id: server.id,
+        hour: at.toSQL(),
+        avg_player_count: playersAt(at.hour),
+        peak_player_count: playersAt(at.hour) * 2,
+        min_player_count: 0,
+        max_slot_count: 1000,
+        samples_count: 6,
+      })
+    }
+    await Database.table('server_stats_hourly').multiInsert(rows)
+
+    const rhythm = await StatsService.getDailyRhythm({
+      server_id: server.id,
+      days: 40,
+      timezone: PARIS,
+    })
+
+    // Le rollup ne descend pas sous l'heure : 24 créneaux, pas 48.
+    assert.equal(rhythm.slotMinutes, 60)
+    assert.equal(rhythm.series.all.length, 24)
+
+    const evening = rhythm.series.all.find((slot) => slot.slot === 21)
+    assert.equal(evening?.playerCount, 500)
+    assert.equal(evening?.peakPlayerCount, 1000)
+    assert.equal(evening?.minuteOfDay, 1260)
+    assert.equal(evening?.daysCount, 40)
+  })
+
+  test('ne renvoie aucun créneau pour un serveur sans relevé', async ({ assert }) => {
+    const server = await createServer()
+
+    const rhythm = await StatsService.getDailyRhythm({
+      server_id: server.id,
+      days: 30,
+      timezone: PARIS,
+    })
+
+    assert.lengthOf(rhythm.series.all, 0)
+    assert.equal(rhythm.daysObserved.all, 0)
+  })
+
+  test('expose la journée type sur l’API publique', async ({ client, assert }) => {
+    const server = await createServer()
+    await seedStats(server.id, 10, DateTime.now().setZone(PARIS).startOf('day'))
+
+    const response = await client
+      .get(`/api/v1/servers/${server.id}/stats/daily-rhythm`)
+      .qs({ days: 12, timezone: PARIS })
+
+    response.assertStatus(200)
+    assert.equal(response.body().slotMinutes, 30)
+    assert.lengthOf(response.body().series.all, 48)
+  })
+
+  test('refuse un fuseau horaire inconnu (422)', async ({ client }) => {
+    const server = await createServer()
+
+    const response = await client
+      .get(`/api/v1/servers/${server.id}/stats/daily-rhythm`)
+      .qs({ timezone: 'Mars/Olympus_Mons' })
+
+    response.assertStatus(422)
+  })
+
+  test('refuse une fenêtre au-delà du plafond (422)', async ({ client }) => {
+    const server = await createServer()
+
+    const response = await client
+      .get(`/api/v1/servers/${server.id}/stats/daily-rhythm`)
+      .qs({ days: 5000, timezone: PARIS })
+
+    response.assertStatus(422)
+  })
+})

--- a/frontend/messages/en/stats.json
+++ b/frontend/messages/en/stats.json
@@ -41,5 +41,45 @@
     "average": "Average",
     "peak": "Peak",
     "peakGlobal": "Peak (sum per server)"
+  },
+  "rhythm": {
+    "title": "Typical day",
+    "subtitle": "The history folded onto 24 hours, to see when this server is alive.",
+    "dayType": {
+      "ariaLabel": "Days included",
+      "all": "All days",
+      "weekday": "Weekdays",
+      "weekend": "Weekends"
+    },
+    "summary": {
+      "lead": "The server is busiest from <b>{from}</b> to <b>{to}</b>.",
+      "detailAverage": "<b>{peak}</b> players on average around {peakAt}, against <b>{low}</b> at the {lowAt} lull.",
+      "detailPeak": "<b>{peak}</b> players at peak around {peakAt}, against <b>{low}</b> at the {lowAt} lull.",
+      "flatLead": "This server has no distinct rush hour.",
+      "flatDetail": "Its player count stays in the same range around the clock."
+    },
+    "slot": {
+      "leadAverage": "<b>{time}</b> · <b>{count}</b> players on average",
+      "leadPeak": "<b>{time}</b> · <b>{count}</b> players at peak",
+      "detailAverage": "Up to <b>{other}</b> at peak, across {days, plural, one {# recorded day} other {# recorded days}}.",
+      "detailPeak": "<b>{other}</b> on average, across {days, plural, one {# recorded day} other {# recorded days}}.",
+      "emptyLead": "<b>{time}</b> · nothing recorded",
+      "emptyDetail": "The server answered no ping in this slot."
+    },
+    "bracket": "Busiest {from} – {to}",
+    "now": "now",
+    "footnote": "{days, plural, one {# day observed} other {# days observed}} · {minutes}-minute slots · {timezone}",
+    "stripAria": "Player count by slot. Use the left and right arrows to move through the day.",
+    "table": {
+      "caption": "Player count by slot",
+      "slot": "Slot",
+      "average": "Average",
+      "peak": "Highest recorded"
+    },
+    "empty": {
+      "title": "No typical day yet",
+      "description": "It takes at least {min} days of records to draw one. This server has {count, plural, =0 {none} one {one} other {#}}."
+    },
+    "error": "The typical day could not load. It will come back on the next refresh."
   }
 }

--- a/frontend/messages/fr/stats.json
+++ b/frontend/messages/fr/stats.json
@@ -41,5 +41,45 @@
     "average": "Moyenne",
     "peak": "Pic",
     "peakGlobal": "Pic (somme par serveur)"
+  },
+  "rhythm": {
+    "title": "Journée type",
+    "subtitle": "L'historique replié sur 24 h, pour voir quand ce serveur est vivant.",
+    "dayType": {
+      "ariaLabel": "Jours pris en compte",
+      "all": "Tous les jours",
+      "weekday": "Semaine",
+      "weekend": "Week-end"
+    },
+    "summary": {
+      "lead": "Le serveur est au plus haut de <b>{from}</b> à <b>{to}</b>.",
+      "detailAverage": "<b>{peak}</b> joueurs en moyenne vers {peakAt}, contre <b>{low}</b> au creux de {lowAt}.",
+      "detailPeak": "<b>{peak}</b> joueurs au plus haut vers {peakAt}, contre <b>{low}</b> au creux de {lowAt}.",
+      "flatLead": "Ce serveur n'a pas d'heure de pointe marquée.",
+      "flatDetail": "L'affluence reste du même ordre tout au long des 24 h."
+    },
+    "slot": {
+      "leadAverage": "<b>{time}</b> · <b>{count}</b> joueurs en moyenne",
+      "leadPeak": "<b>{time}</b> · <b>{count}</b> joueurs au plus haut",
+      "detailAverage": "Jusqu'à <b>{other}</b> au plus haut, sur {days, plural, one {# jour relevé} other {# jours relevés}}.",
+      "detailPeak": "<b>{other}</b> en moyenne, sur {days, plural, one {# jour relevé} other {# jours relevés}}.",
+      "emptyLead": "<b>{time}</b> · aucun relevé",
+      "emptyDetail": "Le serveur n'a répondu à aucun ping sur ce créneau."
+    },
+    "bracket": "Pleine affluence {from} – {to}",
+    "now": "maintenant",
+    "footnote": "{days, plural, one {# jour observé} other {# jours observés}} · créneaux de {minutes} min · {timezone}",
+    "stripAria": "Affluence par créneau. Flèches gauche et droite pour parcourir la journée.",
+    "table": {
+      "caption": "Affluence par créneau",
+      "slot": "Créneau",
+      "average": "Moyenne",
+      "peak": "Plus haut relevé"
+    },
+    "empty": {
+      "title": "Pas encore de journée type",
+      "description": "Il faut au moins {min} jours de relevés pour la dessiner. Ce serveur en a {count, plural, =0 {aucun} one {un} other {#}}."
+    },
+    "error": "La journée type n'a pas pu être chargée. Elle réapparaîtra au prochain rafraîchissement."
   }
 }

--- a/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
@@ -13,6 +13,7 @@ import {
 import { AgCharts } from "ag-charts-react";
 
 import { ServerData } from "@/app/[locale]/(pages)/(index)/page";
+import { DailyRhythm } from "@/components/stats/daily-rhythm";
 import { axisTimeFormat, DEFAULT_PERIOD, effectiveResolution, Period, toStatsQuery } from "@/components/stats/period";
 import { PeriodPicker } from "@/components/stats/period-picker";
 import { SeriesMode, SeriesModeToggle } from "@/components/stats/series-mode-toggle";
@@ -376,6 +377,10 @@ const ServerPage = () => {
             <AgCharts options={options} className="h-full w-full" />
           </div>
         </div>
+
+        {/* Même donnée, même période, repliée sur une journée : la chronologie dit
+            comment le serveur évolue, la bande dit à quelle heure il se remplit. */}
+        <DailyRhythm serverId={Number(serverId)} period={period} seriesMode={seriesMode} />
       </section>
 
       <ImprovedCard

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -73,6 +73,15 @@
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
   --animate-spin-slow: spin-slow 1.5s linear infinite;
+  /* Balayage de la bande « journée type » : la lecture va de minuit à minuit,
+     le tracé aussi. Le décalage par colonne est posé en style inline. */
+  --animate-rhythm-rise: rhythm-rise 400ms cubic-bezier(0.22, 1, 0.36, 1) backwards;
+
+  @keyframes rhythm-rise {
+    from {
+      transform: scaleY(0);
+    }
+  }
 
   @keyframes accordion-down {
     from {

--- a/frontend/src/components/stats/daily-rhythm.tsx
+++ b/frontend/src/components/stats/daily-rhythm.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import { Spinner } from "@/components/ui/spinner";
+import { getServerDailyRhythm } from "@/http/server";
+import { cn } from "@/lib/utils";
+import { DayType } from "@/types/server";
+import { useFormatter, useTranslations } from "next-intl";
+import { KeyboardEvent, ReactNode, useState, useSyncExternalStore } from "react";
+import useSWR from "swr";
+import { Period, periodRangeDays } from "./period";
+import {
+  densify,
+  extremes,
+  MAX_RHYTHM_DAYS,
+  MIN_RHYTHM_DAYS,
+  primeSegments,
+  primeWindow,
+} from "./rhythm";
+import { Segmented } from "./segmented";
+import { SeriesMode } from "./series-mode-toggle";
+
+const DAY_TYPES: readonly DayType[] = ["all", "weekday", "weekend"];
+const MINUTES_PER_DAY = 24 * 60;
+const RULER_HOURS = [0, 6, 12, 18, 24];
+const CURSOR_STEPS: Record<string, number> = { ArrowRight: 1, ArrowLeft: -1 };
+
+/** Les bornes du cadran tombent sur les bords de la bande : elles s'alignent dessus. */
+const TICK_OFFSET: Record<number, string> = { 0: "", 24: "-translate-x-full" };
+
+/** Position — ou largeur — exprimée en part de journée, pour la bande comme pour la règle. */
+const atMinute = (minute: number) => `${(minute / MINUTES_PER_DAY) * 100}%`;
+
+/*
+ * Fuseau du lecteur et heure courante sont deux états extérieurs à React, et tous
+ * deux absents du rendu serveur — d'où l'instantané `null` côté serveur, qui évite
+ * de faire diverger le HTML de l'hydratation.
+ */
+const subscribeNever = () => () => {};
+const readTimezone = () => Intl.DateTimeFormat().resolvedOptions().timeZone;
+const readNothing = () => null;
+
+const subscribeToMinute = (onChange: () => void) => {
+  const id = window.setInterval(onChange, 60_000);
+  return () => window.clearInterval(id);
+};
+const readNowMinutes = () => {
+  const now = new Date();
+  return now.getHours() * 60 + now.getMinutes();
+};
+
+interface DailyRhythmProps {
+  serverId: number;
+  period: Period;
+  seriesMode: SeriesMode;
+}
+
+/**
+ * L'historique du serveur replié sur 24 h : chaque créneau porte la moyenne des
+ * relevés tombés à cette heure-là. La chronologie du dessus dit comment le serveur
+ * évolue ; cette bande dit *quand* il est vivant.
+ *
+ * Le survol — ou les flèches — réécrit la ligne de lecture au-dessus de la bande
+ * plutôt que d'ouvrir une infobulle : ça se place toujours bien, ça marche au
+ * doigt, et la phrase par défaut répond déjà à la question qu'on vient poser.
+ */
+export const DailyRhythm = ({ serverId, period, seriesMode }: DailyRhythmProps) => {
+  const t = useTranslations("Stats");
+  const format = useFormatter();
+  const [dayType, setDayType] = useState<DayType>("all");
+  const [rawCursor, setCursor] = useState<number | null>(null);
+  const timezone = useSyncExternalStore(subscribeNever, readTimezone, readNothing);
+  const nowMinutes = useSyncExternalStore(subscribeToMinute, readNowMinutes, readNothing);
+
+  const days = periodRangeDays(period) ?? MAX_RHYTHM_DAYS;
+  const { data, error, isLoading } = useSWR(
+    timezone ? (["server-rhythm", serverId, days, timezone] as const) : null,
+    ([, id, rangeDays, zone]) => getServerDailyRhythm(id, rangeDays, zone),
+    { refreshInterval: 1000 * 60 * 10 }
+  );
+
+  const slotMinutes = data?.slotMinutes ?? 30;
+  const slotCount = MINUTES_PER_DAY / slotMinutes;
+  // Changer de période peut faire passer la bande de 48 à 24 créneaux : un curseur
+  // hérité de la granularité précédente ne désigne alors plus rien.
+  const cursor = rawCursor !== null && rawCursor < slotCount ? rawCursor : null;
+
+  const slots = densify(data?.series[dayType] ?? [], slotCount);
+  const values = slots.map((slot) => {
+    if (!slot) return null;
+    return seriesMode === "peak" ? slot.peakPlayerCount : slot.playerCount;
+  });
+  const max = Math.max(0, ...values.filter((value): value is number => value !== null));
+  const observed = data?.daysObserved[dayType] ?? 0;
+
+  const bold = { b: (chunks: ReactNode) => <b className="font-semibold text-foreground">{chunks}</b> };
+  // Les bornes d'une plage tombent une fois sur deux sur la demi-heure : les afficher
+  // à l'heure pleine décalerait l'étiquette de 30 min par rapport au crochet tracé.
+  const timeLabel = (minute: number) =>
+    format.dateTime(new Date(2000, 0, 1, Math.floor(minute / 60) % 24, minute % 60), {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  /** Réservé aux graduations, qui tombent toujours sur une heure pleine. */
+  const hourLabel = (hour: number) =>
+    format.dateTime(new Date(2000, 0, 1, hour % 24), { hour: "numeric" });
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const step = CURSOR_STEPS[event.key];
+    if (step !== undefined) {
+      event.preventDefault();
+      setCursor((current) => ((current ?? 0) + step + slotCount) % slotCount);
+      return;
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      setCursor(0);
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      setCursor(slotCount - 1);
+    }
+    if (event.key === "Escape") setCursor(null);
+  };
+
+  const header = (
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <h3 className="text-xs font-bold uppercase tracking-[0.09em] text-foreground">
+          {t("rhythm.title")}
+        </h3>
+        <p className="mt-1 text-xs text-muted-foreground">{t("rhythm.subtitle")}</p>
+      </div>
+      <Segmented
+        value={dayType}
+        onChange={setDayType}
+        ariaLabel={t("rhythm.dayType.ariaLabel")}
+        options={DAY_TYPES.map((value) => ({ value, label: t(`rhythm.dayType.${value}`) }))}
+      />
+    </div>
+  );
+
+  const frame = (children: ReactNode) => (
+    <section className="border-t border-border px-6 py-5">
+      {header}
+      {children}
+    </section>
+  );
+
+  if (error) {
+    return frame(<p className="mt-6 text-sm text-muted-foreground">{t("rhythm.error")}</p>);
+  }
+
+  if (!data || isLoading) {
+    return frame(
+      <div className="mt-6 flex h-44 items-center justify-center">
+        <Spinner size="md" />
+      </div>
+    );
+  }
+
+  if (observed < MIN_RHYTHM_DAYS) {
+    return frame(
+      <div className="mt-6 rounded-lg border border-dashed border-border px-5 py-8 text-center">
+        <p className="text-sm font-medium text-foreground">{t("rhythm.empty.title")}</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {t("rhythm.empty.description", { min: MIN_RHYTHM_DAYS, count: observed })}
+        </p>
+      </div>
+    );
+  }
+
+  const prime = primeWindow(values);
+  const { highest, lowest } = extremes(values);
+  const hovered = cursor === null ? null : slots[cursor];
+
+  const readout = () => {
+    if (cursor !== null && !hovered) {
+      return {
+        lead: t.rich("rhythm.slot.emptyLead", { time: timeLabel(cursor * slotMinutes), ...bold }),
+        detail: t("rhythm.slot.emptyDetail"),
+      };
+    }
+    if (cursor !== null && hovered) {
+      const shown = seriesMode === "peak" ? hovered.peakPlayerCount : hovered.playerCount;
+      const other = seriesMode === "peak" ? hovered.playerCount : hovered.peakPlayerCount;
+      return {
+        lead: t.rich(seriesMode === "peak" ? "rhythm.slot.leadPeak" : "rhythm.slot.leadAverage", {
+          time: timeLabel(hovered.minuteOfDay),
+          count: format.number(shown),
+          ...bold,
+        }),
+        detail: t.rich(
+          seriesMode === "peak" ? "rhythm.slot.detailPeak" : "rhythm.slot.detailAverage",
+          { other: format.number(other), days: hovered.daysCount, ...bold }
+        ),
+      };
+    }
+
+    const lead = prime
+      ? t.rich("rhythm.summary.lead", {
+          from: timeLabel(prime.start * slotMinutes),
+          to: timeLabel((prime.end + 1) * slotMinutes),
+          ...bold,
+        })
+      : t("rhythm.summary.flatLead");
+
+    if (highest === null || lowest === null) return { lead, detail: t("rhythm.summary.flatDetail") };
+
+    return {
+      lead,
+      detail: t.rich(
+        seriesMode === "peak" ? "rhythm.summary.detailPeak" : "rhythm.summary.detailAverage",
+        {
+          peak: format.number(values[highest]!),
+          peakAt: timeLabel(highest * slotMinutes),
+          low: format.number(values[lowest]!),
+          lowAt: timeLabel(lowest * slotMinutes),
+          ...bold,
+        }
+      ),
+    };
+  };
+
+  const { lead, detail } = readout();
+  const nowHour = nowMinutes === null ? null : nowMinutes / 60;
+
+  return frame(
+    <>
+      <div className="mt-5 min-h-14" aria-live="polite">
+        <p className="text-[15px] font-medium leading-snug text-foreground tabular-nums">{lead}</p>
+        <p className="mt-0.5 text-[13px] leading-snug text-muted-foreground tabular-nums">{detail}</p>
+      </div>
+
+      <div className="relative mt-4 pt-6">
+        {prime &&
+          primeSegments(prime, slotCount).map((segment) => (
+            <div
+              key={segment.start}
+              aria-hidden
+              className="pointer-events-none absolute top-1.5 h-2.5 rounded-t-[3px] border border-b-0 border-foreground/25"
+              style={{
+                left: atMinute(segment.start * slotMinutes),
+                width: atMinute((segment.end - segment.start + 1) * slotMinutes),
+              }}
+            >
+              {segment.labelled && (
+                <span className="absolute -top-2 left-1/2 -translate-x-1/2 whitespace-nowrap bg-card px-2 text-[11px] font-semibold text-foreground">
+                  {t("rhythm.bracket", {
+                    from: timeLabel(prime.start * slotMinutes),
+                    to: timeLabel((prime.end + 1) * slotMinutes),
+                  })}
+                </span>
+              )}
+            </div>
+          ))}
+
+        <div
+          role="group"
+          tabIndex={0}
+          aria-label={t("rhythm.stripAria")}
+          onKeyDown={onKeyDown}
+          onPointerLeave={() => setCursor(null)}
+          onBlur={() => setCursor(null)}
+          className="grid h-28 items-end gap-0.5 border-b border-border focus-visible:ring-2 focus-visible:ring-ring sm:h-36"
+          style={{ gridTemplateColumns: `repeat(${slotCount}, minmax(0, 1fr))` }}
+        >
+          {values.map((value, index) => (
+            <div
+              key={index}
+              className="relative flex h-full items-end"
+              onPointerEnter={() => setCursor(index)}
+            >
+              {value === null ? (
+                <div className="h-[3px] w-full rounded-xs bg-muted-foreground/25" />
+              ) : (
+                <div
+                  className={cn(
+                    "min-h-0.5 w-full origin-bottom rounded-t-xs",
+                    "animate-rhythm-rise motion-reduce:animate-none",
+                    cursor === index ? "bg-foreground" : "bg-accent"
+                  )}
+                  style={{
+                    height: `${max > 0 ? (value / max) * 100 : 0}%`,
+                    animationDelay: `${index * 6}ms`,
+                  }}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+
+        {nowMinutes !== null && (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute bottom-0 top-6 border-l border-dashed border-foreground/70"
+            style={{ left: atMinute(nowMinutes) }}
+          />
+        )}
+      </div>
+
+      <div className="relative h-7">
+        {RULER_HOURS.map((hour) => (
+          <span
+            key={hour}
+            className={cn(
+              "absolute top-0 pt-1.5 font-mono text-[11px] text-muted-foreground",
+              TICK_OFFSET[hour] ?? "-translate-x-1/2",
+              nowHour !== null && Math.abs(nowHour - hour) < 1.5 && "invisible"
+            )}
+            style={{ left: atMinute(hour * 60) }}
+          >
+            {hourLabel(hour)}
+          </span>
+        ))}
+        {nowMinutes !== null && (
+          <span
+            className="absolute top-1 -translate-x-1/2 whitespace-nowrap text-[10px] font-bold uppercase tracking-wider text-foreground"
+            style={{ left: atMinute(nowMinutes) }}
+          >
+            {t("rhythm.now")}
+          </span>
+        )}
+      </div>
+
+      <p className="mt-2 text-[11px] text-muted-foreground tabular-nums">
+        {t("rhythm.footnote", {
+          days: observed,
+          minutes: slotMinutes,
+          timezone: data.timezone,
+        })}
+      </p>
+
+      <table className="sr-only">
+        <caption>{t("rhythm.table.caption")}</caption>
+        <thead>
+          <tr>
+            <th>{t("rhythm.table.slot")}</th>
+            <th>{t("rhythm.table.average")}</th>
+            <th>{t("rhythm.table.peak")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {slots.map((slot, index) => (
+            <tr key={index}>
+              <td>{timeLabel(index * slotMinutes)}</td>
+              <td>{slot ? format.number(slot.playerCount) : "—"}</td>
+              <td>{slot ? format.number(slot.peakPlayerCount) : "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+};

--- a/frontend/src/components/stats/period.ts
+++ b/frontend/src/components/stats/period.ts
@@ -52,6 +52,12 @@ export function periodRangeMs(period: Period): number | null {
   return period.preset === "all" ? null : PRESET_RANGE_MS[period.preset];
 }
 
+/** Durée couverte en jours entiers, ou `null` pour « Tout » — même réserve que ci-dessus. */
+export function periodRangeDays(period: Period): number | null {
+  const rangeMs = periodRangeMs(period);
+  return rangeMs === null ? null : Math.max(1, Math.round(rangeMs / DAY));
+}
+
 /**
  * Résolution automatique : la plus fine qui reste lisible sur la plage, et qui
  * ne fait pas basculer la requête sur la table brute pour rien (les buckets

--- a/frontend/src/components/stats/rhythm.test.ts
+++ b/frontend/src/components/stats/rhythm.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { DailyRhythmSlot } from "@/types/server";
+import { densify, extremes, primeSegments, primeWindow } from "./rhythm";
+
+const slot = (index: number, playerCount: number): DailyRhythmSlot => ({
+  slot: index,
+  minuteOfDay: index * 30,
+  playerCount,
+  peakPlayerCount: playerCount * 2,
+  minPlayerCount: 0,
+  samplesCount: 90,
+  daysCount: 30,
+});
+
+/** Journée à 48 créneaux dont seuls ceux listés portent une valeur. */
+const day = (values: Record<number, number>) => {
+  const dense: (number | null)[] = Array.from({ length: 48 }, () => 0);
+  for (const [index, value] of Object.entries(values)) dense[Number(index)] = value;
+  return dense;
+};
+
+describe("densify", () => {
+  it("garde les 24 h de large quand des créneaux manquent", () => {
+    const dense = densify([slot(0, 10), slot(47, 20)], 48);
+
+    expect(dense).toHaveLength(48);
+    expect(dense[0]?.playerCount).toBe(10);
+    expect(dense[47]?.playerCount).toBe(20);
+    expect(dense[24]).toBeNull();
+  });
+
+  it("ignore un créneau hors du cadran plutôt que d'étendre la bande", () => {
+    expect(densify([slot(99, 10)], 48).every((entry) => entry === null)).toBe(true);
+  });
+});
+
+describe("primeWindow", () => {
+  it("retient la plage contiguë la plus longue au-dessus du seuil", () => {
+    // Un creux isolé à 100 et une soirée pleine de 40 à 45.
+    const values = day({ 10: 100, 40: 95, 41: 96, 42: 100, 43: 99, 44: 90, 45: 85 });
+
+    expect(primeWindow(values)).toEqual({ start: 40, end: 45 });
+  });
+
+  it("recolle une pleine affluence qui enjambe minuit", () => {
+    const values = day({ 46: 90, 47: 100, 0: 95, 1: 85 });
+
+    expect(primeWindow(values)).toEqual({ start: 46, end: 49 });
+  });
+
+  it("ne retient rien quand l'affluence est plate sur les 24 h", () => {
+    expect(primeWindow(Array.from({ length: 48 }, () => 100))).toBeNull();
+  });
+
+  it("ne retient rien quand aucun créneau n'a de joueur", () => {
+    expect(primeWindow(Array.from({ length: 48 }, () => 0))).toBeNull();
+    expect(primeWindow(Array.from({ length: 48 }, () => null))).toBeNull();
+  });
+
+  it("traite un créneau sans relevé comme une coupure, pas comme un creux", () => {
+    const values = day({ 20: 100, 22: 100 });
+    values[21] = null;
+
+    expect(primeWindow(values)).toEqual({ start: 20, end: 20 });
+  });
+});
+
+describe("primeSegments", () => {
+  it("laisse une plage ordinaire en un seul morceau étiqueté", () => {
+    expect(primeSegments({ start: 38, end: 46 }, 48)).toEqual([
+      { start: 38, end: 46, labelled: true },
+    ]);
+  });
+
+  it("coupe à minuit et n'étiquette que le plus large des deux morceaux", () => {
+    expect(primeSegments({ start: 45, end: 49 }, 48)).toEqual([
+      { start: 45, end: 47, labelled: true },
+      { start: 0, end: 1, labelled: false },
+    ]);
+  });
+});
+
+describe("extremes", () => {
+  it("renvoie le meilleur et le pire créneau relevé", () => {
+    const values = day({ 5: 12, 20: 300, 44: 180 });
+
+    expect(extremes(values)).toEqual({ highest: 20, lowest: 0 });
+  });
+
+  it("ignore les créneaux sans relevé au lieu de les compter à zéro", () => {
+    const values: (number | null)[] = Array.from({ length: 48 }, () => null);
+    values[10] = 40;
+    values[30] = 90;
+
+    expect(extremes(values)).toEqual({ highest: 30, lowest: 10 });
+  });
+
+  it("ne renvoie rien sur une journée entièrement vide", () => {
+    expect(extremes(Array.from({ length: 48 }, () => null))).toEqual({
+      highest: null,
+      lowest: null,
+    });
+  });
+});

--- a/frontend/src/components/stats/rhythm.ts
+++ b/frontend/src/components/stats/rhythm.ts
@@ -1,0 +1,108 @@
+/**
+ * Lecture de la « journée type » : ce que la bande dit, indépendamment de la
+ * façon dont elle est tracée. L'API renvoie des créneaux indexés depuis minuit
+ * dans le fuseau du lecteur — 48 de 30 min sur les fenêtres courtes, 24 d'une
+ * heure au-delà (cf. `slotMinutes`).
+ */
+
+import { DailyRhythmSlot } from "@/types/server";
+
+/** En deçà, la moyenne ne porte qu'un jour ou deux : la journée type mentirait. */
+export const MIN_RHYTHM_DAYS = 3;
+
+/** Plafond de l'API — sert de repli quand la période choisie est « Tout ». */
+export const MAX_RHYTHM_DAYS = 730;
+
+/** Part du meilleur créneau au-dessus de laquelle on parle de pleine affluence. */
+const PRIME_THRESHOLD = 0.8;
+
+export interface PrimeWindow {
+  start: number;
+  /** Peut dépasser le dernier index : la plage enjambe alors minuit. */
+  end: number;
+}
+
+/**
+ * Rend la série dense sur 24 h. L'API omet les créneaux sans aucun relevé ; les
+ * garder implicites décalerait la bande, et 4 h du matin se retrouverait tracée
+ * à la place de midi.
+ */
+export function densify(slots: DailyRhythmSlot[], slotCount: number): (DailyRhythmSlot | null)[] {
+  const dense: (DailyRhythmSlot | null)[] = Array.from({ length: slotCount }, () => null);
+
+  for (const slot of slots) {
+    if (slot.slot >= 0 && slot.slot < slotCount) dense[slot.slot] = slot;
+  }
+  return dense;
+}
+
+/**
+ * Plage contiguë la plus longue où l'affluence reste au-dessus du seuil de pleine
+ * affluence, ou `null` si le serveur n'a pas d'heure de pointe marquée.
+ *
+ * La recherche court sur deux journées bout à bout : un serveur dont le pic
+ * enjambe minuit — le cas dès qu'on regarde un serveur d'un autre fuseau — a une
+ * seule pleine affluence, pas deux morceaux collés aux bords de la bande.
+ */
+export function primeWindow(values: (number | null)[]): PrimeWindow | null {
+  const known = values.filter((value): value is number => value !== null);
+  const max = known.length > 0 ? Math.max(...known) : 0;
+  if (max <= 0) return null;
+
+  const floor = max * PRIME_THRESHOLD;
+  const count = values.length;
+  let best: PrimeWindow | null = null;
+  let start = -1;
+
+  for (let index = 0; index < count * 2; index++) {
+    const value = values[index % count];
+
+    if (value !== null && value >= floor) {
+      if (start === -1) start = index;
+      // Une plage qui fait le tour du cadran n'a pas de bornes à montrer.
+      if (index - start + 1 >= count) return null;
+      continue;
+    }
+
+    if (start === -1) continue;
+    // Les plages ouvertes au second tour ont déjà été relevées au premier.
+    if (start < count && (!best || index - start > best.end - best.start + 1)) {
+      best = { start, end: index - 1 };
+    }
+    start = -1;
+  }
+
+  return best;
+}
+
+/**
+ * Découpe la plage en segments traçables. Une plage qui enjambe minuit se dessine
+ * en deux morceaux ; l'étiquette va sur le plus large, pour ne pas la répéter.
+ */
+export function primeSegments(window: PrimeWindow, slotCount: number) {
+  if (window.end < slotCount) return [{ start: window.start, end: window.end, labelled: true }];
+
+  const tail = { start: window.start, end: slotCount - 1 };
+  const head = { start: 0, end: window.end - slotCount };
+  const tailIsLonger = tail.end - tail.start >= head.end - head.start;
+
+  return [
+    { ...tail, labelled: tailIsLonger },
+    { ...head, labelled: !tailIsLonger },
+  ];
+}
+
+/** Index du créneau le plus et le moins fréquenté, en ignorant ceux sans relevé. */
+export function extremes(values: (number | null)[]) {
+  let highest: number | null = null;
+  let lowest: number | null = null;
+
+  for (let index = 0; index < values.length; index++) {
+    const value = values[index];
+    if (value === null) continue;
+    if (highest === null || value > values[highest]!) highest = index;
+    if (lowest === null || value < values[lowest]!) lowest = index;
+  }
+
+  return { highest, lowest };
+}

--- a/frontend/src/components/stats/segmented.tsx
+++ b/frontend/src/components/stats/segmented.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface SegmentedProps<T extends string> {
+  value: T;
+  options: readonly { value: T; label: string }[];
+  onChange: (value: T) => void;
+  ariaLabel: string;
+}
+
+/**
+ * Sélecteur segmenté des en-têtes de graphique. Il n'existe que pour tenir
+ * ensemble les commandes qui cohabitent dans la même carte : dès qu'il y en a
+ * deux, un écart de padding ou de focus se voit immédiatement.
+ */
+export const Segmented = <T extends string>({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+}: SegmentedProps<T>) => (
+  <div
+    role="group"
+    aria-label={ariaLabel}
+    className="inline-flex h-9 items-center gap-0.5 rounded-md border border-border bg-secondary p-0.5"
+  >
+    {options.map((option) => (
+      <button
+        key={option.value}
+        type="button"
+        onClick={() => onChange(option.value)}
+        aria-pressed={value === option.value}
+        className={cn(
+          "rounded-sm px-2.5 py-1 text-xs font-medium transition-colors",
+          "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+          value === option.value
+            ? "bg-background text-foreground shadow-xs"
+            : "text-muted-foreground hover:text-foreground"
+        )}
+      >
+        {option.label}
+      </button>
+    ))}
+  </div>
+);

--- a/frontend/src/components/stats/series-mode-toggle.tsx
+++ b/frontend/src/components/stats/series-mode-toggle.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
+import { Segmented } from "./segmented";
 
 export const SERIES_MODES = ["average", "peak"] as const;
 export type SeriesMode = (typeof SERIES_MODES)[number];
@@ -21,28 +21,11 @@ export const SeriesModeToggle = ({ value, onChange }: SeriesModeToggleProps) => 
   const t = useTranslations("Stats");
 
   return (
-    <div
-      role="group"
-      aria-label={t("seriesMode.ariaLabel")}
-      className="inline-flex h-9 items-center gap-0.5 rounded-md border border-border bg-secondary p-0.5"
-    >
-      {SERIES_MODES.map((mode) => (
-        <button
-          key={mode}
-          type="button"
-          onClick={() => onChange(mode)}
-          aria-pressed={value === mode}
-          className={cn(
-            "rounded-sm px-2.5 py-1 text-xs font-medium transition-colors",
-            "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
-            value === mode
-              ? "bg-background text-foreground shadow-xs"
-              : "text-muted-foreground hover:text-foreground"
-          )}
-        >
-          {t(`seriesMode.${mode}`)}
-        </button>
-      ))}
-    </div>
+    <Segmented
+      value={value}
+      onChange={onChange}
+      ariaLabel={t("seriesMode.ariaLabel")}
+      options={SERIES_MODES.map((mode) => ({ value: mode, label: t(`seriesMode.${mode}`) }))}
+    />
   );
 };

--- a/frontend/src/http/server.ts
+++ b/frontend/src/http/server.ts
@@ -2,6 +2,7 @@ import {
   AdminOwnershipClaim,
   Category,
   ClaimStatus,
+  DailyRhythm,
   DnsInstructions,
   MotdInstructions,
   Server,
@@ -87,6 +88,13 @@ export const getServerStats = (
   if (interval) params.set("interval", interval);
 
   return apiFetch<ServerStat[]>(`/servers/${serverId}/stats?${params}`);
+};
+
+/** Journée type : l'historique replié sur 24 h, découpé dans le fuseau du lecteur. */
+export const getServerDailyRhythm = (serverId: number, days: number, timezone: string) => {
+  const params = new URLSearchParams({ days: String(days), timezone });
+
+  return apiFetch<DailyRhythm>(`/servers/${serverId}/stats/daily-rhythm?${params}`);
 };
 
 export const deleteServer = async (serverId: number, token: string) => {

--- a/frontend/src/types/server.ts
+++ b/frontend/src/types/server.ts
@@ -105,6 +105,35 @@ export interface ServerStat {
   createdAt: Date;
 }
 
+export type DayType = "all" | "weekday" | "weekend";
+
+/**
+ * Un créneau de la journée type. `slot` est indexé depuis minuit dans le fuseau
+ * demandé ; sa largeur est portée par `slotMinutes` de la réponse, pas par le type.
+ */
+export interface DailyRhythmSlot {
+  slot: number;
+  minuteOfDay: number;
+  /** Moyenne des relevés tombés sur ce créneau, tous jours confondus. */
+  playerCount: number;
+  peakPlayerCount: number;
+  minPlayerCount: number;
+  samplesCount: number;
+  /** Nombre de jours distincts ayant alimenté ce créneau. */
+  daysCount: number;
+}
+
+export interface DailyRhythm {
+  timezone: string;
+  /** 30 sur les fenêtres courtes (données brutes), 60 au-delà (rollup horaire). */
+  slotMinutes: number;
+  from: string;
+  to: string;
+  daysObserved: Record<DayType, number>;
+  /** Les créneaux sans aucun relevé sont absents — ce n'est pas « zéro joueur ». */
+  series: Record<DayType, DailyRhythmSlot[]>;
+}
+
 export interface ServerGrowthStat {
   serverId: number;
   weeklyGrowth: number | null;

--- a/mcp/src/config.ts
+++ b/mcp/src/config.ts
@@ -73,6 +73,7 @@ export const PUBLIC_ENDPOINTS: ReadonlySet<string> = new Set([
   'get /api/v1/servers/{id}',
   'get /api/v1/servers/{server_id}/categories',
   'get /api/v1/servers/{server_id}/stats',
+  'get /api/v1/servers/{server_id}/stats/daily-rhythm',
   'get /api/v1/global-stats',
   'get /api/v1/website-stats',
   'get /api/v1/categories',

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -8,3 +8,4 @@
 - [Pas de trailer Co-Authored-By](no-coauthor-trailer.md) — ne jamais ajouter d'attribution IA aux commits/PRs
 - [Architecture i18n](i18n-architecture.md) — FR/EN via next-intl (routing hybride domaine+préfixe, catalogue messages/<locale>/<feature>.json) + @adonisjs/i18n ; contenu BDD mono-langue
 - [Rollups stats & backfill](stats-rollups-backfill.md) — 3 paliers brut/horaire/journalier ; rejouer les backfills après toute migration de colonne, horaire AVANT journalier
+- [Base de dev locale](local-dev-database.md) — la commande docker de CLAUDE.md est fausse ; PostgreSQL natif déjà sur 5432, dump arrêté au 18/05/2026

--- a/memory/local-dev-database.md
+++ b/memory/local-dev-database.md
@@ -1,0 +1,30 @@
+---
+name: local-dev-database
+description: Comment atteindre la base de dev locale — la commande docker de CLAUDE.md ne marche pas
+metadata:
+  type: project
+---
+
+**La ligne « Local DB » de `CLAUDE.md` est fausse** : `docker compose --env-file ./.env.development up -d`
+échoue deux fois — `.env.development` n'existe pas (seulement `.env`), et surtout `backend/compose.yaml`
+est la **stack de prod** (images `sportek/*` pré-construites, réseau externe `dokploy-network`) qui ne
+contient **aucun service PostgreSQL**.
+
+La base de dev est un **PostgreSQL natif installé sur la machine**, déjà en écoute sur `0.0.0.0:5432`
+(`minecraft_stats` / `minecraft_stats` / base `minecraft_stats`, cf. `backend/.env`). Il n'y a rien à
+démarrer : `node ace migration:run` et `node ace test` s'y connectent directement.
+
+⚠️ Monter un conteneur Postgres sur le port 5432 **ne sert à rien et induit en erreur** : le Postgres
+natif tient déjà l'IPv4, Docker ne récupère que l'IPv6 (`::`), et l'application continue de parler au
+natif. Le `docker run -p 5432:5432` réussit sans que rien ne l'utilise.
+
+Redis n'est pas lancé en local. `CacheService` dégrade proprement (log `CACHE: read failed, fallback
+to fetcher`) et les tests passent — voir [[stats-rollups-backfill]] pour les paliers d'agrégation.
+
+**Le dump local est daté** : `server_stats` s'arrête au **18/05/2026**, avec un gros trou après
+juillet 2025 (4 relevés/serveur sur les 30 derniers jours du dump). Toute sonde ancrée sur `now()`
+tombe donc dans le vide — viser une fenêtre dense comme juin 2025 (~4 400 relevés/serveur).
+
+**Après tout `node ace`** (`migration:run`, `test`), le codegen réécrit `backend/database/schema.ts` et
+`backend/.adonisjs/server/controllers.ts` **sans formatage**, ce qui pollue le diff sans changer le
+contenu. Remettre en état avec `npx prettier --write` sur ces deux fichiers.


### PR DESCRIPTION
- Introduced a new component `DailyRhythm` to display server activity over a typical day.
- Added localization support for English and French in `stats.json` for the new feature.
- Updated the server API to fetch daily rhythm data with `getServerDailyRhythm`.
- Implemented utility functions for processing daily rhythm data, including `densify`, `primeWindow`, and `extremes`.
- Created a new segmented toggle component for selecting between average and peak player counts.
- Enhanced the global CSS with animations for the daily rhythm display.
- Added tests for the new rhythm-related functions to ensure correctness.
- Updated the documentation to reflect changes in local development setup and database access.