### PR TITLE
Add Minehut hosting provider with API stats and update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      # Version épinglée : sur Node 26.7.0, `node ace docs:generate` casse au boot
+      # d'Ace (« Invalid command exported … Invalid URL » — 26.7 déprécie
+      # `module.register()`, utilisé par le loader TS d'AdonisJS). 26.6.0 est la
+      # dernière version saine. Même épinglage dans `backend/Dockerfile`.
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '26'
+          node-version: '26.6.0'
 
       # node:26 ne fournit plus corepack : on l'installe via npm avant de l'activer,
       # ce qui fournit le yarn épinglé (packageManager: yarn@4).
@@ -130,10 +134,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      # Version épinglée : sur Node 26.7.0, `node ace docs:generate` casse au boot
+      # d'Ace (« Invalid command exported … Invalid URL » — 26.7 déprécie
+      # `module.register()`, utilisé par le loader TS d'AdonisJS). 26.6.0 est la
+      # dernière version saine. Même épinglage dans `backend/Dockerfile`.
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '26'
+          node-version: '26.6.0'
 
       # node:26 ne fournit plus corepack : on l'installe via npm avant de l'activer,
       # ce qui fournit le yarn épinglé (packageManager: yarn@4).

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,11 @@
-FROM node:26
+# Version épinglée volontairement. `node:26` est un tag flottant : le 08/08/2026 il
+# est passé à 26.7.0, où `node ace docs:generate` casse au boot d'Ace avec
+# « Invalid command exported from "archive_old_partitions.js". Invalid URL » (Node
+# 26.7 déprécie `module.register()`, utilisé par le loader TS d'AdonisJS). Le
+# déploiement s'est mis à échouer sans le moindre changement de code — vérifié en
+# rebuildant un commit antérieur, qui échoue aussi. 26.6.0 est la dernière version
+# saine. À relever après une mise à jour d'AdonisJS qui gère les nouveaux hooks.
+FROM node:26.6.0
 
 WORKDIR /home/node/app
 

--- a/backend/app/controllers/posts_controller.ts
+++ b/backend/app/controllers/posts_controller.ts
@@ -137,9 +137,15 @@ export default class PostsController {
    * @operationId resolvePlaceholders
    * @tag POSTS
    * @summary Resolve content placeholders to their current values
-   * @description Resolves a batch of placeholder tokens to their live values. Returns a map of token → value. Publicly accessible.
+   * @description Resolves a batch of placeholder tokens to their live values. Returns a map of token → value, e.g. `{"%PLAYER_COUNT_REALTIME_125%": "42", "%SERVER_VERSION_125%": "1.21.4"}`. Publicly accessible.
    * @requestBody {"placeholders": ["%PLAYER_COUNT_REALTIME_125%", "%SERVER_VERSION_125%"]}
-   * @responseBody 200 - {"%PLAYER_COUNT_REALTIME_125%": "42", "%SERVER_VERSION_125%": "1.21.4"}
+   * @responseBody 200 - Map of each submitted token to its resolved string value
+   *
+   * NB : l'exemple de réponse vit dans `@description` et non dans `@responseBody`.
+   * Les clés de la map commencent par `%`, et adonis-autoswagger écrit les clés
+   * d'objet sans guillemets dans `swagger.yml` — or un scalaire YAML ne peut pas
+   * commencer par `%` (indicateur de directive). Le fichier généré devenait donc
+   * du YAML invalide. Dans une `description`, la valeur est entre guillemets : OK.
    * @responseBody 422 - {"errors": [{"message": "The placeholders field must be defined", "field": "placeholders", "rule": "required"}]}
    */
   async resolvePlaceholders({ request, response }: HttpContext) {

--- a/backend/app/services/server_ownership_service.ts
+++ b/backend/app/services/server_ownership_service.ts
@@ -71,18 +71,18 @@ export default class ServerOwnershipService {
   /**
    * Collaborateurs réseau isolés comme points d'injection : les tests les remplacent
    * par des stubs pour rester hermétiques (aucune requête DNS / aucun ping réel).
+   *
+   * NE PAS passer `readonly` (Sonar S1444 le suggère) : les tests fonctionnels les
+   * réassignent, et `readonly` casse le typecheck — ce qui a fait échouer la CI le
+   * 08/08/2026 sans qu'aucun test local ne bronche.
    */
-  static readonly resolveTxt: (host: string) => Promise<string[][]> = (host) =>
-    dns.promises.resolveTxt(host)
-  static readonly pingServer: (
-    type: ServerType,
-    address: string,
-    port: number
-  ) => Promise<NormalizedPing> = (type, address, port) =>
-    // `detailed` : chez un hébergeur mutualisé, l'appel dédié ramène la MOTD réelle
-    // du serveur — sans lui, on lirait celle du proxy et aucun jeton ne pourrait
-    // jamais être trouvé (cf. host_providers).
-    pingMinecraftServer(type, address, port, INTERACTIVE_PING_TIMEOUT, { detailed: true })
+  static resolveTxt: (host: string) => Promise<string[][]> = (host) => dns.promises.resolveTxt(host)
+  static pingServer: (type: ServerType, address: string, port: number) => Promise<NormalizedPing> =
+    (type, address, port) =>
+      // `detailed` : chez un hébergeur mutualisé, l'appel dédié ramène la MOTD réelle
+      // du serveur — sans lui, on lirait celle du proxy et aucun jeton ne pourrait
+      // jamais être trouvé (cf. host_providers).
+      pingMinecraftServer(type, address, port, INTERACTIVE_PING_TIMEOUT, { detailed: true })
 
   /** Hôtes sur lesquels on accepte l'enregistrement TXT : domaine racine + adresse exacte. */
   static dnsHostCandidates(server: Server): string[] {

--- a/backend/app/services/server_ownership_service.ts
+++ b/backend/app/services/server_ownership_service.ts
@@ -1,21 +1,21 @@
-import dns from 'node:dns'
-import net from 'node:net'
-import { randomBytes } from 'node:crypto'
-import { DateTime } from 'luxon'
 import Server from '#models/server'
 import ServerOwnershipClaim from '#models/server_ownership_claim'
 import type User from '#models/user'
 import { flattenMotd } from '#utils/motd'
-import {
-  TOKEN_TTL_DAYS,
-  VERIFY_PREFIX,
-  type OwnershipMethod,
-} from '../constants/server_ownership.js'
+import { DateTime } from 'luxon'
+import { randomBytes } from 'node:crypto'
+import dns from 'node:dns'
+import net from 'node:net'
 import {
   INTERACTIVE_PING_TIMEOUT,
   pingMinecraftServer,
   type NormalizedPing,
 } from '../../minecraft-ping/minecraft_ping.js'
+import {
+  TOKEN_TTL_DAYS,
+  VERIFY_PREFIX,
+  type OwnershipMethod,
+} from '../constants/server_ownership.js'
 import type { ServerType } from '../constants/server_type.js'
 
 export type ClaimOutcome =
@@ -72,9 +72,17 @@ export default class ServerOwnershipService {
    * Collaborateurs réseau isolés comme points d'injection : les tests les remplacent
    * par des stubs pour rester hermétiques (aucune requête DNS / aucun ping réel).
    */
-  static resolveTxt: (host: string) => Promise<string[][]> = (host) => dns.promises.resolveTxt(host)
-  static pingServer: (type: ServerType, address: string, port: number) => Promise<NormalizedPing> =
-    (type, address, port) => pingMinecraftServer(type, address, port, INTERACTIVE_PING_TIMEOUT)
+  static readonly resolveTxt: (host: string) => Promise<string[][]> = (host) =>
+    dns.promises.resolveTxt(host)
+  static readonly pingServer: (
+    type: ServerType,
+    address: string,
+    port: number
+  ) => Promise<NormalizedPing> = (type, address, port) =>
+    // `detailed` : chez un hébergeur mutualisé, l'appel dédié ramène la MOTD réelle
+    // du serveur — sans lui, on lirait celle du proxy et aucun jeton ne pourrait
+    // jamais être trouvé (cf. host_providers).
+    pingMinecraftServer(type, address, port, INTERACTIVE_PING_TIMEOUT, { detailed: true })
 
   /** Hôtes sur lesquels on accepte l'enregistrement TXT : domaine racine + adresse exacte. */
   static dnsHostCandidates(server: Server): string[] {
@@ -195,7 +203,7 @@ export default class ServerOwnershipService {
     if (server.ownerVerifiedAt && server.userId !== user.id) return { status: 'already_verified' }
 
     const claim = await this.findClaim(server.id, user.id)
-    if (!claim || claim.method !== method || claim.status !== 'pending' || !claim.token) {
+    if (claim?.method !== method || claim.status !== 'pending' || !claim.token) {
       return { status: 'no_claim' }
     }
     if (!claim.isTokenActive) {

--- a/backend/app/services/server_registration_service.ts
+++ b/backend/app/services/server_registration_service.ts
@@ -40,7 +40,18 @@ export default class ServerRegistrationService {
     // Ping interactif : test de joignabilité ET source des empreintes de doublon.
     let pingData: NormalizedPing | null = null
     try {
-      pingData = await pingMinecraftServer(type, data.address, data.port, INTERACTIVE_PING_TIMEOUT)
+      // `detailed` : un seul serveur à traiter, on peut dépenser l'appel dédié qui
+      // ramène le favicon d'un hébergeur mutualisé — c'est ici que l'icône et les
+      // empreintes de doublon sont établies (cf. host_providers).
+      pingData = await pingMinecraftServer(
+        type,
+        data.address,
+        data.port,
+        INTERACTIVE_PING_TIMEOUT,
+        {
+          detailed: true,
+        }
+      )
     } catch {
       pingData = null
     }

--- a/backend/database/schema.ts
+++ b/backend/database/schema.ts
@@ -23,7 +23,15 @@ export class AdvertisementCategorySchema extends BaseModel {
 }
 
 export class AdvertisementEventSchema extends BaseModel {
-  static $columns = ['advertisementId', 'createdAt', 'id', 'placement', 'serverId', 'targetUrl', 'type'] as const
+  static $columns = [
+    'advertisementId',
+    'createdAt',
+    'id',
+    'placement',
+    'serverId',
+    'targetUrl',
+    'type',
+  ] as const
   $columns = AdvertisementEventSchema.$columns
   @column()
   declare advertisementId: number
@@ -42,7 +50,20 @@ export class AdvertisementEventSchema extends BaseModel {
 }
 
 export class AdvertisementSchema extends BaseModel {
-  static $columns = ['createdAt', 'enabled', 'endsAt', 'htmlContent', 'id', 'name', 'showOnHome', 'showOnServer', 'startsAt', 'type', 'updatedAt', 'weight'] as const
+  static $columns = [
+    'createdAt',
+    'enabled',
+    'endsAt',
+    'htmlContent',
+    'id',
+    'name',
+    'showOnHome',
+    'showOnServer',
+    'startsAt',
+    'type',
+    'updatedAt',
+    'weight',
+  ] as const
   $columns = AdvertisementSchema.$columns
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime | null
@@ -71,7 +92,18 @@ export class AdvertisementSchema extends BaseModel {
 }
 
 export class AuthAccessTokenSchema extends BaseModel {
-  static $columns = ['abilities', 'createdAt', 'expiresAt', 'hash', 'id', 'lastUsedAt', 'name', 'tokenableId', 'type', 'updatedAt'] as const
+  static $columns = [
+    'abilities',
+    'createdAt',
+    'expiresAt',
+    'hash',
+    'id',
+    'lastUsedAt',
+    'name',
+    'tokenableId',
+    'type',
+    'updatedAt',
+  ] as const
   $columns = AuthAccessTokenSchema.$columns
   @column()
   declare abilities: string
@@ -156,7 +188,16 @@ export class LanguageSchema extends BaseModel {
 }
 
 export class MinecraftPlayerSchema extends BaseModel {
-  static $columns = ['createdAt', 'headPath', 'id', 'resolvedAt', 'textureHash', 'updatedAt', 'username', 'uuid'] as const
+  static $columns = [
+    'createdAt',
+    'headPath',
+    'id',
+    'resolvedAt',
+    'textureHash',
+    'updatedAt',
+    'username',
+    'uuid',
+  ] as const
   $columns = MinecraftPlayerSchema.$columns
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime | null
@@ -192,7 +233,16 @@ export class PageViewDailySchema extends BaseModel {
 }
 
 export class PageViewSchema extends BaseModel {
-  static $columns = ['createdAt', 'durationMs', 'id', 'path', 'referrer', 'title', 'userId', 'visitorId'] as const
+  static $columns = [
+    'createdAt',
+    'durationMs',
+    'id',
+    'path',
+    'referrer',
+    'title',
+    'userId',
+    'visitorId',
+  ] as const
   $columns = PageViewSchema.$columns
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime | null
@@ -213,7 +263,15 @@ export class PageViewSchema extends BaseModel {
 }
 
 export class PostFeedbackSchema extends BaseModel {
-  static $columns = ['createdAt', 'helpful', 'id', 'postId', 'updatedAt', 'userId', 'visitorId'] as const
+  static $columns = [
+    'createdAt',
+    'helpful',
+    'id',
+    'postId',
+    'updatedAt',
+    'userId',
+    'visitorId',
+  ] as const
   $columns = PostFeedbackSchema.$columns
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime | null
@@ -232,7 +290,17 @@ export class PostFeedbackSchema extends BaseModel {
 }
 
 export class PostTranslationSchema extends BaseModel {
-  static $columns = ['content', 'createdAt', 'excerpt', 'id', 'locale', 'postId', 'slug', 'title', 'updatedAt'] as const
+  static $columns = [
+    'content',
+    'createdAt',
+    'excerpt',
+    'id',
+    'locale',
+    'postId',
+    'slug',
+    'title',
+    'updatedAt',
+  ] as const
   $columns = PostTranslationSchema.$columns
   @column()
   declare content: string
@@ -255,7 +323,17 @@ export class PostTranslationSchema extends BaseModel {
 }
 
 export class PostSchema extends BaseModel {
-  static $columns = ['coverImage', 'createdAt', 'defaultLocale', 'id', 'published', 'publishedAt', 'updatedAt', 'userId', 'viewCount'] as const
+  static $columns = [
+    'coverImage',
+    'createdAt',
+    'defaultLocale',
+    'id',
+    'published',
+    'publishedAt',
+    'updatedAt',
+    'userId',
+    'viewCount',
+  ] as const
   $columns = PostSchema.$columns
   @column()
   declare coverImage: string | null
@@ -304,7 +382,15 @@ export class ServerCategorySchema extends BaseModel {
 }
 
 export class ServerGrowthStatSchema extends BaseModel {
-  static $columns = ['lastMonthAverage', 'lastUpdated', 'lastWeekAverage', 'monthlyGrowth', 'previousWeekAverage', 'serverId', 'weeklyGrowth'] as const
+  static $columns = [
+    'lastMonthAverage',
+    'lastUpdated',
+    'lastWeekAverage',
+    'monthlyGrowth',
+    'previousWeekAverage',
+    'serverId',
+    'weeklyGrowth',
+  ] as const
   $columns = ServerGrowthStatSchema.$columns
   @column()
   declare lastMonthAverage: number | null
@@ -338,7 +424,22 @@ export class ServerLanguageSchema extends BaseModel {
 }
 
 export class ServerOwnershipClaimSchema extends BaseModel {
-  static $columns = ['createdAt', 'evidence', 'evidenceUrl', 'expiresAt', 'id', 'method', 'reviewNote', 'reviewedBy', 'serverId', 'status', 'token', 'updatedAt', 'userId', 'verifiedAt'] as const
+  static $columns = [
+    'createdAt',
+    'evidence',
+    'evidenceUrl',
+    'expiresAt',
+    'id',
+    'method',
+    'reviewNote',
+    'reviewedBy',
+    'serverId',
+    'status',
+    'token',
+    'updatedAt',
+    'userId',
+    'verifiedAt',
+  ] as const
   $columns = ServerOwnershipClaimSchema.$columns
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
@@ -386,7 +487,15 @@ export class ServerStatSchema extends BaseModel {
 }
 
 export class ServerStatsDailySchema extends BaseModel {
-  static $columns = ['avgPlayerCount', 'day', 'maxSlotCount', 'minPlayerCount', 'peakPlayerCount', 'samplesCount', 'serverId'] as const
+  static $columns = [
+    'avgPlayerCount',
+    'day',
+    'maxSlotCount',
+    'minPlayerCount',
+    'peakPlayerCount',
+    'samplesCount',
+    'serverId',
+  ] as const
   $columns = ServerStatsDailySchema.$columns
   @column()
   declare avgPlayerCount: number | null
@@ -405,7 +514,15 @@ export class ServerStatsDailySchema extends BaseModel {
 }
 
 export class ServerStatsHourlySchema extends BaseModel {
-  static $columns = ['avgPlayerCount', 'hour', 'maxSlotCount', 'minPlayerCount', 'peakPlayerCount', 'samplesCount', 'serverId'] as const
+  static $columns = [
+    'avgPlayerCount',
+    'hour',
+    'maxSlotCount',
+    'minPlayerCount',
+    'peakPlayerCount',
+    'samplesCount',
+    'serverId',
+  ] as const
   $columns = ServerStatsHourlySchema.$columns
   @column()
   declare avgPlayerCount: number | null
@@ -424,7 +541,18 @@ export class ServerStatsHourlySchema extends BaseModel {
 }
 
 export class ServerVoteSchema extends BaseModel {
-  static $columns = ['country', 'createdAt', 'id', 'ipHash', 'mojangUuid', 'serverId', 'updatedAt', 'userId', 'username', 'visitorId'] as const
+  static $columns = [
+    'country',
+    'createdAt',
+    'id',
+    'ipHash',
+    'mojangUuid',
+    'serverId',
+    'updatedAt',
+    'userId',
+    'username',
+    'visitorId',
+  ] as const
   $columns = ServerVoteSchema.$columns
   @column()
   declare country: string | null
@@ -449,7 +577,35 @@ export class ServerVoteSchema extends BaseModel {
 }
 
 export class ServerSchema extends BaseModel {
-  static $columns = ['address', 'categoryId', 'createdAt', 'faviconHash', 'hostDomain', 'id', 'imageUrl', 'lastMaxCount', 'lastOnlineAt', 'lastPlayerCount', 'lastStatsAt', 'motd', 'motdHash', 'name', 'nextPingAt', 'ownerVerifiedAt', 'ownerVerifiedMethod', 'peakPlayerAt', 'peakPlayerCount', 'port', 'resolvedEndpoint', 'type', 'updatedAt', 'userId', 'version', 'voteCount', 'website'] as const
+  static $columns = [
+    'address',
+    'categoryId',
+    'createdAt',
+    'faviconHash',
+    'hostDomain',
+    'id',
+    'imageUrl',
+    'lastMaxCount',
+    'lastOnlineAt',
+    'lastPlayerCount',
+    'lastStatsAt',
+    'motd',
+    'motdHash',
+    'name',
+    'nextPingAt',
+    'ownerVerifiedAt',
+    'ownerVerifiedMethod',
+    'peakPlayerAt',
+    'peakPlayerCount',
+    'port',
+    'resolvedEndpoint',
+    'type',
+    'updatedAt',
+    'userId',
+    'version',
+    'voteCount',
+    'website',
+  ] as const
   $columns = ServerSchema.$columns
   @column()
   declare address: string
@@ -508,7 +664,16 @@ export class ServerSchema extends BaseModel {
 }
 
 export class TrafficDailySchema extends BaseModel {
-  static $columns = ['countries', 'createdAt', 'date', 'httpErrors', 'httpRequests', 'id', 'uniqueVisitors', 'updatedAt'] as const
+  static $columns = [
+    'countries',
+    'createdAt',
+    'date',
+    'httpErrors',
+    'httpRequests',
+    'id',
+    'uniqueVisitors',
+    'updatedAt',
+  ] as const
   $columns = TrafficDailySchema.$columns
   @column()
   declare countries: any
@@ -529,7 +694,17 @@ export class TrafficDailySchema extends BaseModel {
 }
 
 export class UserProviderSchema extends BaseModel {
-  static $columns = ['confirmedAt', 'createdAt', 'id', 'linkTokenExpiresAt', 'linkTokenHash', 'provider', 'providerUserId', 'updatedAt', 'userId'] as const
+  static $columns = [
+    'confirmedAt',
+    'createdAt',
+    'id',
+    'linkTokenExpiresAt',
+    'linkTokenHash',
+    'provider',
+    'providerUserId',
+    'updatedAt',
+    'userId',
+  ] as const
   $columns = UserProviderSchema.$columns
   @column.dateTime()
   declare confirmedAt: DateTime | null
@@ -552,7 +727,25 @@ export class UserProviderSchema extends BaseModel {
 }
 
 export class UserSchema extends BaseModel {
-  static $columns = ['avatarUrl', 'blacklistReason', 'blacklistedAt', 'blacklistedBy', 'createdAt', 'email', 'id', 'password', 'passwordResetToken', 'passwordResetTokenExpires', 'provider', 'role', 'updatedAt', 'username', 'verificationToken', 'verificationTokenExpires', 'verified'] as const
+  static $columns = [
+    'avatarUrl',
+    'blacklistReason',
+    'blacklistedAt',
+    'blacklistedBy',
+    'createdAt',
+    'email',
+    'id',
+    'password',
+    'passwordResetToken',
+    'passwordResetTokenExpires',
+    'provider',
+    'role',
+    'updatedAt',
+    'username',
+    'verificationToken',
+    'verificationTokenExpires',
+    'verified',
+  ] as const
   $columns = UserSchema.$columns
   @column()
   declare avatarUrl: string | null
@@ -606,7 +799,15 @@ export class VisitorAccountSchema extends BaseModel {
 }
 
 export class VisitorSchema extends BaseModel {
-  static $columns = ['country', 'firstSeenAt', 'id', 'ipHash', 'lastSeenAt', 'userAgent', 'uuid'] as const
+  static $columns = [
+    'country',
+    'firstSeenAt',
+    'id',
+    'ipHash',
+    'lastSeenAt',
+    'userAgent',
+    'uuid',
+  ] as const
   $columns = VisitorSchema.$columns
   @column()
   declare country: string | null

--- a/backend/database/schema.ts
+++ b/backend/database/schema.ts
@@ -23,15 +23,7 @@ export class AdvertisementCategorySchema extends BaseModel {
 }
 
 export class AdvertisementEventSchema extends BaseModel {
-  static $columns = [
-    'advertisementId',
-    'createdAt',
-    'id',
-    'placement',
-    'serverId',
-    'targetUrl',
-    'type',
-  ] as const
+  static $columns = ['advertisementId', 'createdAt', 'id', 'placement', 'serverId', 'targetUrl', 'type'] as const
   $columns = AdvertisementEventSchema.$columns
   @column()
   declare advertisementId: number
@@ -50,20 +42,7 @@ export class AdvertisementEventSchema extends BaseModel {
 }
 
 export class AdvertisementSchema extends BaseModel {
-  static $columns = [
-    'createdAt',
-    'enabled',
-    'endsAt',
-    'htmlContent',
-    'id',
-    'name',
-    'showOnHome',
-    'showOnServer',
-    'startsAt',
-    'type',
-    'updatedAt',
-    'weight',
-  ] as const
+  static $columns = ['createdAt', 'enabled', 'endsAt', 'htmlContent', 'id', 'name', 'showOnHome', 'showOnServer', 'startsAt', 'type', 'updatedAt', 'weight'] as const
   $columns = AdvertisementSchema.$columns
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime | null
@@ -92,18 +71,7 @@ export class AdvertisementSchema extends BaseModel {
 }
 
 export class AuthAccessTokenSchema extends BaseModel {
-  static $columns = [
-    'abilities',
-    'createdAt',
-    'expiresAt',
-    'hash',
-    'id',
-    'lastUsedAt',
-    'name',
-    'tokenableId',
-    'type',
-    'updatedAt',
-  ] as const
+  static $columns = ['abilities', 'createdAt', 'expiresAt', 'hash', 'id', 'lastUsedAt', 'name', 'tokenableId', 'type', 'updatedAt'] as const
   $columns = AuthAccessTokenSchema.$columns
   @column()
   declare abilities: string
@@ -188,16 +156,7 @@ export class LanguageSchema extends BaseModel {
 }
 
 export class MinecraftPlayerSchema extends BaseModel {
-  static $columns = [
-    'createdAt',
-    'headPath',
-    'id',
-    'resolvedAt',
-    'textureHash',
-    'updatedAt',
-    'username',
-    'uuid',
-  ] as const
+  static $columns = ['createdAt', 'headPath', 'id', 'resolvedAt', 'textureHash', 'updatedAt', 'username', 'uuid'] as const
   $columns = MinecraftPlayerSchema.$columns
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime | null
@@ -233,16 +192,7 @@ export class PageViewDailySchema extends BaseModel {
 }
 
 export class PageViewSchema extends BaseModel {
-  static $columns = [
-    'createdAt',
-    'durationMs',
-    'id',
-    'path',
-    'referrer',
-    'title',
-    'userId',
-    'visitorId',
-  ] as const
+  static $columns = ['createdAt', 'durationMs', 'id', 'path', 'referrer', 'title', 'userId', 'visitorId'] as const
   $columns = PageViewSchema.$columns
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime | null
@@ -263,15 +213,7 @@ export class PageViewSchema extends BaseModel {
 }
 
 export class PostFeedbackSchema extends BaseModel {
-  static $columns = [
-    'createdAt',
-    'helpful',
-    'id',
-    'postId',
-    'updatedAt',
-    'userId',
-    'visitorId',
-  ] as const
+  static $columns = ['createdAt', 'helpful', 'id', 'postId', 'updatedAt', 'userId', 'visitorId'] as const
   $columns = PostFeedbackSchema.$columns
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime | null
@@ -290,17 +232,7 @@ export class PostFeedbackSchema extends BaseModel {
 }
 
 export class PostTranslationSchema extends BaseModel {
-  static $columns = [
-    'content',
-    'createdAt',
-    'excerpt',
-    'id',
-    'locale',
-    'postId',
-    'slug',
-    'title',
-    'updatedAt',
-  ] as const
+  static $columns = ['content', 'createdAt', 'excerpt', 'id', 'locale', 'postId', 'slug', 'title', 'updatedAt'] as const
   $columns = PostTranslationSchema.$columns
   @column()
   declare content: string
@@ -323,17 +255,7 @@ export class PostTranslationSchema extends BaseModel {
 }
 
 export class PostSchema extends BaseModel {
-  static $columns = [
-    'coverImage',
-    'createdAt',
-    'defaultLocale',
-    'id',
-    'published',
-    'publishedAt',
-    'updatedAt',
-    'userId',
-    'viewCount',
-  ] as const
+  static $columns = ['coverImage', 'createdAt', 'defaultLocale', 'id', 'published', 'publishedAt', 'updatedAt', 'userId', 'viewCount'] as const
   $columns = PostSchema.$columns
   @column()
   declare coverImage: string | null
@@ -382,15 +304,7 @@ export class ServerCategorySchema extends BaseModel {
 }
 
 export class ServerGrowthStatSchema extends BaseModel {
-  static $columns = [
-    'lastMonthAverage',
-    'lastUpdated',
-    'lastWeekAverage',
-    'monthlyGrowth',
-    'previousWeekAverage',
-    'serverId',
-    'weeklyGrowth',
-  ] as const
+  static $columns = ['lastMonthAverage', 'lastUpdated', 'lastWeekAverage', 'monthlyGrowth', 'previousWeekAverage', 'serverId', 'weeklyGrowth'] as const
   $columns = ServerGrowthStatSchema.$columns
   @column()
   declare lastMonthAverage: number | null
@@ -424,22 +338,7 @@ export class ServerLanguageSchema extends BaseModel {
 }
 
 export class ServerOwnershipClaimSchema extends BaseModel {
-  static $columns = [
-    'createdAt',
-    'evidence',
-    'evidenceUrl',
-    'expiresAt',
-    'id',
-    'method',
-    'reviewNote',
-    'reviewedBy',
-    'serverId',
-    'status',
-    'token',
-    'updatedAt',
-    'userId',
-    'verifiedAt',
-  ] as const
+  static $columns = ['createdAt', 'evidence', 'evidenceUrl', 'expiresAt', 'id', 'method', 'reviewNote', 'reviewedBy', 'serverId', 'status', 'token', 'updatedAt', 'userId', 'verifiedAt'] as const
   $columns = ServerOwnershipClaimSchema.$columns
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
@@ -487,15 +386,7 @@ export class ServerStatSchema extends BaseModel {
 }
 
 export class ServerStatsDailySchema extends BaseModel {
-  static $columns = [
-    'avgPlayerCount',
-    'day',
-    'maxSlotCount',
-    'minPlayerCount',
-    'peakPlayerCount',
-    'samplesCount',
-    'serverId',
-  ] as const
+  static $columns = ['avgPlayerCount', 'day', 'maxSlotCount', 'minPlayerCount', 'peakPlayerCount', 'samplesCount', 'serverId'] as const
   $columns = ServerStatsDailySchema.$columns
   @column()
   declare avgPlayerCount: number | null
@@ -514,15 +405,7 @@ export class ServerStatsDailySchema extends BaseModel {
 }
 
 export class ServerStatsHourlySchema extends BaseModel {
-  static $columns = [
-    'avgPlayerCount',
-    'hour',
-    'maxSlotCount',
-    'minPlayerCount',
-    'peakPlayerCount',
-    'samplesCount',
-    'serverId',
-  ] as const
+  static $columns = ['avgPlayerCount', 'hour', 'maxSlotCount', 'minPlayerCount', 'peakPlayerCount', 'samplesCount', 'serverId'] as const
   $columns = ServerStatsHourlySchema.$columns
   @column()
   declare avgPlayerCount: number | null
@@ -541,18 +424,7 @@ export class ServerStatsHourlySchema extends BaseModel {
 }
 
 export class ServerVoteSchema extends BaseModel {
-  static $columns = [
-    'country',
-    'createdAt',
-    'id',
-    'ipHash',
-    'mojangUuid',
-    'serverId',
-    'updatedAt',
-    'userId',
-    'username',
-    'visitorId',
-  ] as const
+  static $columns = ['country', 'createdAt', 'id', 'ipHash', 'mojangUuid', 'serverId', 'updatedAt', 'userId', 'username', 'visitorId'] as const
   $columns = ServerVoteSchema.$columns
   @column()
   declare country: string | null
@@ -577,35 +449,7 @@ export class ServerVoteSchema extends BaseModel {
 }
 
 export class ServerSchema extends BaseModel {
-  static $columns = [
-    'address',
-    'categoryId',
-    'createdAt',
-    'faviconHash',
-    'hostDomain',
-    'id',
-    'imageUrl',
-    'lastMaxCount',
-    'lastOnlineAt',
-    'lastPlayerCount',
-    'lastStatsAt',
-    'motd',
-    'motdHash',
-    'name',
-    'nextPingAt',
-    'ownerVerifiedAt',
-    'ownerVerifiedMethod',
-    'peakPlayerAt',
-    'peakPlayerCount',
-    'port',
-    'resolvedEndpoint',
-    'type',
-    'updatedAt',
-    'userId',
-    'version',
-    'voteCount',
-    'website',
-  ] as const
+  static $columns = ['address', 'categoryId', 'createdAt', 'faviconHash', 'hostDomain', 'id', 'imageUrl', 'lastMaxCount', 'lastOnlineAt', 'lastPlayerCount', 'lastStatsAt', 'motd', 'motdHash', 'name', 'nextPingAt', 'ownerVerifiedAt', 'ownerVerifiedMethod', 'peakPlayerAt', 'peakPlayerCount', 'port', 'resolvedEndpoint', 'type', 'updatedAt', 'userId', 'version', 'voteCount', 'website'] as const
   $columns = ServerSchema.$columns
   @column()
   declare address: string
@@ -664,16 +508,7 @@ export class ServerSchema extends BaseModel {
 }
 
 export class TrafficDailySchema extends BaseModel {
-  static $columns = [
-    'countries',
-    'createdAt',
-    'date',
-    'httpErrors',
-    'httpRequests',
-    'id',
-    'uniqueVisitors',
-    'updatedAt',
-  ] as const
+  static $columns = ['countries', 'createdAt', 'date', 'httpErrors', 'httpRequests', 'id', 'uniqueVisitors', 'updatedAt'] as const
   $columns = TrafficDailySchema.$columns
   @column()
   declare countries: any
@@ -694,17 +529,7 @@ export class TrafficDailySchema extends BaseModel {
 }
 
 export class UserProviderSchema extends BaseModel {
-  static $columns = [
-    'confirmedAt',
-    'createdAt',
-    'id',
-    'linkTokenExpiresAt',
-    'linkTokenHash',
-    'provider',
-    'providerUserId',
-    'updatedAt',
-    'userId',
-  ] as const
+  static $columns = ['confirmedAt', 'createdAt', 'id', 'linkTokenExpiresAt', 'linkTokenHash', 'provider', 'providerUserId', 'updatedAt', 'userId'] as const
   $columns = UserProviderSchema.$columns
   @column.dateTime()
   declare confirmedAt: DateTime | null
@@ -727,25 +552,7 @@ export class UserProviderSchema extends BaseModel {
 }
 
 export class UserSchema extends BaseModel {
-  static $columns = [
-    'avatarUrl',
-    'blacklistReason',
-    'blacklistedAt',
-    'blacklistedBy',
-    'createdAt',
-    'email',
-    'id',
-    'password',
-    'passwordResetToken',
-    'passwordResetTokenExpires',
-    'provider',
-    'role',
-    'updatedAt',
-    'username',
-    'verificationToken',
-    'verificationTokenExpires',
-    'verified',
-  ] as const
+  static $columns = ['avatarUrl', 'blacklistReason', 'blacklistedAt', 'blacklistedBy', 'createdAt', 'email', 'id', 'password', 'passwordResetToken', 'passwordResetTokenExpires', 'provider', 'role', 'updatedAt', 'username', 'verificationToken', 'verificationTokenExpires', 'verified'] as const
   $columns = UserSchema.$columns
   @column()
   declare avatarUrl: string | null
@@ -799,15 +606,7 @@ export class VisitorAccountSchema extends BaseModel {
 }
 
 export class VisitorSchema extends BaseModel {
-  static $columns = [
-    'country',
-    'firstSeenAt',
-    'id',
-    'ipHash',
-    'lastSeenAt',
-    'userAgent',
-    'uuid',
-  ] as const
+  static $columns = ['country', 'firstSeenAt', 'id', 'ipHash', 'lastSeenAt', 'userAgent', 'uuid'] as const
   $columns = VisitorSchema.$columns
   @column()
   declare country: string | null

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -3,6 +3,12 @@ import { configApp } from '@adonisjs/eslint-config'
 export default [
   ...configApp(),
   {
-    ignores: ['app/PrometheusMetricController.ts'],
+    ignores: [
+      'app/PrometheusMetricController.ts',
+      // Généré par `node ace migration:run` (scan des tables), et non formaté par le
+      // générateur : sans cette exclusion, toute régénération fait échouer `eslint .`
+      // sur des erreurs prettier dans un fichier que personne n'écrit à la main.
+      'database/schema.ts',
+    ],
   },
 ]

--- a/backend/minecraft-ping/host_providers/index.ts
+++ b/backend/minecraft-ping/host_providers/index.ts
@@ -1,0 +1,22 @@
+import minehutProvider from './minehut_provider.js'
+import type { HostStatsProvider } from './types.js'
+
+/**
+ * Hébergeurs dont les stats se lisent via API plutôt que par ping direct (cf.
+ * `./types.ts` pour le pourquoi). Ajouter un hébergeur = un fichier provider +
+ * une entrée ici.
+ */
+const PROVIDERS: HostStatsProvider[] = [minehutProvider]
+
+/** Le premier provider qui reconnaît l'adresse, avec la clé qu'il en a extraite. */
+export function resolveHostProvider(
+  address: string
+): { provider: HostStatsProvider; key: string } | null {
+  for (const provider of PROVIDERS) {
+    const key = provider.resolveKey(address)
+    if (key) return { provider, key }
+  }
+  return null
+}
+
+export type { HostServerStats, HostStatsProvider } from './types.js'

--- a/backend/minecraft-ping/host_providers/minehut_provider.ts
+++ b/backend/minecraft-ping/host_providers/minehut_provider.ts
@@ -1,0 +1,144 @@
+import type { HostServerStats, HostStatsProvider } from './types.js'
+
+/**
+ * Endpoints publics, aucun token requis (le login Minehut ne donne accès qu'à
+ * l'administration de ses propres serveurs, pas aux compteurs des autres).
+ *
+ * `/servers` ne liste que les serveurs EN LIGNE (~760 sur ~1470) et pèse ~540 Ko :
+ * un seul appel couvre tous les serveurs d'un cycle de ping, mais il n'expose
+ * aucun favicon. `?byName=true` coûte un appel par serveur (~10 Ko) et ramène en
+ * plus l'icône et la MOTD réelle — d'où le mode `detailed` (cf. types.ts).
+ */
+const SERVERS_API = 'https://api.minehut.com/servers'
+const SERVER_API = 'https://api.minehut.com/server/'
+
+const FETCH_TIMEOUT_MS = 5000
+
+/**
+ * Durée de vie de l'instantané. Le pinger balaie ses serveurs dus en quelques
+ * secondes : une minute suffit pour qu'un cycle entier ne coûte qu'un seul appel
+ * à Minehut, tout en restant frais pour les ajouts/éditions interactifs.
+ */
+const SNAPSHOT_TTL_MS = 60_000
+
+/** Suffixe des hôtes servis par le proxy Minehut. */
+const HOST_SUFFIX = '.minehut.gg'
+
+interface MinehutServersResponse {
+  servers?: {
+    name?: string
+    motd?: string | null
+    maxPlayers?: number | null
+    playerData?: { playerCount?: number | null } | null
+    versionMin?: string | null
+    versionMax?: string | null
+  }[]
+}
+
+interface MinehutServerResponse {
+  server?: {
+    online?: boolean
+    playerCount?: number | null
+    maxPlayers?: number | null
+    motd?: string | null
+    server_list_favicon?: string | null
+  } | null
+}
+
+let snapshot: { fetchedAt: number; stats: Map<string, HostServerStats> } | null = null
+let inFlight: Promise<Map<string, HostServerStats>> | null = null
+
+/** Minehut expose une plage de versions, le plus souvent vide des deux côtés. */
+function formatVersion(min?: string | null, max?: string | null): string | null {
+  if (!min) return max ?? null
+  if (!max || min === max) return min
+  return `${min}-${max}`
+}
+
+async function fetchSnapshot(): Promise<Map<string, HostServerStats>> {
+  const res = await fetch(SERVERS_API, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
+  if (!res.ok) throw new Error(`Minehut API responded ${res.status}`)
+
+  const body = (await res.json()) as MinehutServersResponse
+
+  const stats = new Map<string, HostServerStats>()
+  for (const entry of body.servers ?? []) {
+    if (!entry.name) continue
+    stats.set(entry.name.toLowerCase(), {
+      players: { online: entry.playerData?.playerCount ?? 0, max: entry.maxPlayers ?? 0 },
+      motd: entry.motd ?? null,
+      version: formatVersion(entry.versionMin, entry.versionMax),
+      favicon: null,
+    })
+  }
+
+  snapshot = { fetchedAt: Date.now(), stats }
+  return stats
+}
+
+/**
+ * Une clé absente de l'instantané = serveur hors-ligne. Une erreur réseau se
+ * propage volontairement : mieux vaut un ping en échec (player_count NULL) qu'un
+ * compteur inventé.
+ */
+async function loadSnapshot(): Promise<Map<string, HostServerStats>> {
+  if (snapshot && Date.now() - snapshot.fetchedAt < SNAPSHOT_TTL_MS) return snapshot.stats
+
+  // Un cycle de ping démarre 20 pings en parallèle : on partage le même appel.
+  if (inFlight) return inFlight
+
+  inFlight = fetchSnapshot()
+  try {
+    return await inFlight
+  } finally {
+    inFlight = null
+  }
+}
+
+/** Fiche complète d'un serveur — seule source du favicon. Un appel par serveur. */
+async function fetchDetails(key: string): Promise<HostServerStats | null> {
+  const url = `${SERVER_API}${encodeURIComponent(key)}?byName=true`
+  const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
+  if (!res.ok) throw new Error(`Minehut API responded ${res.status}`)
+
+  // Un nom inconnu renvoie `{"server": null}` en HTTP 200.
+  const { server } = (await res.json()) as MinehutServerResponse
+  if (!server?.online) return null
+
+  return {
+    players: { online: server.playerCount ?? 0, max: server.maxPlayers ?? 0 },
+    // Le même champ que l'instantané, délibérément : la fiche expose aussi
+    // `server_list_motd` (la MOTD réelle du serveur, en composant Chat), mais s'en
+    // servir ici ferait osciller `motd_hash` entre deux valeurs selon le chemin de
+    // ping. `motd` est en prime le champ que le propriétaire édite depuis le panel
+    // Minehut, donc celui où chercher un jeton de vérification de propriété.
+    motd: server.motd ?? null,
+    // Cette fiche n'expose pas la version ; l'instantané `/servers` la couvre.
+    version: null,
+    favicon: server.server_list_favicon ?? null,
+  }
+}
+
+const minehutProvider: HostStatsProvider = {
+  id: 'minehut',
+
+  resolveKey(address) {
+    const host = address.trim().toLowerCase()
+    if (!host.endsWith(HOST_SUFFIX)) return null
+
+    // Le nom du serveur est le premier label — `thatbox.minehut.gg`, ou la
+    // variante Bedrock `thatbox.bedrock.minehut.gg`. `minehut.gg` nu n'est le
+    // sous-domaine de personne et reste donc pingué normalement.
+    const [key] = host.slice(0, -HOST_SUFFIX.length).split('.')
+    return key || null
+  },
+
+  async fetchStats(key, options) {
+    if (options?.detailed) return fetchDetails(key)
+
+    const stats = await loadSnapshot()
+    return stats.get(key) ?? null
+  },
+}
+
+export default minehutProvider

--- a/backend/minecraft-ping/host_providers/types.ts
+++ b/backend/minecraft-ping/host_providers/types.ts
@@ -1,0 +1,46 @@
+/** Stats live d'un serveur telles que rapportées par l'API de son hébergeur. */
+export interface HostServerStats {
+  players: { online: number; max: number }
+  /** MOTD brute ou composant Chat déjà parsé — `flattenMotd` accepte les deux. */
+  motd: unknown
+  /** null quand l'hébergeur ne l'expose pas — l'appelant garde la version connue. */
+  version: string | null
+  /** Data URI base64 de l'icône du serveur. Renseigné en mode `detailed` seulement. */
+  favicon: string | null
+}
+
+/**
+ * Source de stats alternative pour les hébergeurs à proxy mutualisé.
+ *
+ * Problème : chez un hébergeur de ce type (Minehut…), le ping Minecraft direct ne
+ * parle jamais au serveur visé — c'est le proxy du réseau qui répond, avec les
+ * compteurs du réseau ENTIER. `thatboxsrver.minehut.gg` remonte ainsi ~4600
+ * joueurs alors qu'il en a 0, `max` vaut le nombre de serveurs du réseau, et
+ * n'importe quel sous-domaine inexistant répond exactement la même chose (donc
+ * un serveur fantôme passerait la validation à l'ajout). Le seul chiffre
+ * exploitable vient de l'API de l'hébergeur, interrogée par nom de serveur.
+ *
+ * Un provider par hébergeur, enregistré dans `./index.ts`.
+ */
+export interface HostStatsProvider {
+  readonly id: string
+
+  /**
+   * Identifiant du serveur chez l'hébergeur, extrait de l'adresse
+   * (`thatboxsrver.minehut.gg` -> `thatboxsrver`), ou null si l'adresse ne relève
+   * pas de cet hébergeur.
+   */
+  resolveKey(address: string): string | null
+
+  /**
+   * Stats live du serveur, ou null s'il est hors-ligne ou inexistant chez
+   * l'hébergeur — les deux se traduisent par un ping en échec côté appelant.
+   *
+   * `detailed` autorise le provider à dépenser un appel réseau dédié à ce seul
+   * serveur pour ramener aussi le favicon : c'est le mode des chemins qui ne
+   * traitent qu'un serveur à la fois (ajout, vérification de propriété, balayage
+   * 6 h). Hors de ce mode, libre au provider de mutualiser un appel entre toutes
+   * les clés du cycle.
+   */
+  fetchStats(key: string, options?: { detailed?: boolean }): Promise<HostServerStats | null>
+}

--- a/backend/minecraft-ping/minecraft_ping.ts
+++ b/backend/minecraft-ping/minecraft_ping.ts
@@ -1,5 +1,6 @@
 import { pingBedrock, pingJava } from '@minescope/mineping'
 import type { ServerType } from '../app/constants/server_type.js'
+import { resolveHostProvider } from './host_providers/index.js'
 
 /**
  * Timeout par défaut pour les pings périodiques. 5s : laisse une chance aux serveurs
@@ -24,7 +25,10 @@ export const INTERACTIVE_PING_TIMEOUT = 5000
  */
 export interface NormalizedPing {
   players: { online: number; max: number }
-  version: { name: string }
+  // Absente quand les stats viennent d'une API d'hébergeur qui ne l'expose pas
+  // (cf. host_providers) : les appelants doivent alors garder la version connue
+  // plutôt que de l'écraser.
+  version?: { name: string }
   // Absent en Bedrock : le pong RakNet ne contient pas d'icône de serveur.
   favicon?: string
   description?: unknown
@@ -33,13 +37,35 @@ export interface NormalizedPing {
 /**
  * Ping un serveur Minecraft de l'édition donnée et renvoie une réponse normalisée.
  * Rejette si le serveur est injoignable (timeout, refus de connexion…).
+ *
+ * @param options.detailed  Pour un serveur chez un hébergeur mutualisé, autorise un
+ *   appel API dédié qui ramène aussi le favicon (cf. host_providers/types.ts). Sans
+ *   effet sur un ping direct, qui renvoie toujours tout ce que le serveur expose.
  */
 export const pingMinecraftServer = async (
   type: ServerType,
   address: string,
   port: number,
-  timeout: number = DEFAULT_PING_TIMEOUT
+  timeout: number = DEFAULT_PING_TIMEOUT,
+  options: { detailed?: boolean } = {}
 ): Promise<NormalizedPing> => {
+  // Hébergeur à proxy mutualisé : le ping direct interrogerait le proxy du réseau,
+  // qui répond les compteurs du réseau entier pour n'importe quel sous-domaine.
+  // On lit l'API de l'hébergeur à la place (cf. host_providers/types.ts).
+  const hosted = resolveHostProvider(address)
+  if (hosted) {
+    const stats = await hosted.provider.fetchStats(hosted.key, options)
+    if (!stats) {
+      throw new Error(`${hosted.provider.id}: server "${hosted.key}" is offline or does not exist`)
+    }
+    return {
+      players: stats.players,
+      version: stats.version ? { name: stats.version } : undefined,
+      favicon: stats.favicon ?? undefined,
+      description: stats.motd,
+    }
+  }
+
   if (type === 'bedrock') {
     const data = await pingBedrock(address, { port, timeout })
     return {

--- a/backend/start/scheduler.ts
+++ b/backend/start/scheduler.ts
@@ -9,7 +9,7 @@ import redis from '@adonisjs/redis/services/main'
 import scheduler from 'adonisjs-scheduler/services/main'
 import { DateTime } from 'luxon'
 import pLimit from 'p-limit'
-import { pingMinecraftServer } from '../minecraft-ping/minecraft_ping.js'
+import { DEFAULT_PING_TIMEOUT, pingMinecraftServer } from '../minecraft-ping/minecraft_ping.js'
 
 type ServerStatRow = {
   server_id: number
@@ -98,6 +98,34 @@ async function releasePingLock(serverId: number): Promise<void> {
 }
 
 /**
+ * Empreinte du favicon : sert à la fois à la détection de doublon et à décider
+ * s'il faut réécrire l'image. On ne réuploade sur le stockage (S3 en prod) que si
+ * le favicon a réellement changé — ou s'il n'existe pas encore. Réécrire des
+ * octets identiques à chaque ping ne ferait que générer des PUT S3 inutiles (les
+ * favicons ne changent quasi jamais), ce qui a dominé la facture AWS. Le hash
+ * suffit donc à détecter les vrais changements.
+ *
+ * Mute le serveur sans le sauvegarder — l'appelant persiste.
+ */
+async function storeFaviconIfChanged(server: Server, favicon?: string): Promise<void> {
+  if (!favicon) return
+
+  const faviconHash = DuplicateDetectionService.hashFavicon(favicon)
+  if (server.imageUrl && faviconHash === server.faviconHash) return
+
+  try {
+    server.imageUrl = await ImageStorageService.storeServerFavicon(server.id, favicon)
+    server.faviconHash = faviconHash
+  } catch (error) {
+    // On n'avance pas faviconHash : le prochain ping retentera l'upload.
+    logger.warn(
+      { serverId: server.id, err: (error as Error).message },
+      'SCHEDULER: image processing failed'
+    )
+  }
+}
+
+/**
  * Met à jour les informations du serveur et retourne la stat à insérer.
  * - 1 seule tentative (Niveau 1.2/1.3 — pas de retry sur les pings périodiques)
  * - Timeout court (DEFAULT_PING_TIMEOUT côté lib)
@@ -115,35 +143,24 @@ async function updateServerInfo(server: Server, overwriteImage = false): Promise
   const createdAt = new Date()
 
   try {
-    const data = await pingMinecraftServer(server.type, server.address, server.port)
+    // `overwriteImage` marque le balayage 6h : c'est là qu'on peut se permettre un
+    // appel API dédié par serveur chez un hébergeur mutualisé, seul moyen d'obtenir
+    // son favicon (l'instantané mutualisé du cycle 5 min ne l'expose pas).
+    const data = await pingMinecraftServer(
+      server.type,
+      server.address,
+      server.port,
+      DEFAULT_PING_TIMEOUT,
+      { detailed: overwriteImage }
+    )
     if (data) {
-      // Empreinte du favicon : sert à la fois à la détection de doublon et à
-      // décider s'il faut réécrire l'image. On ne réuploade sur le stockage
-      // (S3 en prod) que si le favicon a réellement changé — ou s'il n'existe
-      // pas encore. Réécrire des octets identiques à chaque ping ne ferait que
-      // générer des PUT S3 inutiles (les favicons ne changent quasi jamais),
-      // ce qui a dominé la facture AWS. `overwriteImage` ne force donc plus la
-      // réécriture : le hash suffit à détecter les vrais changements.
-      if (data.favicon) {
-        const faviconHash = DuplicateDetectionService.hashFavicon(data.favicon)
-        if (!server.imageUrl || faviconHash !== server.faviconHash) {
-          try {
-            server.imageUrl = await ImageStorageService.storeServerFavicon(server.id, data.favicon)
-            server.faviconHash = faviconHash
-          } catch (imgErr) {
-            // On n'avance pas faviconHash : le prochain ping retentera l'upload.
-            logger.warn(
-              { serverId: server.id, err: (imgErr as Error).message },
-              'SCHEDULER: image processing failed'
-            )
-          }
-        }
-      }
+      await storeFaviconIfChanged(server, data.favicon)
 
       playerOnline = data.players?.online ?? 0
       maxPlayer = data.players?.max ?? 0
 
-      server.version = data.version.name
+      // Absente quand les stats viennent d'une API d'hébergeur : on garde la connue.
+      if (data.version) server.version = data.version.name
       server.lastPlayerCount = playerOnline
       server.lastMaxCount = maxPlayer
       server.lastStatsAt = DateTime.fromJSDate(createdAt)

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -103,7 +103,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 219
+            "example": 618
           },
           "name": {
             "type": "string",
@@ -123,7 +123,7 @@
           },
           "weight": {
             "type": "number",
-            "example": 804
+            "example": 21
           },
           "show_on_home": {
             "type": "boolean",
@@ -176,11 +176,11 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 538
+            "example": 58
           },
           "advertisement_id": {
             "type": "number",
-            "example": 644
+            "example": 490
           },
           "type": {
             "$ref": "#/components/schemas/'impression'",
@@ -192,7 +192,7 @@
           },
           "server_id": {
             "type": "number",
-            "example": 409
+            "example": 292
           },
           "target_url": {
             "type": "string",
@@ -210,13 +210,69 @@
         },
         "description": "AdvertisementEvent (Model)"
       },
+      "BlacklistedIdentifier": {
+        "type": "object",
+        "required": [],
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 681
+          },
+          "type": {
+            "$ref": "#/components/schemas/'email'",
+            "example": null
+          },
+          "value": {
+            "type": "string",
+            "example": "Lorem Ipsum"
+          },
+          "reason": {
+            "type": "string",
+            "example": "Lorem Ipsum"
+          },
+          "blacklisted_by": {
+            "type": "number",
+            "example": 354
+          },
+          "created_at": {
+            "type": "string",
+            "example": "2021-03-23T16:13:08.489+01:00",
+            "format": "date-time"
+          }
+        },
+        "description": "BlacklistedIdentifier (Model)"
+      },
+      "BlacklistedIdentifierUser": {
+        "type": "object",
+        "required": [],
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 263
+          },
+          "blacklisted_identifier_id": {
+            "type": "number",
+            "example": 598
+          },
+          "user_id": {
+            "type": "number",
+            "example": 639
+          },
+          "created_at": {
+            "type": "string",
+            "example": "2021-03-23T16:13:08.489+01:00",
+            "format": "date-time"
+          }
+        },
+        "description": "BlacklistedIdentifierUser (Model)"
+      },
       "Category": {
         "type": "object",
         "required": [],
         "properties": {
           "id": {
             "type": "number",
-            "example": 872
+            "example": 843
           },
           "name": {
             "type": "string",
@@ -241,7 +297,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 805
+            "example": 119
           },
           "code": {
             "$ref": "#/components/schemas/LanguageCode",
@@ -274,7 +330,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 555
+            "example": 137
           },
           "uuid": {
             "type": "string",
@@ -316,15 +372,15 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 118
+            "example": 354
           },
           "visitor_id": {
             "type": "number",
-            "example": 794
+            "example": 78
           },
           "user_id": {
             "type": "number",
-            "example": 76
+            "example": 853
           },
           "path": {
             "type": "string",
@@ -340,7 +396,7 @@
           },
           "duration_ms": {
             "type": "number",
-            "example": 262
+            "example": 285
           },
           "created_at": {
             "type": "string",
@@ -364,7 +420,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 263
+            "example": 477
           },
           "cover_image": {
             "type": "string",
@@ -376,7 +432,7 @@
           },
           "view_count": {
             "type": "number",
-            "example": 565
+            "example": 874
           },
           "default_locale": {
             "type": "string",
@@ -389,7 +445,7 @@
           },
           "user_id": {
             "type": "number",
-            "example": 660
+            "example": 663
           },
           "author": {
             "$ref": "#/components/schemas/User",
@@ -421,15 +477,15 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 808
+            "example": 543
           },
           "post_id": {
             "type": "number",
-            "example": 202
+            "example": 290
           },
           "user_id": {
             "type": "number",
-            "example": 72
+            "example": 975
           },
           "visitor_id": {
             "type": "string",
@@ -466,11 +522,11 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 39
+            "example": 557
           },
           "post_id": {
             "type": "number",
-            "example": 959
+            "example": 388
           },
           "locale": {
             "type": "string",
@@ -515,7 +571,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 930
+            "example": 893
           },
           "name": {
             "type": "string",
@@ -527,7 +583,7 @@
           },
           "port": {
             "type": "number",
-            "example": 407
+            "example": 436
           },
           "type": {
             "$ref": "#/components/schemas/ServerType",
@@ -567,7 +623,7 @@
           },
           "user_id": {
             "type": "number",
-            "example": 677
+            "example": 30
           },
           "user": {
             "$ref": "#/components/schemas/User",
@@ -602,7 +658,7 @@
           },
           "vote_count": {
             "type": "number",
-            "example": 990
+            "example": 256
           },
           "categories": {
             "type": "array",
@@ -625,11 +681,11 @@
           },
           "last_player_count": {
             "type": "number",
-            "example": 763
+            "example": 193
           },
           "last_max_count": {
             "type": "number",
-            "example": 951
+            "example": 286
           },
           "last_stats_at": {
             "type": "string",
@@ -638,7 +694,7 @@
           },
           "peak_player_count": {
             "type": "number",
-            "example": 622
+            "example": 73
           },
           "peak_player_at": {
             "type": "string",
@@ -669,27 +725,27 @@
         "properties": {
           "server_id": {
             "type": "number",
-            "example": 460
+            "example": 749
           },
           "weekly_growth": {
             "type": "number",
-            "example": 977
+            "example": 544
           },
           "monthly_growth": {
             "type": "number",
-            "example": 288
+            "example": 969
           },
           "last_week_average": {
             "type": "number",
-            "example": 236
+            "example": 865
           },
           "previous_week_average": {
             "type": "number",
-            "example": 795
+            "example": 180
           },
           "last_month_average": {
             "type": "number",
-            "example": 881
+            "example": 619
           },
           "last_updated": {
             "type": "string",
@@ -705,11 +761,11 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 996
+            "example": 65
           },
           "server_id": {
             "type": "number",
-            "example": 516
+            "example": 181
           },
           "server": {
             "$ref": "#/components/schemas/Server",
@@ -717,7 +773,7 @@
           },
           "user_id": {
             "type": "number",
-            "example": 785
+            "example": 957
           },
           "user": {
             "$ref": "#/components/schemas/User",
@@ -751,7 +807,7 @@
           },
           "reviewed_by": {
             "type": "number",
-            "example": 432
+            "example": 5
           },
           "reviewer": {
             "$ref": "#/components/schemas/User",
@@ -780,7 +836,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 321
+            "example": 969
           },
           "server": {
             "$ref": "#/components/schemas/Server",
@@ -788,15 +844,15 @@
           },
           "server_id": {
             "type": "number",
-            "example": 816
+            "example": 919
           },
           "player_count": {
             "type": "number",
-            "example": 203
+            "example": 27
           },
           "max_count": {
             "type": "number",
-            "example": 725
+            "example": 835
           },
           "created_at": {
             "type": "string",
@@ -812,7 +868,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 340
+            "example": 200
           },
           "server": {
             "$ref": "#/components/schemas/Server",
@@ -820,11 +876,11 @@
           },
           "server_id": {
             "type": "number",
-            "example": 492
+            "example": 898
           },
           "visitor_id": {
             "type": "number",
-            "example": 365
+            "example": 565
           },
           "user": {
             "$ref": "#/components/schemas/User",
@@ -832,7 +888,7 @@
           },
           "user_id": {
             "type": "number",
-            "example": 540
+            "example": 427
           },
           "username": {
             "type": "string",
@@ -869,7 +925,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 623
+            "example": 784
           },
           "date": {
             "type": "string",
@@ -878,15 +934,15 @@
           },
           "http_requests": {
             "type": "number",
-            "example": 600
+            "example": 787
           },
           "http_errors": {
             "type": "number",
-            "example": 348
+            "example": 131
           },
           "unique_visitors": {
             "type": "number",
-            "example": 569
+            "example": 386
           },
           "countries": {
             "$ref": "#/components/schemas/Record<string, number>",
@@ -911,7 +967,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 122
+            "example": 280
           },
           "username": {
             "type": "string",
@@ -937,6 +993,19 @@
             "type": "string",
             "example": "2021-03-23T16:13:08.489+01:00",
             "format": "date-time"
+          },
+          "blacklisted_at": {
+            "type": "string",
+            "example": "2021-03-23T16:13:08.489+01:00",
+            "format": "date-time"
+          },
+          "blacklisted_by": {
+            "type": "number",
+            "example": 775
+          },
+          "blacklist_reason": {
+            "type": "string",
+            "example": "Lorem Ipsum"
           },
           "created_at": {
             "type": "string",
@@ -971,7 +1040,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 321
+            "example": 665
           },
           "user": {
             "$ref": "#/components/schemas/User",
@@ -979,7 +1048,7 @@
           },
           "user_id": {
             "type": "number",
-            "example": 605
+            "example": 725
           },
           "provider": {
             "$ref": "#/components/schemas/'google'",
@@ -1013,7 +1082,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 593
+            "example": 467
           },
           "uuid": {
             "type": "string",
@@ -1064,15 +1133,15 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 684
+            "example": 838
           },
           "visitor_id": {
             "type": "number",
-            "example": 710
+            "example": 959
           },
           "user_id": {
             "type": "number",
-            "example": 948
+            "example": 781
           },
           "linked_at": {
             "type": "string",
@@ -1107,7 +1176,7 @@
           },
           "type": {
             "type": "number",
-            "example": 42,
+            "example": 140,
             "choices": [
               "custom",
               "network"
@@ -1150,13 +1219,13 @@
             "type": "array",
             "items": {
               "type": "number",
-              "example": 166
+              "example": 839
             }
           }
         },
         "example": {
           "name": "Lorem Ipsum",
-          "type": 42,
+          "type": 140,
           "htmlContent": "Lorem Ipsum",
           "enabled": true,
           "weight": 1,
@@ -1165,7 +1234,7 @@
           "startsAt": "Lorem Ipsum",
           "endsAt": "Lorem Ipsum",
           "categoryIds": [
-            166
+            839
           ]
         },
         "description": "CreateAdvertisementValidator (Validator)"
@@ -1181,7 +1250,7 @@
           },
           "type": {
             "type": "number",
-            "example": 566,
+            "example": 35,
             "choices": [
               "custom",
               "network"
@@ -1223,13 +1292,13 @@
             "type": "array",
             "items": {
               "type": "number",
-              "example": 20
+              "example": 74
             }
           }
         },
         "example": {
           "name": "Lorem Ipsum",
-          "type": 566,
+          "type": 35,
           "htmlContent": "Lorem Ipsum",
           "enabled": true,
           "weight": 1,
@@ -1238,7 +1307,7 @@
           "startsAt": "Lorem Ipsum",
           "endsAt": "Lorem Ipsum",
           "categoryIds": [
-            20
+            74
           ]
         },
         "description": "UpdateAdvertisementValidator (Validator)"
@@ -1284,7 +1353,7 @@
           },
           "durationMs": {
             "type": "number",
-            "example": 361,
+            "example": 602,
             "maximum": 86400000
           }
         },
@@ -1293,7 +1362,7 @@
           "path": "Lorem Ipsum",
           "referrer": "Lorem Ipsum",
           "title": "Lorem Ipsum",
-          "durationMs": 361
+          "durationMs": 602
         },
         "description": "TrackPageViewValidator (Validator)"
       },
@@ -1309,13 +1378,13 @@
           },
           "expiresInDays": {
             "type": "number",
-            "example": 320,
+            "example": 292,
             "maximum": 3650
           }
         },
         "example": {
           "name": "Lorem Ipsum",
-          "expiresInDays": 320
+          "expiresInDays": 292
         },
         "description": "CreateApiTokenValidator (Validator)"
       },
@@ -1324,12 +1393,12 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 308,
+            "example": 920,
             "required": true
           }
         },
         "example": {
-          "id": 308
+          "id": 920
         },
         "description": "CategoryIdValidator (Validator)"
       },
@@ -1352,7 +1421,7 @@
         "properties": {
           "id": {
             "type": "number",
-            "example": 616,
+            "example": 219,
             "required": true
           },
           "name": {
@@ -1362,7 +1431,7 @@
           }
         },
         "example": {
-          "id": 616,
+          "id": 219,
           "name": "Lorem Ipsum"
         },
         "description": "UpdateCategoryValidator (Validator)"
@@ -1372,15 +1441,15 @@
         "properties": {
           "fromDate": {
             "type": "number",
-            "example": 111
+            "example": 225
           },
           "toDate": {
             "type": "number",
-            "example": 974
+            "example": 979
           },
           "interval": {
             "type": "number",
-            "example": 385,
+            "example": 163,
             "choices": [
               "30 minutes",
               "1 hour",
@@ -1392,19 +1461,19 @@
           },
           "categoryId": {
             "type": "number",
-            "example": 92
+            "example": 450
           },
           "languageId": {
             "type": "number",
-            "example": 393
+            "example": 733
           }
         },
         "example": {
-          "fromDate": 111,
-          "toDate": 974,
-          "interval": 385,
-          "categoryId": 92,
-          "languageId": 393
+          "fromDate": 225,
+          "toDate": 979,
+          "interval": 163,
+          "categoryId": 450,
+          "languageId": 733
         },
         "description": "GlobalStatValidator (Validator)"
       },
@@ -1413,7 +1482,7 @@
         "properties": {
           "defaultLocale": {
             "type": "number",
-            "example": 316,
+            "example": 432,
             "choices": [
               "fr",
               "en",
@@ -1433,7 +1502,7 @@
               "properties": {
                 "locale": {
                   "type": "number",
-                  "example": 934,
+                  "example": 282,
                   "choices": [
                     "fr",
                     "en",
@@ -1462,7 +1531,7 @@
                 },
                 "excerpt": {
                   "type": "number",
-                  "example": 565,
+                  "example": 292,
                   "maximum": 500
                 }
               }
@@ -1491,11 +1560,11 @@
           }
         },
         "example": {
-          "defaultLocale": 316,
+          "defaultLocale": 432,
           "coverImage": "Lorem Ipsum",
           "translations": [
             {
-              "locale": 934,
+              "locale": 282,
               "title": "Lorem Ipsum",
               "slug": "Lorem Ipsum",
               "content": "Lorem Ipsum",
@@ -1515,13 +1584,13 @@
           },
           "serverId": {
             "type": "number",
-            "example": 674,
+            "example": 966,
             "required": true
           }
         },
         "example": {
           "placeholderName": "Lorem Ipsum",
-          "serverId": 674
+          "serverId": 966
         },
         "description": "PreviewPlaceholderValidator (Validator)"
       },
@@ -1579,7 +1648,7 @@
         "properties": {
           "defaultLocale": {
             "type": "number",
-            "example": 407,
+            "example": 666,
             "choices": [
               "fr",
               "en",
@@ -1598,7 +1667,7 @@
               "properties": {
                 "locale": {
                   "type": "number",
-                  "example": 73,
+                  "example": 295,
                   "choices": [
                     "fr",
                     "en",
@@ -1625,7 +1694,7 @@
                 },
                 "excerpt": {
                   "type": "number",
-                  "example": 618,
+                  "example": 83,
                   "maximum": 500
                 }
               }
@@ -1653,11 +1722,11 @@
           }
         },
         "example": {
-          "defaultLocale": 407,
+          "defaultLocale": 666,
           "coverImage": "Lorem Ipsum",
           "translations": [
             {
-              "locale": 73,
+              "locale": 295,
               "title": "Lorem Ipsum",
               "slug": "Lorem Ipsum",
               "content": "Lorem Ipsum",
@@ -1689,7 +1758,7 @@
           },
           "type": {
             "type": "number",
-            "example": 812,
+            "example": 442,
             "choices": [
               "java",
               "bedrock"
@@ -1703,7 +1772,7 @@
             "type": "array",
             "items": {
               "type": "number",
-              "example": 650
+              "example": 421
             },
             "required": true,
             "properties": {
@@ -1729,7 +1798,7 @@
             "type": "array",
             "items": {
               "type": "number",
-              "example": 751
+              "example": 905
             },
             "required": true
           }
@@ -1738,7 +1807,7 @@
           "name": "Lorem Ipsum",
           "address": "Lorem Ipsum",
           "port": 1,
-          "type": 812,
+          "type": 442,
           "imageUrl": "Lorem Ipsum",
           "categories": [
             "Lorem Ipsum"
@@ -1747,7 +1816,7 @@
           "website": "Lorem Ipsum",
           "motd": "Lorem Ipsum",
           "languages": [
-            751
+            905
           ]
         },
         "description": "CreateServerValidator (Validator)"
@@ -1771,7 +1840,7 @@
           },
           "type": {
             "type": "number",
-            "example": 453,
+            "example": 227,
             "choices": [
               "java",
               "bedrock"
@@ -1785,7 +1854,7 @@
             "type": "array",
             "items": {
               "type": "number",
-              "example": 56
+              "example": 714
             },
             "properties": {
               "items": {
@@ -1810,7 +1879,7 @@
             "type": "array",
             "items": {
               "type": "number",
-              "example": 264
+              "example": 640
             }
           }
         },
@@ -1818,7 +1887,7 @@
           "name": "Lorem Ipsum",
           "address": "Lorem Ipsum",
           "port": 1,
-          "type": 453,
+          "type": 227,
           "imageUrl": "Lorem Ipsum",
           "categories": [
             "Lorem Ipsum"
@@ -1827,7 +1896,7 @@
           "website": "Lorem Ipsum",
           "motd": "Lorem Ipsum",
           "languages": [
-            264
+            640
           ]
         },
         "description": "UpdateServerValidator (Validator)"
@@ -1837,18 +1906,18 @@
         "properties": {
           "serverId": {
             "type": "number",
-            "example": 658,
+            "example": 366,
             "required": true
           },
           "categoryId": {
             "type": "number",
-            "example": 150,
+            "example": 654,
             "required": true
           }
         },
         "example": {
-          "serverId": 658,
-          "categoryId": 150
+          "serverId": 366,
+          "categoryId": 654
         },
         "description": "attachServerCategoryValidator (Validator)"
       },
@@ -1938,7 +2007,7 @@
         "properties": {
           "server_id": {
             "type": "number",
-            "example": 857,
+            "example": 513,
             "required": true
           },
           "days": {
@@ -1956,7 +2025,7 @@
           }
         },
         "example": {
-          "server_id": 857,
+          "server_id": 513,
           "days": 1,
           "timezone": "Lorem Ipsum"
         },
@@ -1967,20 +2036,20 @@
         "properties": {
           "server_id": {
             "type": "number",
-            "example": 22,
+            "example": 835,
             "required": true
           },
           "fromDate": {
             "type": "number",
-            "example": 979
+            "example": 743
           },
           "toDate": {
             "type": "number",
-            "example": 612
+            "example": 348
           },
           "interval": {
             "type": "number",
-            "example": 771,
+            "example": 798,
             "choices": [
               "30 minutes",
               "1 hour",
@@ -1992,7 +2061,7 @@
           },
           "format": {
             "type": "number",
-            "example": 829,
+            "example": 391,
             "choices": [
               "csv",
               "json"
@@ -2001,11 +2070,11 @@
           }
         },
         "example": {
-          "server_id": 22,
-          "fromDate": 979,
-          "toDate": 612,
-          "interval": 771,
-          "format": 829
+          "server_id": 835,
+          "fromDate": 743,
+          "toDate": 348,
+          "interval": 798,
+          "format": 391
         },
         "description": "StatExportValidator (Validator)"
       },
@@ -2014,24 +2083,24 @@
         "properties": {
           "server_id": {
             "type": "number",
-            "example": 619,
+            "example": 12,
             "required": true
           },
           "exactTime": {
             "type": "number",
-            "example": 616
+            "example": 410
           },
           "fromDate": {
             "type": "number",
-            "example": 723
+            "example": 692
           },
           "toDate": {
             "type": "number",
-            "example": 245
+            "example": 692
           },
           "interval": {
             "type": "number",
-            "example": 25,
+            "example": 910,
             "choices": [
               "30 minutes",
               "1 hour",
@@ -2043,11 +2112,11 @@
           }
         },
         "example": {
-          "server_id": 619,
-          "exactTime": 616,
-          "fromDate": 723,
-          "toDate": 245,
-          "interval": 25
+          "server_id": 12,
+          "exactTime": 410,
+          "fromDate": 692,
+          "toDate": 692,
+          "interval": 910
         },
         "description": "StatValidator (Validator)"
       },
@@ -2196,6 +2265,26 @@
         },
         "description": "ResetPasswordValidator (Validator)"
       },
+      "UpdateUserBlacklistValidator": {
+        "type": "object",
+        "properties": {
+          "blacklisted": {
+            "type": "boolean",
+            "example": true,
+            "required": true
+          },
+          "reason": {
+            "type": "string",
+            "example": "Lorem Ipsum",
+            "maxLength": 500
+          }
+        },
+        "example": {
+          "blacklisted": true,
+          "reason": "Lorem Ipsum"
+        },
+        "description": "UpdateUserBlacklistValidator (Validator)"
+      },
       "UpdateUserValidator": {
         "type": "object",
         "properties": {
@@ -2301,10 +2390,10 @@
                 "example": [
                   {
                     "server": {
-                      "id": 930,
+                      "id": 893,
                       "name": "John Doe",
                       "address": "1028 Farland Street",
-                      "port": 407,
+                      "port": 436,
                       "type": {},
                       "version": "Lorem Ipsum",
                       "website": "Lorem Ipsum",
@@ -2314,15 +2403,15 @@
                       "resolved_endpoint": "Lorem Ipsum",
                       "motd_hash": "Lorem Ipsum",
                       "host_domain": "Lorem Ipsum",
-                      "user_id": 677,
+                      "user_id": 30,
                       "owner_verified_at": "2021-03-23T16:13:08.489+01:00",
                       "owner_verified_method": {},
-                      "vote_count": 990,
+                      "vote_count": 256,
                       "last_online_at": "2021-03-23T16:13:08.489+01:00",
-                      "last_player_count": 763,
-                      "last_max_count": 951,
+                      "last_player_count": 193,
+                      "last_max_count": 286,
                       "last_stats_at": "2021-03-23T16:13:08.489+01:00",
-                      "peak_player_count": 622,
+                      "peak_player_count": 73,
                       "peak_player_at": "2021-03-23T16:13:08.489+01:00",
                       "next_ping_at": "2021-03-23T16:13:08.489+01:00",
                       "created_at": "2021-03-23T16:13:08.489+01:00",
@@ -2332,12 +2421,12 @@
                       "<Category>"
                     ],
                     "growthStat": {
-                      "server_id": 460,
-                      "weekly_growth": 977,
-                      "monthly_growth": 288,
-                      "last_week_average": 236,
-                      "previous_week_average": 795,
-                      "last_month_average": 881,
+                      "server_id": 749,
+                      "weekly_growth": 544,
+                      "monthly_growth": 969,
+                      "last_week_average": 865,
+                      "previous_week_average": 180,
+                      "last_month_average": 619,
                       "last_updated": "2021-03-23T16:13:08.489+01:00"
                     }
                   }
@@ -2971,10 +3060,10 @@
                 "example": {
                   "verified": true,
                   "server": {
-                    "id": 930,
+                    "id": 893,
                     "name": "John Doe",
                     "address": "1028 Farland Street",
-                    "port": 407,
+                    "port": 436,
                     "type": {},
                     "version": "Lorem Ipsum",
                     "website": "Lorem Ipsum",
@@ -2984,15 +3073,15 @@
                     "resolved_endpoint": "Lorem Ipsum",
                     "motd_hash": "Lorem Ipsum",
                     "host_domain": "Lorem Ipsum",
-                    "user_id": 677,
+                    "user_id": 30,
                     "owner_verified_at": "2021-03-23T16:13:08.489+01:00",
                     "owner_verified_method": {},
-                    "vote_count": 990,
+                    "vote_count": 256,
                     "last_online_at": "2021-03-23T16:13:08.489+01:00",
-                    "last_player_count": 763,
-                    "last_max_count": 951,
+                    "last_player_count": 193,
+                    "last_max_count": 286,
                     "last_stats_at": "2021-03-23T16:13:08.489+01:00",
-                    "peak_player_count": 622,
+                    "peak_player_count": 73,
                     "peak_player_at": "2021-03-23T16:13:08.489+01:00",
                     "next_ping_at": "2021-03-23T16:13:08.489+01:00",
                     "created_at": "2021-03-23T16:13:08.489+01:00",
@@ -3224,10 +3313,10 @@
                 "example": {
                   "verified": true,
                   "server": {
-                    "id": 930,
+                    "id": 893,
                     "name": "John Doe",
                     "address": "1028 Farland Street",
-                    "port": 407,
+                    "port": 436,
                     "type": {},
                     "version": "Lorem Ipsum",
                     "website": "Lorem Ipsum",
@@ -3237,15 +3326,15 @@
                     "resolved_endpoint": "Lorem Ipsum",
                     "motd_hash": "Lorem Ipsum",
                     "host_domain": "Lorem Ipsum",
-                    "user_id": 677,
+                    "user_id": 30,
                     "owner_verified_at": "2021-03-23T16:13:08.489+01:00",
                     "owner_verified_method": {},
-                    "vote_count": 990,
+                    "vote_count": 256,
                     "last_online_at": "2021-03-23T16:13:08.489+01:00",
-                    "last_player_count": 763,
-                    "last_max_count": 951,
+                    "last_player_count": 193,
+                    "last_max_count": 286,
                     "last_stats_at": "2021-03-23T16:13:08.489+01:00",
-                    "peak_player_count": 622,
+                    "peak_player_count": 73,
                     "peak_player_at": "2021-03-23T16:13:08.489+01:00",
                     "next_ping_at": "2021-03-23T16:13:08.489+01:00",
                     "created_at": "2021-03-23T16:13:08.489+01:00",
@@ -6025,7 +6114,7 @@
               },
               "example": {
                 "name": "Lorem Ipsum",
-                "expiresInDays": 320
+                "expiresInDays": 292
               }
             }
           }
@@ -6779,7 +6868,7 @@
     "/api/v1/posts/placeholders/resolve": {
       "post": {
         "summary": "Resolve content placeholders to their current values (resolvePlaceholders)",
-        "description": "Resolves a batch of placeholder tokens to their live values. Returns a map of token → value. Publicly accessible.\n\n _app/controllers/posts_controller.ts_ - **resolvePlaceholders**",
+        "description": "Resolves a batch of placeholder tokens to their live values. Returns a map of token → value, e.g. `{\"%PLAYER_COUNT_REALTIME_125%\": \"42\", \"%SERVER_VERSION_125%\": \"1.21.4\"}`. Publicly accessible.\n\n _app/controllers/posts_controller.ts_ - **resolvePlaceholders**",
         "operationId": "resolvePlaceholders",
         "parameters": [],
         "tags": [
@@ -6788,21 +6877,11 @@
         "responses": {
           "200": {
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "%PLAYER_COUNT_REALTIME_125%": "42",
-                    "%SERVER_VERSION_125%": "1.21.4"
-                  }
-                },
-                "example": {
-                  "%PLAYER_COUNT_REALTIME_125%": "42",
-                  "%SERVER_VERSION_125%": "1.21.4"
-                }
+              "text/plain": {
+                "example": "Map of each submitted token to its resolved string value"
               }
             },
-            "description": "Returns **200** (OK) as **application/json**"
+            "description": "Returns **200** (OK) as **text/plain**"
           },
           "422": {
             "content": {
@@ -7534,10 +7613,10 @@
                     "status": "pending",
                     "evidence": "Discord: owner#1234",
                     "server": {
-                      "id": 930,
+                      "id": 893,
                       "name": "John Doe",
                       "address": "1028 Farland Street",
-                      "port": 407,
+                      "port": 436,
                       "type": {},
                       "version": "Lorem Ipsum",
                       "website": "Lorem Ipsum",
@@ -7547,28 +7626,31 @@
                       "resolved_endpoint": "Lorem Ipsum",
                       "motd_hash": "Lorem Ipsum",
                       "host_domain": "Lorem Ipsum",
-                      "user_id": 677,
+                      "user_id": 30,
                       "owner_verified_at": "2021-03-23T16:13:08.489+01:00",
                       "owner_verified_method": {},
-                      "vote_count": 990,
+                      "vote_count": 256,
                       "last_online_at": "2021-03-23T16:13:08.489+01:00",
-                      "last_player_count": 763,
-                      "last_max_count": 951,
+                      "last_player_count": 193,
+                      "last_max_count": 286,
                       "last_stats_at": "2021-03-23T16:13:08.489+01:00",
-                      "peak_player_count": 622,
+                      "peak_player_count": 73,
                       "peak_player_at": "2021-03-23T16:13:08.489+01:00",
                       "next_ping_at": "2021-03-23T16:13:08.489+01:00",
                       "created_at": "2021-03-23T16:13:08.489+01:00",
                       "updated_at": "2021-03-23T16:13:08.489+01:00"
                     },
                     "user": {
-                      "id": 122,
+                      "id": 280,
                       "username": "Lorem Ipsum",
                       "verified": true,
                       "provider": {},
                       "role": {},
                       "avatar_url": "Lorem Ipsum",
                       "verification_token_expires": "2021-03-23T16:13:08.489+01:00",
+                      "blacklisted_at": "2021-03-23T16:13:08.489+01:00",
+                      "blacklisted_by": 775,
+                      "blacklist_reason": "Lorem Ipsum",
                       "created_at": "2021-03-23T16:13:08.489+01:00",
                       "updated_at": "2021-03-23T16:13:08.489+01:00"
                     }
@@ -7643,10 +7725,10 @@
                 "example": {
                   "message": "Claim approved.",
                   "server": {
-                    "id": 930,
+                    "id": 893,
                     "name": "John Doe",
                     "address": "1028 Farland Street",
-                    "port": 407,
+                    "port": 436,
                     "type": {},
                     "version": "Lorem Ipsum",
                     "website": "Lorem Ipsum",
@@ -7656,15 +7738,15 @@
                     "resolved_endpoint": "Lorem Ipsum",
                     "motd_hash": "Lorem Ipsum",
                     "host_domain": "Lorem Ipsum",
-                    "user_id": 677,
+                    "user_id": 30,
                     "owner_verified_at": "2021-03-23T16:13:08.489+01:00",
                     "owner_verified_method": {},
-                    "vote_count": 990,
+                    "vote_count": 256,
                     "last_online_at": "2021-03-23T16:13:08.489+01:00",
-                    "last_player_count": 763,
-                    "last_max_count": 951,
+                    "last_player_count": 193,
+                    "last_max_count": 286,
                     "last_stats_at": "2021-03-23T16:13:08.489+01:00",
-                    "peak_player_count": 622,
+                    "peak_player_count": 73,
                     "peak_player_at": "2021-03-23T16:13:08.489+01:00",
                     "next_ping_at": "2021-03-23T16:13:08.489+01:00",
                     "created_at": "2021-03-23T16:13:08.489+01:00",
@@ -7881,6 +7963,45 @@
       "patch": {
         "summary": " (updateRole)",
         "description": "\n\n _app/controllers/users_controller.ts_ - **updateRole**",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "ADMIN"
+        ],
+        "responses": {
+          "401": {
+            "description": "Returns **401** (Unauthorized)"
+          },
+          "403": {
+            "description": "Returns **403** (Forbidden)"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": [
+              "access"
+            ]
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {}
+          }
+        }
+      }
+    },
+    "/api/v1/admin/users/{id}/blacklist": {
+      "patch": {
+        "summary": " (updateBlacklist)",
+        "description": "\n\n _app/controllers/users_controller.ts_ - **updateBlacklist**",
         "parameters": [
           {
             "in": "path",

--- a/backend/swagger.yml
+++ b/backend/swagger.yml
@@ -78,7 +78,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 219
+          example: 618
         name:
           type: "string"
           example: "John Doe"
@@ -93,7 +93,7 @@ components:
           example: true
         weight:
           type: "number"
-          example: 804
+          example: 21
         show_on_home:
           type: "boolean"
           example: true
@@ -133,10 +133,10 @@ components:
       properties:
         id:
           type: "number"
-          example: 538
+          example: 58
         advertisement_id:
           type: "number"
-          example: 644
+          example: 490
         type:
           $ref: "#/components/schemas/'impression'"
           example: null
@@ -145,7 +145,7 @@ components:
           example: "Lorem Ipsum"
         server_id:
           type: "number"
-          example: 409
+          example: 292
         target_url:
           type: "string"
           example: "Lorem Ipsum"
@@ -157,13 +157,55 @@ components:
           $ref: "#/components/schemas/Advertisement"
           example: null
       description: "AdvertisementEvent (Model)"
+    BlacklistedIdentifier:
+      type: "object"
+      required: []
+      properties:
+        id:
+          type: "number"
+          example: 681
+        type:
+          $ref: "#/components/schemas/'email'"
+          example: null
+        value:
+          type: "string"
+          example: "Lorem Ipsum"
+        reason:
+          type: "string"
+          example: "Lorem Ipsum"
+        blacklisted_by:
+          type: "number"
+          example: 354
+        created_at:
+          type: "string"
+          example: "2021-03-23T16:13:08.489+01:00"
+          format: "date-time"
+      description: "BlacklistedIdentifier (Model)"
+    BlacklistedIdentifierUser:
+      type: "object"
+      required: []
+      properties:
+        id:
+          type: "number"
+          example: 263
+        blacklisted_identifier_id:
+          type: "number"
+          example: 598
+        user_id:
+          type: "number"
+          example: 639
+        created_at:
+          type: "string"
+          example: "2021-03-23T16:13:08.489+01:00"
+          format: "date-time"
+      description: "BlacklistedIdentifierUser (Model)"
     Category:
       type: "object"
       required: []
       properties:
         id:
           type: "number"
-          example: 872
+          example: 843
         name:
           type: "string"
           example: "John Doe"
@@ -182,7 +224,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 805
+          example: 119
         code:
           $ref: "#/components/schemas/LanguageCode"
           example: null
@@ -207,7 +249,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 555
+          example: 137
         uuid:
           type: "string"
           example: "Lorem Ipsum"
@@ -239,13 +281,13 @@ components:
       properties:
         id:
           type: "number"
-          example: 118
+          example: 354
         visitor_id:
           type: "number"
-          example: 794
+          example: 78
         user_id:
           type: "number"
-          example: 76
+          example: 853
         path:
           type: "string"
           example: "Lorem Ipsum"
@@ -257,7 +299,7 @@ components:
           example: "Lorem Ipsum"
         duration_ms:
           type: "number"
-          example: 262
+          example: 285
         created_at:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
@@ -275,7 +317,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 263
+          example: 477
         cover_image:
           type: "string"
           example: "Lorem Ipsum"
@@ -284,7 +326,7 @@ components:
           example: true
         view_count:
           type: "number"
-          example: 565
+          example: 874
         default_locale:
           type: "string"
           example: "Lorem Ipsum"
@@ -294,7 +336,7 @@ components:
           format: "date-time"
         user_id:
           type: "number"
-          example: 660
+          example: 663
         author:
           $ref: "#/components/schemas/User"
           example: null
@@ -318,13 +360,13 @@ components:
       properties:
         id:
           type: "number"
-          example: 808
+          example: 543
         post_id:
           type: "number"
-          example: 202
+          example: 290
         user_id:
           type: "number"
-          example: 72
+          example: 975
         visitor_id:
           type: "string"
           example: "Lorem Ipsum"
@@ -352,10 +394,10 @@ components:
       properties:
         id:
           type: "number"
-          example: 39
+          example: 557
         post_id:
           type: "number"
-          example: 959
+          example: 388
         locale:
           type: "string"
           example: "Lorem Ipsum"
@@ -389,7 +431,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 930
+          example: 893
         name:
           type: "string"
           example: "John Doe"
@@ -398,7 +440,7 @@ components:
           example: "1028 Farland Street"
         port:
           type: "number"
-          example: 407
+          example: 436
         type:
           $ref: "#/components/schemas/ServerType"
           example: null
@@ -428,7 +470,7 @@ components:
           example: "Lorem Ipsum"
         user_id:
           type: "number"
-          example: 677
+          example: 30
         user:
           $ref: "#/components/schemas/User"
           example: null
@@ -454,7 +496,7 @@ components:
             example: null
         vote_count:
           type: "number"
-          example: 990
+          example: 256
         categories:
           type: "array"
           items:
@@ -471,17 +513,17 @@ components:
           format: "date-time"
         last_player_count:
           type: "number"
-          example: 763
+          example: 193
         last_max_count:
           type: "number"
-          example: 951
+          example: 286
         last_stats_at:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
           format: "date-time"
         peak_player_count:
           type: "number"
-          example: 622
+          example: 73
         peak_player_at:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
@@ -505,22 +547,22 @@ components:
       properties:
         server_id:
           type: "number"
-          example: 460
+          example: 749
         weekly_growth:
           type: "number"
-          example: 977
+          example: 544
         monthly_growth:
           type: "number"
-          example: 288
+          example: 969
         last_week_average:
           type: "number"
-          example: 236
+          example: 865
         previous_week_average:
           type: "number"
-          example: 795
+          example: 180
         last_month_average:
           type: "number"
-          example: 881
+          example: 619
         last_updated:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
@@ -532,16 +574,16 @@ components:
       properties:
         id:
           type: "number"
-          example: 996
+          example: 65
         server_id:
           type: "number"
-          example: 516
+          example: 181
         server:
           $ref: "#/components/schemas/Server"
           example: null
         user_id:
           type: "number"
-          example: 785
+          example: 957
         user:
           $ref: "#/components/schemas/User"
           example: null
@@ -567,7 +609,7 @@ components:
           format: "date-time"
         reviewed_by:
           type: "number"
-          example: 432
+          example: 5
         reviewer:
           $ref: "#/components/schemas/User"
           example: null
@@ -589,19 +631,19 @@ components:
       properties:
         id:
           type: "number"
-          example: 321
+          example: 969
         server:
           $ref: "#/components/schemas/Server"
           example: null
         server_id:
           type: "number"
-          example: 816
+          example: 919
         player_count:
           type: "number"
-          example: 203
+          example: 27
         max_count:
           type: "number"
-          example: 725
+          example: 835
         created_at:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
@@ -613,22 +655,22 @@ components:
       properties:
         id:
           type: "number"
-          example: 340
+          example: 200
         server:
           $ref: "#/components/schemas/Server"
           example: null
         server_id:
           type: "number"
-          example: 492
+          example: 898
         visitor_id:
           type: "number"
-          example: 365
+          example: 565
         user:
           $ref: "#/components/schemas/User"
           example: null
         user_id:
           type: "number"
-          example: 540
+          example: 427
         username:
           type: "string"
           example: "Lorem Ipsum"
@@ -656,20 +698,20 @@ components:
       properties:
         id:
           type: "number"
-          example: 623
+          example: 784
         date:
           type: "string"
           example: "2021-03-23"
           format: "date-time"
         http_requests:
           type: "number"
-          example: 600
+          example: 787
         http_errors:
           type: "number"
-          example: 348
+          example: 131
         unique_visitors:
           type: "number"
-          example: 569
+          example: 386
         countries:
           $ref: "#/components/schemas/Record<string, number>"
           example: null
@@ -688,7 +730,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 122
+          example: 280
         username:
           type: "string"
           example: "Lorem Ipsum"
@@ -708,6 +750,16 @@ components:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
           format: "date-time"
+        blacklisted_at:
+          type: "string"
+          example: "2021-03-23T16:13:08.489+01:00"
+          format: "date-time"
+        blacklisted_by:
+          type: "number"
+          example: 775
+        blacklist_reason:
+          type: "string"
+          example: "Lorem Ipsum"
         created_at:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
@@ -733,13 +785,13 @@ components:
       properties:
         id:
           type: "number"
-          example: 321
+          example: 665
         user:
           $ref: "#/components/schemas/User"
           example: null
         user_id:
           type: "number"
-          example: 605
+          example: 725
         provider:
           $ref: "#/components/schemas/'google'"
           example: null
@@ -765,7 +817,7 @@ components:
       properties:
         id:
           type: "number"
-          example: 593
+          example: 467
         uuid:
           type: "string"
           example: "Lorem Ipsum"
@@ -803,13 +855,13 @@ components:
       properties:
         id:
           type: "number"
-          example: 684
+          example: 838
         visitor_id:
           type: "number"
-          example: 710
+          example: 959
         user_id:
           type: "number"
-          example: 948
+          example: 781
         linked_at:
           type: "string"
           example: "2021-03-23T16:13:08.489+01:00"
@@ -836,7 +888,7 @@ components:
           maxLength: 255
         type:
           type: "number"
-          example: 42
+          example: 140
           choices:
             - "custom"
             - "network"
@@ -870,10 +922,10 @@ components:
           type: "array"
           items:
             type: "number"
-            example: 166
+            example: 839
       example:
         name: "Lorem Ipsum"
-        type: 42
+        type: 140
         htmlContent: "Lorem Ipsum"
         enabled: true
         weight: 1
@@ -882,7 +934,7 @@ components:
         startsAt: "Lorem Ipsum"
         endsAt: "Lorem Ipsum"
         categoryIds:
-          - 166
+          - 839
       description: "CreateAdvertisementValidator (Validator)"
     UpdateAdvertisementValidator:
       type: "object"
@@ -894,7 +946,7 @@ components:
           maxLength: 255
         type:
           type: "number"
-          example: 566
+          example: 35
           choices:
             - "custom"
             - "network"
@@ -927,10 +979,10 @@ components:
           type: "array"
           items:
             type: "number"
-            example: 20
+            example: 74
       example:
         name: "Lorem Ipsum"
-        type: 566
+        type: 35
         htmlContent: "Lorem Ipsum"
         enabled: true
         weight: 1
@@ -939,7 +991,7 @@ components:
         startsAt: "Lorem Ipsum"
         endsAt: "Lorem Ipsum"
         categoryIds:
-          - 20
+          - 74
       description: "UpdateAdvertisementValidator (Validator)"
     IdentifyVisitorValidator:
       type: "object"
@@ -974,14 +1026,14 @@ components:
           maxLength: 512
         durationMs:
           type: "number"
-          example: 361
+          example: 602
           maximum: 86400000
       example:
         visitorId: "Lorem Ipsum"
         path: "Lorem Ipsum"
         referrer: "Lorem Ipsum"
         title: "Lorem Ipsum"
-        durationMs: 361
+        durationMs: 602
       description: "TrackPageViewValidator (Validator)"
     CreateApiTokenValidator:
       type: "object"
@@ -994,21 +1046,21 @@ components:
           maxLength: 100
         expiresInDays:
           type: "number"
-          example: 320
+          example: 292
           maximum: 3650
       example:
         name: "Lorem Ipsum"
-        expiresInDays: 320
+        expiresInDays: 292
       description: "CreateApiTokenValidator (Validator)"
     CategoryIdValidator:
       type: "object"
       properties:
         id:
           type: "number"
-          example: 308
+          example: 920
           required: true
       example:
-        id: 308
+        id: 920
       description: "CategoryIdValidator (Validator)"
     CreateCategoryValidator:
       type: "object"
@@ -1025,14 +1077,14 @@ components:
       properties:
         id:
           type: "number"
-          example: 616
+          example: 219
           required: true
         name:
           type: "string"
           example: "Lorem Ipsum"
           required: true
       example:
-        id: 616
+        id: 219
         name: "Lorem Ipsum"
       description: "UpdateCategoryValidator (Validator)"
     GlobalStatValidator:
@@ -1040,13 +1092,13 @@ components:
       properties:
         fromDate:
           type: "number"
-          example: 111
+          example: 225
         toDate:
           type: "number"
-          example: 974
+          example: 979
         interval:
           type: "number"
-          example: 385
+          example: 163
           choices:
             - "30 minutes"
             - "1 hour"
@@ -1056,23 +1108,23 @@ components:
             - "1 week"
         categoryId:
           type: "number"
-          example: 92
+          example: 450
         languageId:
           type: "number"
-          example: 393
+          example: 733
       example:
-        fromDate: 111
-        toDate: 974
-        interval: 385
-        categoryId: 92
-        languageId: 393
+        fromDate: 225
+        toDate: 979
+        interval: 163
+        categoryId: 450
+        languageId: 733
       description: "GlobalStatValidator (Validator)"
     CreatePostValidator:
       type: "object"
       properties:
         defaultLocale:
           type: "number"
-          example: 316
+          example: 432
           choices:
             - "fr"
             - "en"
@@ -1089,7 +1141,7 @@ components:
             properties:
               locale:
                 type: "number"
-                example: 934
+                example: 282
                 choices:
                   - "fr"
                   - "en"
@@ -1113,7 +1165,7 @@ components:
                 required: true
               excerpt:
                 type: "number"
-                example: 565
+                example: 292
                 maximum: 500
           required: true
           properties:
@@ -1131,10 +1183,10 @@ components:
                 type: "string"
                 example: "Lorem Ipsum"
       example:
-        defaultLocale: 316
+        defaultLocale: 432
         coverImage: "Lorem Ipsum"
         translations:
-          - locale: 934
+          - locale: 282
             title: "Lorem Ipsum"
             slug: "Lorem Ipsum"
             content: "Lorem Ipsum"
@@ -1149,11 +1201,11 @@ components:
           required: true
         serverId:
           type: "number"
-          example: 674
+          example: 966
           required: true
       example:
         placeholderName: "Lorem Ipsum"
-        serverId: 674
+        serverId: 966
       description: "PreviewPlaceholderValidator (Validator)"
     ResolvePlaceholdersValidator:
       type: "object"
@@ -1196,7 +1248,7 @@ components:
       properties:
         defaultLocale:
           type: "number"
-          example: 407
+          example: 666
           choices:
             - "fr"
             - "en"
@@ -1212,7 +1264,7 @@ components:
             properties:
               locale:
                 type: "number"
-                example: 73
+                example: 295
                 choices:
                   - "fr"
                   - "en"
@@ -1234,7 +1286,7 @@ components:
                 minimum: 10
               excerpt:
                 type: "number"
-                example: 618
+                example: 83
                 maximum: 500
           properties:
             items:
@@ -1251,10 +1303,10 @@ components:
                 type: "string"
                 example: "Lorem Ipsum"
       example:
-        defaultLocale: 407
+        defaultLocale: 666
         coverImage: "Lorem Ipsum"
         translations:
-          - locale: 73
+          - locale: 295
             title: "Lorem Ipsum"
             slug: "Lorem Ipsum"
             content: "Lorem Ipsum"
@@ -1279,7 +1331,7 @@ components:
           required: true
         type:
           type: "number"
-          example: 812
+          example: 442
           choices:
             - "java"
             - "bedrock"
@@ -1290,7 +1342,7 @@ components:
           type: "array"
           items:
             type: "number"
-            example: 650
+            example: 421
           required: true
           properties:
             items:
@@ -1309,13 +1361,13 @@ components:
           type: "array"
           items:
             type: "number"
-            example: 751
+            example: 905
           required: true
       example:
         name: "Lorem Ipsum"
         address: "Lorem Ipsum"
         port: 1
-        type: 812
+        type: 442
         imageUrl: "Lorem Ipsum"
         categories:
           - "Lorem Ipsum"
@@ -1323,7 +1375,7 @@ components:
         website: "Lorem Ipsum"
         motd: "Lorem Ipsum"
         languages:
-          - 751
+          - 905
       description: "CreateServerValidator (Validator)"
     UpdateServerValidator:
       type: "object"
@@ -1341,7 +1393,7 @@ components:
           minimum: 1
         type:
           type: "number"
-          example: 453
+          example: 227
           choices:
             - "java"
             - "bedrock"
@@ -1352,7 +1404,7 @@ components:
           type: "array"
           items:
             type: "number"
-            example: 56
+            example: 714
           properties:
             items:
               type: "string"
@@ -1370,12 +1422,12 @@ components:
           type: "array"
           items:
             type: "number"
-            example: 264
+            example: 640
       example:
         name: "Lorem Ipsum"
         address: "Lorem Ipsum"
         port: 1
-        type: 453
+        type: 227
         imageUrl: "Lorem Ipsum"
         categories:
           - "Lorem Ipsum"
@@ -1383,22 +1435,22 @@ components:
         website: "Lorem Ipsum"
         motd: "Lorem Ipsum"
         languages:
-          - 264
+          - 640
       description: "UpdateServerValidator (Validator)"
     attachServerCategoryValidator:
       type: "object"
       properties:
         serverId:
           type: "number"
-          example: 658
+          example: 366
           required: true
         categoryId:
           type: "number"
-          example: 150
+          example: 654
           required: true
       example:
-        serverId: 658
-        categoryId: 150
+        serverId: 366
+        categoryId: 654
       description: "attachServerCategoryValidator (Validator)"
     CreateManualClaimValidator:
       type: "object"
@@ -1466,7 +1518,7 @@ components:
       properties:
         server_id:
           type: "number"
-          example: 857
+          example: 513
           required: true
         days:
           type: "number"
@@ -1480,7 +1532,7 @@ components:
           required: true
           maxLength: 64
       example:
-        server_id: 857
+        server_id: 513
         days: 1
         timezone: "Lorem Ipsum"
       description: "DailyRhythmValidator (Validator)"
@@ -1489,17 +1541,17 @@ components:
       properties:
         server_id:
           type: "number"
-          example: 22
+          example: 835
           required: true
         fromDate:
           type: "number"
-          example: 979
+          example: 743
         toDate:
           type: "number"
-          example: 612
+          example: 348
         interval:
           type: "number"
-          example: 771
+          example: 798
           choices:
             - "30 minutes"
             - "1 hour"
@@ -1509,37 +1561,37 @@ components:
             - "1 week"
         format:
           type: "number"
-          example: 829
+          example: 391
           choices:
             - "csv"
             - "json"
           required: true
       example:
-        server_id: 22
-        fromDate: 979
-        toDate: 612
-        interval: 771
-        format: 829
+        server_id: 835
+        fromDate: 743
+        toDate: 348
+        interval: 798
+        format: 391
       description: "StatExportValidator (Validator)"
     StatValidator:
       type: "object"
       properties:
         server_id:
           type: "number"
-          example: 619
+          example: 12
           required: true
         exactTime:
           type: "number"
-          example: 616
+          example: 410
         fromDate:
           type: "number"
-          example: 723
+          example: 692
         toDate:
           type: "number"
-          example: 245
+          example: 692
         interval:
           type: "number"
-          example: 25
+          example: 910
           choices:
             - "30 minutes"
             - "1 hour"
@@ -1548,11 +1600,11 @@ components:
             - "1 day"
             - "1 week"
       example:
-        server_id: 619
-        exactTime: 616
-        fromDate: 723
-        toDate: 245
-        interval: 25
+        server_id: 12
+        exactTime: 410
+        fromDate: 692
+        toDate: 692
+        interval: 910
       description: "StatValidator (Validator)"
     ChangePasswordValidator:
       type: "object"
@@ -1666,6 +1718,21 @@ components:
         token: "Lorem Ipsum"
         password: "Lorem Ipsum"
       description: "ResetPasswordValidator (Validator)"
+    UpdateUserBlacklistValidator:
+      type: "object"
+      properties:
+        blacklisted:
+          type: "boolean"
+          example: true
+          required: true
+        reason:
+          type: "string"
+          example: "Lorem Ipsum"
+          maxLength: 500
+      example:
+        blacklisted: true
+        reason: "Lorem Ipsum"
+      description: "UpdateUserBlacklistValidator (Validator)"
     UpdateUserValidator:
       type: "object"
       properties:
@@ -1743,10 +1810,10 @@ paths:
                   type: "object"
               example:
                 - server:
-                    id: 930
+                    id: 893
                     name: "John Doe"
                     address: "1028 Farland Street"
-                    port: 407
+                    port: 436
                     type: {}
                     version: "Lorem Ipsum"
                     website: "Lorem Ipsum"
@@ -1756,15 +1823,15 @@ paths:
                     resolved_endpoint: "Lorem Ipsum"
                     motd_hash: "Lorem Ipsum"
                     host_domain: "Lorem Ipsum"
-                    user_id: 677
+                    user_id: 30
                     owner_verified_at: "2021-03-23T16:13:08.489+01:00"
                     owner_verified_method: {}
-                    vote_count: 990
+                    vote_count: 256
                     last_online_at: "2021-03-23T16:13:08.489+01:00"
-                    last_player_count: 763
-                    last_max_count: 951
+                    last_player_count: 193
+                    last_max_count: 286
                     last_stats_at: "2021-03-23T16:13:08.489+01:00"
-                    peak_player_count: 622
+                    peak_player_count: 73
                     peak_player_at: "2021-03-23T16:13:08.489+01:00"
                     next_ping_at: "2021-03-23T16:13:08.489+01:00"
                     created_at: "2021-03-23T16:13:08.489+01:00"
@@ -1772,12 +1839,12 @@ paths:
                   categories:
                     - "<Category>"
                   growthStat:
-                    server_id: 460
-                    weekly_growth: 977
-                    monthly_growth: 288
-                    last_week_average: 236
-                    previous_week_average: 795
-                    last_month_average: 881
+                    server_id: 749
+                    weekly_growth: 544
+                    monthly_growth: 969
+                    last_week_average: 865
+                    previous_week_average: 180
+                    last_month_average: 619
                     last_updated: "2021-03-23T16:13:08.489+01:00"
           description: "Returns **200** (OK) as **application/json**"
         401:
@@ -2182,10 +2249,10 @@ paths:
               example:
                 verified: true
                 server:
-                  id: 930
+                  id: 893
                   name: "John Doe"
                   address: "1028 Farland Street"
-                  port: 407
+                  port: 436
                   type: {}
                   version: "Lorem Ipsum"
                   website: "Lorem Ipsum"
@@ -2195,15 +2262,15 @@ paths:
                   resolved_endpoint: "Lorem Ipsum"
                   motd_hash: "Lorem Ipsum"
                   host_domain: "Lorem Ipsum"
-                  user_id: 677
+                  user_id: 30
                   owner_verified_at: "2021-03-23T16:13:08.489+01:00"
                   owner_verified_method: {}
-                  vote_count: 990
+                  vote_count: 256
                   last_online_at: "2021-03-23T16:13:08.489+01:00"
-                  last_player_count: 763
-                  last_max_count: 951
+                  last_player_count: 193
+                  last_max_count: 286
                   last_stats_at: "2021-03-23T16:13:08.489+01:00"
-                  peak_player_count: 622
+                  peak_player_count: 73
                   peak_player_at: "2021-03-23T16:13:08.489+01:00"
                   next_ping_at: "2021-03-23T16:13:08.489+01:00"
                   created_at: "2021-03-23T16:13:08.489+01:00"
@@ -2353,10 +2420,10 @@ paths:
               example:
                 verified: true
                 server:
-                  id: 930
+                  id: 893
                   name: "John Doe"
                   address: "1028 Farland Street"
-                  port: 407
+                  port: 436
                   type: {}
                   version: "Lorem Ipsum"
                   website: "Lorem Ipsum"
@@ -2366,15 +2433,15 @@ paths:
                   resolved_endpoint: "Lorem Ipsum"
                   motd_hash: "Lorem Ipsum"
                   host_domain: "Lorem Ipsum"
-                  user_id: 677
+                  user_id: 30
                   owner_verified_at: "2021-03-23T16:13:08.489+01:00"
                   owner_verified_method: {}
-                  vote_count: 990
+                  vote_count: 256
                   last_online_at: "2021-03-23T16:13:08.489+01:00"
-                  last_player_count: 763
-                  last_max_count: 951
+                  last_player_count: 193
+                  last_max_count: 286
                   last_stats_at: "2021-03-23T16:13:08.489+01:00"
-                  peak_player_count: 622
+                  peak_player_count: 73
                   peak_player_at: "2021-03-23T16:13:08.489+01:00"
                   next_ping_at: "2021-03-23T16:13:08.489+01:00"
                   created_at: "2021-03-23T16:13:08.489+01:00"
@@ -4192,7 +4259,7 @@ paths:
               $ref: "#/components/schemas/CreateApiTokenValidator"
             example:
               name: "Lorem Ipsum"
-              expiresInDays: 320
+              expiresInDays: 292
   /api/v1/account/api-tokens/{id}:
     delete:
       summary: "Revoke an API token (destroy)"
@@ -4682,7 +4749,7 @@ paths:
   /api/v1/posts/placeholders/resolve:
     post:
       summary: "Resolve content placeholders to their current values (resolvePlaceholders)"
-      description: "Resolves a batch of placeholder tokens to their live values. Returns a map of token → value. Publicly accessible.\n\n _app/controllers/posts_controller.ts_ - **resolvePlaceholders**"
+      description: "Resolves a batch of placeholder tokens to their live values. Returns a map of token → value, e.g. `{\"%PLAYER_COUNT_REALTIME_125%\": \"42\", \"%SERVER_VERSION_125%\": \"1.21.4\"}`. Publicly accessible.\n\n _app/controllers/posts_controller.ts_ - **resolvePlaceholders**"
       operationId: "resolvePlaceholders"
       parameters: []
       tags:
@@ -4690,16 +4757,9 @@ paths:
       responses:
         200:
           content:
-            application/json:
-              schema:
-                type: "object"
-                properties:
-                  %PLAYER_COUNT_REALTIME_125%: "42"
-                  %SERVER_VERSION_125%: "1.21.4"
-              example:
-                %PLAYER_COUNT_REALTIME_125%: "42"
-                %SERVER_VERSION_125%: "1.21.4"
-          description: "Returns **200** (OK) as **application/json**"
+            text/plain:
+              example: "Map of each submitted token to its resolved string value"
+          description: "Returns **200** (OK) as **text/plain**"
         422:
           content:
             application/json:
@@ -5157,10 +5217,10 @@ paths:
                   status: "pending"
                   evidence: "Discord: owner#1234"
                   server:
-                    id: 930
+                    id: 893
                     name: "John Doe"
                     address: "1028 Farland Street"
-                    port: 407
+                    port: 436
                     type: {}
                     version: "Lorem Ipsum"
                     website: "Lorem Ipsum"
@@ -5170,27 +5230,30 @@ paths:
                     resolved_endpoint: "Lorem Ipsum"
                     motd_hash: "Lorem Ipsum"
                     host_domain: "Lorem Ipsum"
-                    user_id: 677
+                    user_id: 30
                     owner_verified_at: "2021-03-23T16:13:08.489+01:00"
                     owner_verified_method: {}
-                    vote_count: 990
+                    vote_count: 256
                     last_online_at: "2021-03-23T16:13:08.489+01:00"
-                    last_player_count: 763
-                    last_max_count: 951
+                    last_player_count: 193
+                    last_max_count: 286
                     last_stats_at: "2021-03-23T16:13:08.489+01:00"
-                    peak_player_count: 622
+                    peak_player_count: 73
                     peak_player_at: "2021-03-23T16:13:08.489+01:00"
                     next_ping_at: "2021-03-23T16:13:08.489+01:00"
                     created_at: "2021-03-23T16:13:08.489+01:00"
                     updated_at: "2021-03-23T16:13:08.489+01:00"
                   user:
-                    id: 122
+                    id: 280
                     username: "Lorem Ipsum"
                     verified: true
                     provider: {}
                     role: {}
                     avatar_url: "Lorem Ipsum"
                     verification_token_expires: "2021-03-23T16:13:08.489+01:00"
+                    blacklisted_at: "2021-03-23T16:13:08.489+01:00"
+                    blacklisted_by: 775
+                    blacklist_reason: "Lorem Ipsum"
                     created_at: "2021-03-23T16:13:08.489+01:00"
                     updated_at: "2021-03-23T16:13:08.489+01:00"
           description: "Returns **200** (OK) as **application/json**"
@@ -5237,10 +5300,10 @@ paths:
               example:
                 message: "Claim approved."
                 server:
-                  id: 930
+                  id: 893
                   name: "John Doe"
                   address: "1028 Farland Street"
-                  port: 407
+                  port: 436
                   type: {}
                   version: "Lorem Ipsum"
                   website: "Lorem Ipsum"
@@ -5250,15 +5313,15 @@ paths:
                   resolved_endpoint: "Lorem Ipsum"
                   motd_hash: "Lorem Ipsum"
                   host_domain: "Lorem Ipsum"
-                  user_id: 677
+                  user_id: 30
                   owner_verified_at: "2021-03-23T16:13:08.489+01:00"
                   owner_verified_method: {}
-                  vote_count: 990
+                  vote_count: 256
                   last_online_at: "2021-03-23T16:13:08.489+01:00"
-                  last_player_count: 763
-                  last_max_count: 951
+                  last_player_count: 193
+                  last_max_count: 286
                   last_stats_at: "2021-03-23T16:13:08.489+01:00"
-                  peak_player_count: 622
+                  peak_player_count: 73
                   peak_player_at: "2021-03-23T16:13:08.489+01:00"
                   next_ping_at: "2021-03-23T16:13:08.489+01:00"
                   created_at: "2021-03-23T16:13:08.489+01:00"
@@ -5389,6 +5452,29 @@ paths:
     patch:
       summary: " (updateRole)"
       description: "\n\n _app/controllers/users_controller.ts_ - **updateRole**"
+      parameters:
+        - in: "path"
+          name: "id"
+          schema:
+            type: "string"
+          required: true
+      tags:
+        - "ADMIN"
+      responses:
+        401:
+          description: "Returns **401** (Unauthorized)"
+        403:
+          description: "Returns **403** (Forbidden)"
+      security:
+        - BearerAuth:
+            - "access"
+      requestBody:
+        content:
+          application/json: {}
+  /api/v1/admin/users/{id}/blacklist:
+    patch:
+      summary: " (updateBlacklist)"
+      description: "\n\n _app/controllers/users_controller.ts_ - **updateBlacklist**"
       parameters:
         - in: "path"
           name: "id"

--- a/backend/tests/unit/minehut_provider.spec.ts
+++ b/backend/tests/unit/minehut_provider.spec.ts
@@ -1,0 +1,131 @@
+import { test } from '@japa/runner'
+import minehutProvider from '../../minecraft-ping/host_providers/minehut_provider.js'
+import { resolveHostProvider } from '../../minecraft-ping/host_providers/index.js'
+
+test.group('minehutProvider.resolveKey', () => {
+  test('extrait le nom du serveur du sous-domaine', ({ assert }) => {
+    assert.equal(minehutProvider.resolveKey('thatboxsrver.minehut.gg'), 'thatboxsrver')
+    assert.equal(minehutProvider.resolveKey('TechMines.Minehut.GG'), 'techmines')
+    assert.equal(minehutProvider.resolveKey('  techmines.minehut.gg  '), 'techmines')
+  })
+
+  test('gère la variante Bedrock', ({ assert }) => {
+    assert.equal(minehutProvider.resolveKey('thatbox.bedrock.minehut.gg'), 'thatbox')
+  })
+
+  test('ignore les hôtes qui ne sont pas des sous-domaines Minehut', ({ assert }) => {
+    assert.isNull(minehutProvider.resolveKey('mc.hypixel.net'))
+    assert.isNull(minehutProvider.resolveKey('192.168.1.1'))
+    // `minehut.gg` nu n'est le sous-domaine de personne : c'est le réseau lui-même.
+    assert.isNull(minehutProvider.resolveKey('minehut.gg'))
+    // Un hôte qui se contente de *contenir* le suffixe ne doit pas matcher.
+    assert.isNull(minehutProvider.resolveKey('minehut.gg.evil.com'))
+  })
+})
+
+test.group('resolveHostProvider', () => {
+  test('route une adresse Minehut vers son provider', ({ assert }) => {
+    const hosted = resolveHostProvider('thatboxsrver.minehut.gg')
+    assert.equal(hosted?.provider.id, 'minehut')
+    assert.equal(hosted?.key, 'thatboxsrver')
+  })
+
+  test('laisse passer une adresse ordinaire (ping direct)', ({ assert }) => {
+    assert.isNull(resolveHostProvider('mc.hypixel.net'))
+  })
+})
+
+/** Stub de `fetch` qui sert la liste `/servers` ou la fiche `?byName=true`. */
+function stubMinehutApi(urls: string[]) {
+  const realFetch = globalThis.fetch
+
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input)
+    urls.push(url)
+
+    if (url.includes('?byName=true')) {
+      return new Response(
+        JSON.stringify({
+          server: {
+            online: true,
+            playerCount: 246,
+            maxPlayers: 500,
+            motd: 'Box-PvP',
+            server_list_favicon: 'data:image/png;base64,AAAA',
+          },
+        }),
+        { status: 200 }
+      )
+    }
+
+    return new Response(
+      JSON.stringify({
+        servers: [
+          {
+            name: 'TechMines',
+            motd: 'Box-PvP',
+            maxPlayers: 500,
+            playerData: { playerCount: 246 },
+            versionMin: '1.20',
+            versionMax: '1.21',
+          },
+        ],
+      }),
+      { status: 200 }
+    )
+  }) as typeof fetch
+
+  return () => {
+    globalThis.fetch = realFetch
+  }
+}
+
+test.group('minehutProvider.fetchStats', (group) => {
+  let urls: string[] = []
+
+  group.each.setup(() => {
+    urls = []
+    return stubMinehutApi(urls)
+  })
+
+  test('lit le compte réel du serveur listé, et mutualise l’appel réseau', async ({ assert }) => {
+    const stats = await minehutProvider.fetchStats('techmines')
+    assert.deepEqual(stats, {
+      players: { online: 246, max: 500 },
+      motd: 'Box-PvP',
+      version: '1.20-1.21',
+      favicon: null,
+    })
+
+    // Un serveur absent de la liste `/servers` est hors-ligne : surtout pas les
+    // ~4600 joueurs du réseau que renverrait un ping direct du proxy Minehut.
+    assert.isNull(await minehutProvider.fetchStats('thatboxsrver'))
+
+    // Les deux résolutions partagent le même instantané (TTL) : un seul appel.
+    assert.lengthOf(urls, 1)
+  })
+
+  test('le mode detailed ramène le favicon via la fiche du serveur', async ({ assert }) => {
+    const stats = await minehutProvider.fetchStats('techmines', { detailed: true })
+
+    assert.equal(stats?.favicon, 'data:image/png;base64,AAAA')
+    assert.deepEqual(stats?.players, { online: 246, max: 500 })
+    assert.isTrue(urls[0].endsWith('/server/techmines?byName=true'))
+
+    // Même MOTD que l'instantané : `motd_hash` ne doit pas dépendre du chemin de ping.
+    const snapshotStats = await minehutProvider.fetchStats('techmines')
+    assert.equal(stats?.motd, snapshotStats?.motd)
+  })
+
+  test('un serveur hors-ligne ou inconnu ne renvoie rien en mode detailed', async ({ assert }) => {
+    // Le teardown du group restaure le vrai `fetch`.
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ server: { online: false } }), { status: 200 })) as typeof fetch
+    assert.isNull(await minehutProvider.fetchStats('thatboxsrver', { detailed: true }))
+
+    // Un nom inexistant : `{"server": null}` en HTTP 200.
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ server: null }), { status: 200 })) as typeof fetch
+    assert.isNull(await minehutProvider.fetchStats('zzz-nexiste-pas', { detailed: true }))
+  })
+})


### PR DESCRIPTION
This pull request introduces support for host-specific API-based server stats retrieval, notably for Minehut-hosted servers, to ensure accurate player counts and MOTD when the direct Minecraft ping would otherwise return only network-level data. It also pins the Node.js version to 26.6.0 in CI and Docker to avoid breaking changes with AdonisJS, improves documentation and error handling, and refines code organization.

**Support for host-specific stats providers:**

* Added a provider system for hosters like Minehut, using their public API to get accurate server stats instead of proxy-level data from direct pings. This includes new files `host_providers/index.ts`, `host_providers/minehut_provider.ts`, and `host_providers/types.ts`, and integration into `minecraft_ping.ts` to use these providers when appropriate. [[1]](diffhunk://#diff-bbe36943f459b86e2ea80843896800de730bb738b37b96484c3e6678a3cb1decR1-R22) [[2]](diffhunk://#diff-acc1641db07ae766a0da6dfdeaf3f64317d50a82a67739cfdcd982782f1a39d6R1-R144) [[3]](diffhunk://#diff-3ea42f1c59a441643692c4454645f2336e194b4ef6794278b623c3baa2e4bfdcR3) [[4]](diffhunk://#diff-3ea42f1c59a441643692c4454645f2336e194b4ef6794278b623c3baa2e4bfdcR40-R68)

* The `pingMinecraftServer` function now accepts a `detailed` option, allowing code paths that need extra data (like the favicon) to trigger a dedicated API call. The `NormalizedPing` interface is updated to handle cases where the version may be missing. [[1]](diffhunk://#diff-3ea42f1c59a441643692c4454645f2336e194b4ef6794278b623c3baa2e4bfdcL27-R31) [[2]](diffhunk://#diff-3ea42f1c59a441643692c4454645f2336e194b4ef6794278b623c3baa2e4bfdcR40-R68)

**Bug fixes and improvements:**

* In `ServerOwnershipService` and `ServerRegistrationService`, pings for ownership verification and registration now use the `detailed` mode to ensure the real MOTD and favicon are retrieved, fixing issues with proxy-based hosters. [[1]](diffhunk://#diff-eb7289875105020544a99113afdf631f98db6ee46c241f684f81e6acd5ac4440R74-R85) [[2]](diffhunk://#diff-6148f0562b7e07a07f8eb2534567409a342242b6054d68dfbeb6983e1e9c9a58L43-R54)

* Fixed a logic bug in claim verification to avoid false negatives when a claim exists but does not match the expected method/status.

**Build and workflow stability:**

* Node.js version is pinned to 26.6.0 in both CI (`.github/workflows/ci.yml`) and `backend/Dockerfile` to avoid breaking changes in Node 26.7.0 that affect AdonisJS. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR79-R86) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR137-R144) [[3]](diffhunk://#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486L1-R8)

**Documentation and developer experience:**

* Improved OpenAPI documentation for the `resolvePlaceholders` endpoint, clarifying response examples and documenting YAML generation caveats.

* Updated ESLint config to ignore generated files that are not hand-edited, preventing spurious lint failures.

**Code organization and maintainability:**

* Reordered imports in `server_ownership_service.ts` for clarity and added comments to clarify why certain fields are not `readonly`, preventing CI failures due to type issues. [[1]](diffhunk://#diff-eb7289875105020544a99113afdf631f98db6ee46c241f684f81e6acd5ac4440L1-R18) [[2]](diffhunk://#diff-eb7289875105020544a99113afdf631f98db6ee46c241f684f81e6acd5ac4440R74-R85)

(References: [[1]](diffhunk://#diff-bbe36943f459b86e2ea80843896800de730bb738b37b96484c3e6678a3cb1decR1-R22) [[2]](diffhunk://#diff-acc1641db07ae766a0da6dfdeaf3f64317d50a82a67739cfdcd982782f1a39d6R1-R144) [[3]](diffhunk://#diff-3ea42f1c59a441643692c4454645f2336e194b4ef6794278b623c3baa2e4bfdcR40-R68) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR79-R86) [[5]](diffhunk://#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486L1-R8)