### PR TITLE
fix(docker): install corepack on node:26 images so yarn is available

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,10 @@ FROM node:26
 
 WORKDIR /home/node/app
 
+# Les images node:26 ne fournissent plus yarn ni corepack : on installe
+# corepack via npm puis on l'active pour obtenir le yarn épinglé (packageManager).
+RUN npm install -g corepack@latest && corepack enable
+
 # On copie le package.json et on installe les dépendances
 COPY package.json ./
 COPY yarn.lock ./

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,10 @@
 # syntax=docker.io/docker/dockerfile:1
 
 FROM node:26-alpine AS base
+# node:26 ne fournit plus yarn ni corepack : on installe corepack via npm puis
+# on l'active pour obtenir le yarn épinglé (packageManager). Fait dans `base`
+# pour que les étapes `deps` et `builder` en héritent.
+RUN npm install -g corepack@latest && corepack enable
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -7,7 +7,8 @@ FROM node:26-alpine AS builder
 
 WORKDIR /app
 
-RUN corepack enable
+# node:26 ne fournit plus corepack : on l'installe via npm avant de l'activer.
+RUN npm install -g corepack@latest && corepack enable
 
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
@@ -24,7 +25,8 @@ FROM node:26-alpine AS runtime
 ENV NODE_ENV=production
 WORKDIR /app
 
-RUN corepack enable
+# node:26 ne fournit plus corepack : on l'installe via npm avant de l'activer.
+RUN npm install -g corepack@latest && corepack enable
 
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile --production && yarn cache clean

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -7,6 +7,7 @@
   "author": "Sportek aka Gabriel Landry",
   "description": "Serveur MCP (Model Context Protocol) pour Minecraft Stats — expose les endpoints publics en lecture seule aux agents IA, généré automatiquement depuis le spec OpenAPI du backend.",
   "main": "build/server.js",
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "build": "tsc",


### PR DESCRIPTION
## Contexte

Après le passage à Node 26 (PR #260), la CI (`ci.yml`) est verte mais **les deux pipelines de déploiement Docker échouent** sur `staging` :

| Pipeline | Erreur |
|----------|--------|
| Build and Deploy Backend | `RUN yarn install` → `/bin/sh: yarn: not found` |
| Build and Deploy MCP | `RUN corepack enable` → `/bin/sh: corepack: not found` |

**Cause racine :** les images `node:26` / `node:26-alpine` ne fournissent plus `yarn` ni `corepack` préinstallés (Node 25+ a débundlé corepack). Sur `node:24` ça fonctionnait — d'où la régression au passage à Node 26.

## Changements

Dans les 3 Dockerfiles, avant toute commande yarn, on installe corepack via **npm** (toujours fourni) puis on l'active, ce qui utilise le `yarn@1.22.22` épinglé via `packageManager` :

```dockerfile
RUN npm install -g corepack@latest && corepack enable
```

- `backend/Dockerfile` : ajouté avant `yarn install`
- `frontend/Dockerfile` : ajouté dans le stage `base` (hérité par `deps` et `builder`)
- `mcp/Dockerfile` : remplace le `corepack enable` nu dans les deux stages
- `mcp/package.json` : ajout du champ `packageManager` (yarn@1.22.22) pour que corepack résolve la même version que backend/frontend de façon déterministe

## Validation

Build Docker non exécutable dans l'environnement de dev (pas de daemon). Mécanisme validé en isolation avec Node local : `npm i -g corepack@latest` → corepack 0.35.0 → résout `yarn 1.22.22` depuis le champ `packageManager`. JSON valides, lockfile mcp toujours cohérent (`--frozen-lockfile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015qDQSxnEVybcbHWi3r4f2C)_