### PR TITLE
fix(servers): tronquer le fil d'Ariane à côté des actions admin

### DIFF
--- a/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/servers/[serverId]/[[...serverName]]/page.tsx
@@ -330,7 +330,13 @@ const ServerPage = () => {
   return (
     <main className="flex-1 space-y-6 py-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <nav aria-label={t("detail.breadcrumbAria")} className="flex items-center gap-2 text-sm text-muted-foreground">
+        {/* `min-w-0` : sans lui, le fil d'Ariane impose sa largeur de contenu au
+            conteneur flex et le nom d'un serveur un peu long déborde à droite au
+            lieu d'être tronqué. */}
+        <nav
+          aria-label={t("detail.breadcrumbAria")}
+          className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground"
+        >
           <Link href="/" className="text-accent transition-colors hover:underline">
             {t("detail.breadcrumb")}
           </Link>


### PR DESCRIPTION
Suite de #286, qui a ajouté les actions admin (modifier / supprimer) sur la fiche serveur.

## Le problème

Regrouper le fil d'Ariane et la barre d'actions admin dans un même conteneur flex a fait perdre au `<nav>` sa capacité à rétrécir : il imposait sa largeur de contenu au lieu de laisser le `<span class="truncate">` faire son travail. Le nom d'un serveur un peu long partait donc sous le bord droit de l'écran sur mobile.

Mesuré au navigateur sur la page serveur, en 375 px, avec un nom de serveur long :

| | largeur du `<nav>` | débordement de `<main>` | nom tronqué |
| --- | --- | --- | --- |
| avant #286 | 343 px | non | oui |
| après #286 | 428 px | +85 px | non |
| avec ce correctif | 343 px | non | oui |

## Le correctif

`min-w-0` sur le `<nav>` du fil d'Ariane, ce qui rend la troncature au `<span>` qui la portait déjà.

## Vérification

Back + front lancés en local, connecté avec un compte admin, sur une fiche serveur au nom volontairement long. Vérifié en 320 / 375 / 390 / 1280 px : plus de débordement horizontal, fil d'Ariane en ellipse, et les trois actions admin passent proprement sur une seconde ligne sous le fil d'Ariane sur mobile. `yarn lint` : 0 erreur (9 warnings préexistants, ailleurs).

Deux débordements relevés au passage sont **antérieurs** et hors périmètre (identiques sans compte admin) : le conteneur AG Charts en 320 px, et le menu mobile hors-écran (`aside w-[85%]`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fn2py88k3GpR3322QGaVr6)_