### PR TITLE
Promotion staging -> main : correctif de détection + fil d'Ariane

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,9 @@ on:
     branches:
       - main
       - staging
+  # Filet de secours : permet de forcer un déploiement complet sans pousser un
+  # commit vide, par exemple après une panne d'infrastructure.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -43,27 +46,71 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-
-      - name: Filter paths
-        uses: dorny/paths-filter@v4
-        id: filter
         with:
-          # Le workflow et son script se trouvent dans les trois filtres : les
-          # modifier doit redéployer, sinon un correctif du pipeline reste
+          # `git diff` a besoin du commit précédent, qui n'est pas dans un
+          # clone superficiel.
+          fetch-depth: 0
+
+      # `dorny/paths-filter` a été retiré : sur un merge `staging` -> `main`, il
+      # calculait le diff depuis le merge-base des deux branches. Après le merge
+      # ce merge-base *est* la pointe de main, donc « 0 changed files », donc
+      # aucun déploiement — et un run vert. C'est exactement la panne
+      # silencieuse que ce workflow existe pour éliminer.
+      #
+      # On compare donc explicitement `before`..`sha`, ce que GitHub fournit
+      # pour tout push, merge inclus. Règle de sûreté : si l'ensemble modifié
+      # n'est pas déterminable avec certitude, on déploie tout. Déployer trop se
+      # remarque et se corrige ; ne rien déployer sans le savoir, non.
+      - name: Detect changes
+        id: filter
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          deploy_all() {
+            echo "Raison : $1 — tous les services seront déployés."
+            for svc in backend mcp frontend; do echo "${svc}=true" >> "$GITHUB_OUTPUT"; done
+            exit 0
+          }
+
+          # `[ test ] && cmd` sortirait du script sous `set -e` quand le test est
+          # faux : le statut non nul du test devient celui de la commande.
+          if [ "$EVENT" != "push" ]; then
+            deploy_all "déclenchement manuel (${EVENT})"
+          fi
+          case "$BEFORE" in
+            ""|0000000000000000000000000000000000000000)
+              deploy_all "pas de commit de référence (nouvelle branche)" ;;
+          esac
+          git cat-file -e "${BEFORE}^{commit}" 2>/dev/null \
+            || deploy_all "commit de référence ${BEFORE} introuvable"
+          changed=$(git diff --name-only "$BEFORE" "$AFTER") \
+            || deploy_all "git diff en échec"
+          if [ -z "$changed" ]; then
+            deploy_all "aucun fichier modifié détecté"
+          fi
+
+          echo "Fichiers modifiés :"
+          printf '%s\n' "$changed" | sed 's/^/  /'
+
+          # Le workflow et son script comptent pour les trois services : modifier
+          # le pipeline doit le rejouer partout, sinon un correctif reste
           # invérifiable jusqu'au prochain changement applicatif.
-          filters: |
-            backend:
-              - 'backend/**'
-              - '.github/workflows/deploy.yml'
-              - '.github/scripts/dokploy-deploy.sh'
-            mcp:
-              - 'mcp/**'
-              - '.github/workflows/deploy.yml'
-              - '.github/scripts/dokploy-deploy.sh'
-            frontend:
-              - 'frontend/**'
-              - '.github/workflows/deploy.yml'
-              - '.github/scripts/dokploy-deploy.sh'
+          pipeline=$(printf '%s\n' "$changed" \
+            | grep -cE '^\.github/(workflows/deploy\.yml|scripts/dokploy-deploy\.sh)$' || true)
+
+          for svc in backend mcp frontend; do
+            hits=$(printf '%s\n' "$changed" | grep -cE "^${svc}/" || true)
+            if [ "$hits" -gt 0 ] || [ "$pipeline" -gt 0 ]; then
+              echo "${svc}=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "${svc}=false" >> "$GITHUB_OUTPUT"
+            fi
+          done
+          echo "Résultat :"; cat "$GITHUB_OUTPUT" | sed 's/^/  /'
 
   build-backend:
     name: Build and push backend image


### PR DESCRIPTION
## Summary

Promotion de `staging` vers `main`, contenant #292 — le correctif de détection des fichiers modifiés sur les merges de promotion.

Le merge précédent (#291) n'avait rien déployé : `dorny/paths-filter` calculait le diff depuis le merge-base de `staging` et `main`, qui après un merge de promotion **est** la pointe de main. Zéro fichier détecté, zéro service déployé, run vert. Le correctif frontend de #288 n'est donc toujours pas en production.

Ce merge est à la fois le correctif et son test : si la détection fonctionne, ce push doit sélectionner les trois services et déployer.

## Changes

- **#292** — détection basée sur `github.event.before`..`sha`, avec la règle « dans le doute, on déploie tout ». Ajoute `workflow_dispatch`.
- **#288** — `fix(servers): tronquer le fil d'Ariane à côté des actions admin`, jamais déployé jusqu'ici.

## Testing

Validé sur `staging` : les cinq jobs au vert, `Detect changed workspaces` inclus, avec déploiement effectif du frontend et de la stack. La logique de détection avait aussi été exercée hors CI contre l'historique du dépôt, notamment sur le merge fautif lui-même (voir #292).

## Notes

À vérifier juste après ce merge : le run `Deploy` sur `main` ne doit **pas** afficher de jobs `skipped`, et les annotations doivent contenir un identifiant de déploiement Dokploy terminé pour la stack comme pour le frontend.

Reste ensuite à couper `autoDeploy` sur l'application frontend de production (`KA6_jcrlqlWVZKmRbgpq-`) ; le compose prod est déjà à `false`.
