### PR TITLE
ci(deploy): faire du frontend un service du compose

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,10 @@
 name: Deploy
 
-# Un seul workflow pilote les trois services. Auparavant `deploy-backend.yml` et
-# `deploy-mcp.yml` couvraient le backend et le MCP, tandis que le frontend était
-# déployé par l'auto-deploy de Dokploy via le webhook de la GitHub App : deux
-# mécanismes distincts pour un même dépôt, sans vue d'ensemble.
+# Un seul workflow pilote les trois services, et un seul appel les déploie
+# ensemble : le frontend fait désormais partie du compose au lieu d'être une
+# application Dokploy à part, buildée sur le serveur via le webhook de la GitHub
+# App. Deux mécanismes distincts pour un même dépôt rendaient l'état réel des
+# déploiements impossible à lire d'un coup d'œil.
 #
 # Surtout, l'ancien déclencheur se contentait d'un `curl` sur `compose.deploy`,
 # qui répond 200 dès la *mise en file*. En août 2026 un build figé d'un autre
@@ -196,9 +197,72 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  build-frontend:
+    name: Build and push frontend image
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    # Nécessaire pour lire `vars.FRONTEND_BUILD_ARGS`, dont les valeurs diffèrent
+    # entre prod et staging (URL d'API, bucket S3, domaine de base).
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
+
+    env:
+      IMAGE_NAME: sportek/minecraft-stats-front
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set image tag
+        id: set-tag
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          else
+            echo "tag=staging" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check build args are configured
+        env:
+          BUILD_ARGS: ${{ vars.FRONTEND_BUILD_ARGS }}
+        run: |
+          # Les NEXT_PUBLIC_* sont figées dans le bundle client au build. Une
+          # variable absente ne casse pas la construction : elle produit
+          # silencieusement un site avec des URLs d'API vides et un captcha mort.
+          missing=""
+          for key in NEXT_PUBLIC_API_URL NEXT_PUBLIC_BACKEND_URL \
+                     NEXT_PUBLIC_TURNSTILE_SITE_KEY NEXT_PUBLIC_ASSETS_URL; do
+            printf '%s\n' "$BUILD_ARGS" | grep -q "^${key}=" || missing="${missing} ${key}"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::FRONTEND_BUILD_ARGS incomplet pour '${{ github.ref_name == 'main' && 'production' || 'staging' }}' — manquant :${missing}"
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: ./frontend
+          push: true
+          build-args: ${{ vars.FRONTEND_BUILD_ARGS }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.set-tag.outputs.tag }}
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   deploy-stack:
-    name: Deploy backend stack
-    needs: [changes, build-backend, build-mcp]
+    name: Deploy stack
+    needs: [changes, build-backend, build-mcp, build-frontend]
     # Les deux builds sont conditionnels. Le `success()` implicite de `needs:`
     # sauterait ce job dès que l'un des deux est `skipped` — c'est-à-dire dès
     # qu'un push ne touche qu'un seul des deux services. On exige seulement
@@ -208,11 +272,15 @@ jobs:
     if: >-
       !cancelled()
       && needs.changes.result == 'success'
-      && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true')
+      && (needs.changes.outputs.backend == 'true'
+          || needs.changes.outputs.mcp == 'true'
+          || needs.changes.outputs.frontend == 'true')
       && needs.build-backend.result != 'failure'
       && needs.build-backend.result != 'cancelled'
       && needs.build-mcp.result != 'failure'
       && needs.build-mcp.result != 'cancelled'
+      && needs.build-frontend.result != 'failure'
+      && needs.build-frontend.result != 'cancelled'
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
 
@@ -233,26 +301,3 @@ jobs:
           fi
           chmod +x .github/scripts/dokploy-deploy.sh
           .github/scripts/dokploy-deploy.sh compose "${COMPOSE_ID}"
-
-  deploy-frontend:
-    name: Deploy frontend
-    needs: changes
-    if: needs.changes.outputs.frontend == 'true'
-    runs-on: ubuntu-latest
-    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Deploy and wait
-        env:
-          DOKPLOY_API_TOKEN: ${{ secrets.DOKPLOY_API_TOKEN }}
-          APP_ID: ${{ vars.DOKPLOY_FRONTEND_APP_ID }}
-        run: |
-          if [ -z "${APP_ID}" ]; then
-            echo "::error::DOKPLOY_FRONTEND_APP_ID absent de l'environnement '${{ github.ref_name == 'main' && 'production' || 'staging' }}'."
-            exit 1
-          fi
-          chmod +x .github/scripts/dokploy-deploy.sh
-          .github/scripts/dokploy-deploy.sh application "${APP_ID}"

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -106,6 +106,47 @@ services:
       start_period: 10s
 
   ##########################################################################
+  # Frontend (Next.js)
+  ##########################################################################
+  # Les variables NEXT_PUBLIC_* sont figées dans le bundle client au moment du
+  # build (voir frontend/Dockerfile) : celles listées ici ne servent qu'au rendu
+  # côté serveur. Changer une URL d'API demande donc un rebuild de l'image, pas
+  # seulement un redéploiement.
+  frontend:
+    container_name: "stats-frontend-${APP_NAME}"
+    image: "sportek/minecraft-stats-front:${IMAGE_TAG:-latest}"
+    pull_policy: always
+    restart: "unless-stopped"
+    depends_on:
+      - adonis_app
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - HOSTNAME=0.0.0.0
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+      - NEXT_PUBLIC_BACKEND_URL=${NEXT_PUBLIC_BACKEND_URL}
+      - NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL:-}
+      - NEXT_PUBLIC_ASSETS_URL=${NEXT_PUBLIC_ASSETS_URL}
+      - NEXT_PUBLIC_TURNSTILE_SITE_KEY=${NEXT_PUBLIC_TURNSTILE_SITE_KEY}
+      - NEXT_PUBLIC_GOOGLE_TAG_MANAGER=${NEXT_PUBLIC_GOOGLE_TAG_MANAGER}
+      - NEXT_PUBLIC_MICROSOFT_CLARITY=${NEXT_PUBLIC_MICROSOFT_CLARITY}
+    networks:
+      - sail
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    healthcheck:
+      # 127.0.0.1 et non localhost : le serveur Next écoute en IPv4 (0.0.0.0),
+      # alors que localhost résout en IPv6 (::1) dans l'image Alpine.
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:3000/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  ##########################################################################
   # Serveur MCP (Model Context Protocol) — expose les stats publiques aux IA
   ##########################################################################
   mcp:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -30,11 +30,24 @@ COPY . .
 
 # Accept build arguments for NEXT_PUBLIC_* variables
 # These MUST be available at build time for Next.js to embed them in the client bundle
+#
+# TURNSTILE_SITE_KEY et ASSETS_URL manquaient ici. Ils fonctionnaient malgré tout
+# parce que Dokploy buildait l'image lui-même : son option « create .env file »
+# dépose un `.env` dans le contexte de build, que `.dockerignore` ne filtre pas
+# (il n'exclut que `.env*.local`, `.env.development` et `.env.test`), et que le
+# `COPY . .` ci-dessus embarque — Next le lit alors au build.
+#
+# Ce `.env` n'existe plus dès que l'image est construite ailleurs. Sans ces deux
+# ARG, `NEXT_PUBLIC_TURNSTILE_SITE_KEY` devient `undefined` dans un composant
+# client (`components/form/turnstile.tsx` est en "use client"), donc le captcha
+# casse — et le build reste vert.
 ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_BACKEND_URL
 ARG NEXT_PUBLIC_BASE_URL
 ARG NEXT_PUBLIC_GOOGLE_TAG_MANAGER
 ARG NEXT_PUBLIC_MICROSOFT_CLARITY
+ARG NEXT_PUBLIC_TURNSTILE_SITE_KEY
+ARG NEXT_PUBLIC_ASSETS_URL
 
 # Convert build args to environment variables for the build process
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
@@ -42,6 +55,8 @@ ENV NEXT_PUBLIC_BACKEND_URL=$NEXT_PUBLIC_BACKEND_URL
 ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
 ENV NEXT_PUBLIC_GOOGLE_TAG_MANAGER=$NEXT_PUBLIC_GOOGLE_TAG_MANAGER
 ENV NEXT_PUBLIC_MICROSOFT_CLARITY=$NEXT_PUBLIC_MICROSOFT_CLARITY
+ENV NEXT_PUBLIC_TURNSTILE_SITE_KEY=$NEXT_PUBLIC_TURNSTILE_SITE_KEY
+ENV NEXT_PUBLIC_ASSETS_URL=$NEXT_PUBLIC_ASSETS_URL
 
 # Disable Next.js telemetry
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
> **Empilée sur #289** — la base de cette PR est `ci/unify-deploy-workflow`. À merger seulement après #289, et **pas sans la bascule décrite plus bas**. Laissée en brouillon pour cette raison.

## Summary

Le frontend est une application Dokploy distincte, buildée sur wyvern depuis le dépôt via le webhook de la GitHub App, pendant que backend et MCP passent par des images construites en CI et tirées par le compose. Deux mécanismes pour un même dépôt.

Cette PR aligne le frontend sur le motif des deux autres : image construite par GitHub Actions, tirée par le compose. Un seul `compose.deploy` déploie alors les trois services ensemble.

## Changes

- **`.github/workflows/deploy.yml`** — nouveau job `build-frontend` (image `sportek/minecraft-stats-front`, tags `:latest` / `:staging` / `:<sha>`), et le job `deploy-frontend` disparaît puisque la stack couvre tout.
- **`backend/compose.yaml`** — service `frontend`, port 3000, `pull_policy: always`, healthcheck sur `127.0.0.1` (et non `localhost`, qui résout en IPv6 sur Alpine alors que Next écoute en IPv4 — même piège que le service `mcp`).
- **`frontend/Dockerfile`** — deux `ARG` ajoutés. Voir ci-dessous, c'est le point sensible.
- Variables GitHub `FRONTEND_BUILD_ARGS` créées dans les deux environnements.

## Le piège, et pourquoi il méritait d'être cherché

`NEXT_PUBLIC_TURNSTILE_SITE_KEY` et `NEXT_PUBLIC_ASSETS_URL` sont utilisées par le frontend mais **n'étaient pas déclarées comme `ARG`**. Elles fonctionnent quand même aujourd'hui parce que l'option « create .env file » de Dokploy dépose un `.env` dans le contexte de build ; `.dockerignore` n'exclut que `.env*.local`, `.env.development` et `.env.test`, donc le `COPY . .` l'embarque, et Next le lit au build.

Ce `.env` disparaît dès que l'image est construite ailleurs. Or `components/form/turnstile.tsx` est en `"use client"` : la valeur est figée dans le bundle client. Sans ces `ARG`, **le captcha aurait cassé en production avec un build parfaitement vert**. `NEXT_PUBLIC_ASSETS_URL` aurait dégradé plus doucement — repli sur le backend, donc les images quittent S3 pour retomber sur l'API.

Le job `build-frontend` refuse désormais de construire si l'une des variables critiques manque, plutôt que de produire une image cassée.

Deux constats au passage :
- `NEXT_PUBLIC_GOOGLE_ANALYTICS` est définie sur staging mais **n'apparaît nulle part dans le code** — non reportée.
- `NEXT_PUBLIC_BASE_URL` est absente en prod (présente en staging). `domain.ts` a un repli explicite, donc c'est sans effet. Je reproduis la configuration existante plutôt que d'inventer une valeur.

## Bascule requise au merge — à faire ensemble

Cette PR ne peut pas être mergée seule : le service compose ne sert à rien tant que les domaines pointent sur l'ancienne application, et supprimer l'application avant de recréer les domaines coupe le site.

**Sur staging d'abord :**

1. Ajouter au champ `env` du compose staging (`RCdDrshf1bGHBsCrKaKGs`) les variables `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_BACKEND_URL`, `NEXT_PUBLIC_BASE_URL`, `NEXT_PUBLIC_ASSETS_URL`, `NEXT_PUBLIC_TURNSTILE_SITE_KEY`, `NEXT_PUBLIC_GOOGLE_TAG_MANAGER`, `NEXT_PUBLIC_MICROSOFT_CLARITY` — le compose les référence pour le rendu serveur.
2. Merger, laisser le workflow builder l'image et déployer la stack.
3. Recréer les domaines de staging sur le compose avec `serviceName: frontend`, port 3000.
4. Vérifier le site, **et en particulier le captcha** sur un formulaire.
5. Supprimer l'application Dokploy `mv1Jrt0hTuKip7AfJn_J1`.

**Puis la même séquence en prod** avec le compose `7EDs5TtNzsEGOslDkKOg7`, les 4 domaines (`minecraft-stats.com`, `minecraft-stats.fr`, `prod.minecraft-stats.com`, `prod.minecraft-stats.fr`) et l'application `KA6_jcrlqlWVZKmRbgpq-`.

Point rassurant sur les domaines : les 8 sont en `certificateType: "none"` — le TLS est assuré par Cloudflare, il n'y a donc aucun certificat Let's Encrypt à perdre ou à réémettre.

## Testing

- YAML du workflow et du compose parsés, graphe des jobs vérifié.
- Utilisation réelle des `NEXT_PUBLIC_*` tracée dans le code source pour distinguer build-time et runtime.
- **Non testé : le build et le déploiement réels.** Ils ne peuvent l'être qu'en exécutant la bascule, sur staging en premier.
