### PR TITLE
feat(servers): actions admin (modifier/supprimer) sur la fiche serveur

### DIFF
--- a/backend/tests/functional/daily_rhythm.spec.ts
+++ b/backend/tests/functional/daily_rhythm.spec.ts
@@ -155,11 +155,16 @@ test.group('Daily rhythm', (group) => {
 
   test('bascule sur le rollup horaire au-delà d’un mois de fenêtre', async ({ assert }) => {
     const server = await createServer()
-    const endsAt = DateTime.now().setZone(PARIS).startOf('day')
+    // La fenêtre du service est glissante (`now − 40 j` → `now`), pas calée sur
+    // minuit : elle contient exactement 40 fois une heure locale donnée à condition
+    // que la donnée couvre ses deux bords. Semer jusqu'à minuit laissait le bord
+    // récent à découvert, et le créneau de 21 h tombait à 39 jours dès que la suite
+    // tournait après 21 h — heure de Paris.
+    const endsAt = DateTime.now().setZone(PARIS).startOf('hour')
     const rows: Record<string, unknown>[] = []
 
-    for (let hour = 0; hour < 40 * 24; hour++) {
-      const at = endsAt.minus({ hours: hour + 1 })
+    for (let hour = 0; hour < 41 * 24; hour++) {
+      const at = endsAt.minus({ hours: hour })
       rows.push({
         server_id: server.id,
         hour: at.toSQL(),
@@ -187,6 +192,14 @@ test.group('Daily rhythm', (group) => {
     assert.equal(evening?.peakPlayerCount, 1000)
     assert.equal(evening?.minuteOfDay, 1260)
     assert.equal(evening?.daysCount, 40)
+
+    // Toutes les heures locales, pas seulement celle du soir : c'est l'invariant qui
+    // lâche si la donnée cesse de déborder de la fenêtre, quelle que soit l'heure à
+    // laquelle la suite tourne.
+    assert.deepEqual(
+      rhythm.series.all.map((slot) => slot.daysCount),
+      Array.from({ length: 24 }, () => 40)
+    )
   })
 
   test('ne renvoie aucun créneau pour un serveur sans relevé', async ({ assert }) => {

--- a/frontend/messages/en/servers.json
+++ b/frontend/messages/en/servers.json
@@ -96,6 +96,20 @@
     "detailsTitle": "Server details",
     "detailsSubtitle": "Update your server's details, categories, and languages."
   },
+  "admin": {
+    "label": "Admin",
+    "edit": "Edit",
+    "delete": "Delete",
+    "dialogTitle": "Delete this server?",
+    "dialogDescription": "<b>{name}</b> will be permanently removed from Minecraft Stats, along with its whole tracking history. This action cannot be undone.",
+    "cancel": "Cancel",
+    "confirmDelete": "Delete server",
+    "deleting": "Deleting…",
+    "removedTitle": "Server deleted",
+    "removedDescription": "{name} is no longer listed on Minecraft Stats.",
+    "removeErrorTitle": "Could not delete server",
+    "removeErrorDescription": "An error occurred."
+  },
   "claim": {
     "verifiedBadge": "Verified ownership",
     "button": "Claim this server",

--- a/frontend/messages/es/servers.json
+++ b/frontend/messages/es/servers.json
@@ -96,6 +96,20 @@
     "detailsTitle": "Detalles del servidor",
     "detailsSubtitle": "Actualiza los detalles, las categorías y los idiomas de tu servidor."
   },
+  "admin": {
+    "label": "Admin",
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "dialogTitle": "¿Eliminar este servidor?",
+    "dialogDescription": "<b>{name}</b> se eliminará definitivamente de Minecraft Stats, junto con todo su historial de seguimiento. Esta acción no se puede deshacer.",
+    "cancel": "Cancelar",
+    "confirmDelete": "Eliminar servidor",
+    "deleting": "Eliminando…",
+    "removedTitle": "Servidor eliminado",
+    "removedDescription": "{name} ya no aparece en Minecraft Stats.",
+    "removeErrorTitle": "No se pudo eliminar el servidor",
+    "removeErrorDescription": "Se produjo un error."
+  },
   "claim": {
     "verifiedBadge": "Propiedad verificada",
     "button": "Reclamar este servidor",

--- a/frontend/messages/fr/servers.json
+++ b/frontend/messages/fr/servers.json
@@ -96,6 +96,20 @@
     "detailsTitle": "Détails du serveur",
     "detailsSubtitle": "Mettez à jour les détails, catégories et langues de votre serveur."
   },
+  "admin": {
+    "label": "Admin",
+    "edit": "Modifier",
+    "delete": "Supprimer",
+    "dialogTitle": "Supprimer ce serveur ?",
+    "dialogDescription": "<b>{name}</b> sera définitivement retiré de Minecraft Stats, ainsi que tout son historique de suivi. Cette action est irréversible.",
+    "cancel": "Annuler",
+    "confirmDelete": "Supprimer le serveur",
+    "deleting": "Suppression…",
+    "removedTitle": "Serveur supprimé",
+    "removedDescription": "{name} n'est plus référencé sur Minecraft Stats.",
+    "removeErrorTitle": "Impossible de supprimer le serveur",
+    "removeErrorDescription": "Une erreur est survenue."
+  },
   "claim": {
     "verifiedBadge": "Propriété vérifiée",
     "button": "Revendiquer ce serveur",

--- a/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
@@ -29,6 +29,7 @@ import { useEntitlements } from "@/hooks/use-entitlements";
 import { useAuth } from "@/contexts/auth";
 import { SeriesMode, SeriesModeToggle } from "@/components/stats/series-mode-toggle";
 import { ServerFAQStructuredData, ServerStructuredData } from "@/components/seo/structured-data";
+import ServerAdminActions from "@/components/serveur/server-admin-actions";
 import ServerDetailHeader from "@/components/serveur/server-detail-header";
 import ClaimServerBanner from "@/components/serveur/claim-server-banner";
 import ServerFAQ from "@/components/serveur/server-faq";
@@ -328,13 +329,18 @@ const ServerPage = () => {
 
   return (
     <main className="flex-1 space-y-6 py-6">
-      <nav aria-label={t("detail.breadcrumbAria")} className="flex items-center gap-2 text-sm text-muted-foreground">
-        <Link href="/" className="text-accent transition-colors hover:underline">
-          {t("detail.breadcrumb")}
-        </Link>
-        <span aria-hidden="true">/</span>
-        <span className="truncate font-medium text-foreground">{serverData.server.name}</span>
-      </nav>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <nav aria-label={t("detail.breadcrumbAria")} className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Link href="/" className="text-accent transition-colors hover:underline">
+            {t("detail.breadcrumb")}
+          </Link>
+          <span aria-hidden="true">/</span>
+          <span className="truncate font-medium text-foreground">{serverData.server.name}</span>
+        </nav>
+
+        {/* Ne s'affiche que pour les admins Minecraft Stats. */}
+        <ServerAdminActions serverId={serverData.server.id} serverName={serverData.server.name} />
+      </div>
 
       <ServerStructuredData
         server={serverData.server}

--- a/frontend/src/components/serveur/server-admin-actions.tsx
+++ b/frontend/src/components/serveur/server-admin-actions.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useToast } from "@/components/ui/use-toast";
+import { useAuth } from "@/contexts/auth";
+import { deleteServer } from "@/http/server";
+import { Link, useRouter } from "@/i18n/navigation";
+import { Pencil, ShieldAlert, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+interface ServerAdminActionsProps {
+  serverId: number;
+  serverName: string;
+}
+
+/**
+ * Raccourcis « modifier / supprimer » posés sur la fiche publique du serveur.
+ * Réservés aux admins Minecraft Stats : le propriétaire, lui, gère son serveur
+ * depuis /account/my-servers. La suppression est définitive et vaut pour tout
+ * le site — d'où la confirmation.
+ */
+const ServerAdminActions = ({ serverId, serverName }: ServerAdminActionsProps) => {
+  const t = useTranslations("Servers.admin");
+  const { user, getToken } = useAuth();
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  if (user?.role !== "admin") return null;
+
+  const confirmDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteServer(serverId, getToken() ?? "");
+      toast({
+        title: t("removedTitle"),
+        description: t("removedDescription", { name: serverName }),
+        variant: "success",
+      });
+      setIsConfirmOpen(false);
+      // La fiche n'existe plus : rester dessus n'afficherait qu'un 404.
+      router.push("/");
+    } catch (error) {
+      toast({
+        title: t("removeErrorTitle"),
+        description: error instanceof Error ? error.message : t("removeErrorDescription"),
+        variant: "error",
+      });
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-secondary px-2 py-1 text-xs font-medium text-muted-foreground">
+        <ShieldAlert className="h-3.5 w-3.5" />
+        {t("label")}
+      </span>
+      <Button asChild variant="outline" size="sm" className="gap-1.5">
+        <Link href={`/servers/${serverId}/edit`}>
+          <Pencil className="h-4 w-4" />
+          {t("edit")}
+        </Link>
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setIsConfirmOpen(true)}
+        className="gap-1.5 text-destructive hover:bg-destructive/10 hover:text-destructive"
+      >
+        <Trash2 className="h-4 w-4" />
+        {t("delete")}
+      </Button>
+
+      <Dialog open={isConfirmOpen} onOpenChange={(open) => !isDeleting && setIsConfirmOpen(open)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("dialogTitle")}</DialogTitle>
+            <DialogDescription>
+              {t.rich("dialogDescription", {
+                name: serverName,
+                b: (chunks) => <span className="font-medium text-foreground">{chunks}</span>,
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsConfirmOpen(false)} disabled={isDeleting}>
+              {t("cancel")}
+            </Button>
+            <Button variant="destructive" onClick={confirmDelete} disabled={isDeleting}>
+              {isDeleting ? t("deleting") : t("confirmDelete")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default ServerAdminActions;


### PR DESCRIPTION
Les admins Minecraft Stats devaient passer par /account/my-servers pour
modifier ou supprimer un serveur, ce qui ne fonctionne que pour leurs
propres serveurs. La fiche publique expose désormais les deux actions,
uniquement pour le rôle admin :

- lien « Modifier » vers /servers/:id/edit (déjà autorisé par ServerPolicy) ;
- « Supprimer » avec dialogue de confirmation, toast et redirection vers
  l'accueil (la fiche n'existe plus après suppression).

Traductions ajoutées en fr/en/es.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fn2py88k3GpR3322QGaVr6