### PR TITLE
Promotion staging -> main : frontend dans le compose

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,10 @@
 name: Deploy
 
-# Un seul workflow pilote les trois services. Auparavant `deploy-backend.yml` et
-# `deploy-mcp.yml` couvraient le backend et le MCP, tandis que le frontend était
-# déployé par l'auto-deploy de Dokploy via le webhook de la GitHub App : deux
-# mécanismes distincts pour un même dépôt, sans vue d'ensemble.
+# Un seul workflow pilote les trois services, et un seul appel les déploie
+# ensemble : le frontend fait désormais partie du compose au lieu d'être une
+# application Dokploy à part, buildée sur le serveur via le webhook de la GitHub
+# App. Deux mécanismes distincts pour un même dépôt rendaient l'état réel des
+# déploiements impossible à lire d'un coup d'œil.
 #
 # Surtout, l'ancien déclencheur se contentait d'un `curl` sur `compose.deploy`,
 # qui répond 200 dès la *mise en file*. En août 2026 un build figé d'un autre
@@ -196,9 +197,72 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  build-frontend:
+    name: Build and push frontend image
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    # Nécessaire pour lire `vars.FRONTEND_BUILD_ARGS`, dont les valeurs diffèrent
+    # entre prod et staging (URL d'API, bucket S3, domaine de base).
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
+
+    env:
+      IMAGE_NAME: sportek/minecraft-stats-front
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set image tag
+        id: set-tag
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          else
+            echo "tag=staging" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check build args are configured
+        env:
+          BUILD_ARGS: ${{ vars.FRONTEND_BUILD_ARGS }}
+        run: |
+          # Les NEXT_PUBLIC_* sont figées dans le bundle client au build. Une
+          # variable absente ne casse pas la construction : elle produit
+          # silencieusement un site avec des URLs d'API vides et un captcha mort.
+          missing=""
+          for key in NEXT_PUBLIC_API_URL NEXT_PUBLIC_BACKEND_URL \
+                     NEXT_PUBLIC_TURNSTILE_SITE_KEY NEXT_PUBLIC_ASSETS_URL; do
+            printf '%s\n' "$BUILD_ARGS" | grep -q "^${key}=" || missing="${missing} ${key}"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::FRONTEND_BUILD_ARGS incomplet pour '${{ github.ref_name == 'main' && 'production' || 'staging' }}' — manquant :${missing}"
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: ./frontend
+          push: true
+          build-args: ${{ vars.FRONTEND_BUILD_ARGS }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.set-tag.outputs.tag }}
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   deploy-stack:
-    name: Deploy backend stack
-    needs: [changes, build-backend, build-mcp]
+    name: Deploy stack
+    needs: [changes, build-backend, build-mcp, build-frontend]
     # Les deux builds sont conditionnels. Le `success()` implicite de `needs:`
     # sauterait ce job dès que l'un des deux est `skipped` — c'est-à-dire dès
     # qu'un push ne touche qu'un seul des deux services. On exige seulement
@@ -208,11 +272,15 @@ jobs:
     if: >-
       !cancelled()
       && needs.changes.result == 'success'
-      && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true')
+      && (needs.changes.outputs.backend == 'true'
+          || needs.changes.outputs.mcp == 'true'
+          || needs.changes.outputs.frontend == 'true')
       && needs.build-backend.result != 'failure'
       && needs.build-backend.result != 'cancelled'
       && needs.build-mcp.result != 'failure'
       && needs.build-mcp.result != 'cancelled'
+      && needs.build-frontend.result != 'failure'
+      && needs.build-frontend.result != 'cancelled'
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
 
@@ -233,26 +301,3 @@ jobs:
           fi
           chmod +x .github/scripts/dokploy-deploy.sh
           .github/scripts/dokploy-deploy.sh compose "${COMPOSE_ID}"
-
-  deploy-frontend:
-    name: Deploy frontend
-    needs: changes
-    if: needs.changes.outputs.frontend == 'true'
-    runs-on: ubuntu-latest
-    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Deploy and wait
-        env:
-          DOKPLOY_API_TOKEN: ${{ secrets.DOKPLOY_API_TOKEN }}
-          APP_ID: ${{ vars.DOKPLOY_FRONTEND_APP_ID }}
-        run: |
-          if [ -z "${APP_ID}" ]; then
-            echo "::error::DOKPLOY_FRONTEND_APP_ID absent de l'environnement '${{ github.ref_name == 'main' && 'production' || 'staging' }}'."
-            exit 1
-          fi
-          chmod +x .github/scripts/dokploy-deploy.sh
-          .github/scripts/dokploy-deploy.sh application "${APP_ID}"

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -106,6 +106,47 @@ services:
       start_period: 10s
 
   ##########################################################################
+  # Frontend (Next.js)
+  ##########################################################################
+  # Les variables NEXT_PUBLIC_* sont figées dans le bundle client au moment du
+  # build (voir frontend/Dockerfile) : celles listées ici ne servent qu'au rendu
+  # côté serveur. Changer une URL d'API demande donc un rebuild de l'image, pas
+  # seulement un redéploiement.
+  frontend:
+    container_name: "stats-frontend-${APP_NAME}"
+    image: "sportek/minecraft-stats-front:${IMAGE_TAG:-latest}"
+    pull_policy: always
+    restart: "unless-stopped"
+    depends_on:
+      - adonis_app
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - HOSTNAME=0.0.0.0
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+      - NEXT_PUBLIC_BACKEND_URL=${NEXT_PUBLIC_BACKEND_URL}
+      - NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL:-}
+      - NEXT_PUBLIC_ASSETS_URL=${NEXT_PUBLIC_ASSETS_URL}
+      - NEXT_PUBLIC_TURNSTILE_SITE_KEY=${NEXT_PUBLIC_TURNSTILE_SITE_KEY}
+      - NEXT_PUBLIC_GOOGLE_TAG_MANAGER=${NEXT_PUBLIC_GOOGLE_TAG_MANAGER}
+      - NEXT_PUBLIC_MICROSOFT_CLARITY=${NEXT_PUBLIC_MICROSOFT_CLARITY}
+    networks:
+      - sail
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    healthcheck:
+      # 127.0.0.1 et non localhost : le serveur Next écoute en IPv4 (0.0.0.0),
+      # alors que localhost résout en IPv6 (::1) dans l'image Alpine.
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:3000/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  ##########################################################################
   # Serveur MCP (Model Context Protocol) — expose les stats publiques aux IA
   ##########################################################################
   mcp:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -30,11 +30,24 @@ COPY . .
 
 # Accept build arguments for NEXT_PUBLIC_* variables
 # These MUST be available at build time for Next.js to embed them in the client bundle
+#
+# TURNSTILE_SITE_KEY et ASSETS_URL manquaient ici. Ils fonctionnaient malgré tout
+# parce que Dokploy buildait l'image lui-même : son option « create .env file »
+# dépose un `.env` dans le contexte de build, que `.dockerignore` ne filtre pas
+# (il n'exclut que `.env*.local`, `.env.development` et `.env.test`), et que le
+# `COPY . .` ci-dessus embarque — Next le lit alors au build.
+#
+# Ce `.env` n'existe plus dès que l'image est construite ailleurs. Sans ces deux
+# ARG, `NEXT_PUBLIC_TURNSTILE_SITE_KEY` devient `undefined` dans un composant
+# client (`components/form/turnstile.tsx` est en "use client"), donc le captcha
+# casse — et le build reste vert.
 ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_BACKEND_URL
 ARG NEXT_PUBLIC_BASE_URL
 ARG NEXT_PUBLIC_GOOGLE_TAG_MANAGER
 ARG NEXT_PUBLIC_MICROSOFT_CLARITY
+ARG NEXT_PUBLIC_TURNSTILE_SITE_KEY
+ARG NEXT_PUBLIC_ASSETS_URL
 
 # Convert build args to environment variables for the build process
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
@@ -42,6 +55,8 @@ ENV NEXT_PUBLIC_BACKEND_URL=$NEXT_PUBLIC_BACKEND_URL
 ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
 ENV NEXT_PUBLIC_GOOGLE_TAG_MANAGER=$NEXT_PUBLIC_GOOGLE_TAG_MANAGER
 ENV NEXT_PUBLIC_MICROSOFT_CLARITY=$NEXT_PUBLIC_MICROSOFT_CLARITY
+ENV NEXT_PUBLIC_TURNSTILE_SITE_KEY=$NEXT_PUBLIC_TURNSTILE_SITE_KEY
+ENV NEXT_PUBLIC_ASSETS_URL=$NEXT_PUBLIC_ASSETS_URL
 
 # Disable Next.js telemetry
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
## Summary

Promotion de #290 : le frontend devient un service du compose au lieu d'une application Dokploy autonome. Un seul `compose.deploy` déploiera alors les trois services ensemble.

## Testing

Bascule complète déjà exécutée et vérifiée sur staging :

- Image `sportek/minecraft-stats-front:staging` construite et poussée par le workflow, stack déployée, cinq jobs au vert.
- Conteneur `stats-frontend-dev` vérifié `Up (healthy)` et répondant 200 en interne **avant** tout changement de routage.
- Les deux domaines déplacés vers le compose avec `serviceName: frontend`, puis redéploiement pour générer les labels Traefik.
- `staging.minecraft-stats.fr` et `.com` répondent 200 ; l'ancienne application a été supprimée.
- **Bundle client inspecté** : `NEXT_PUBLIC_TURNSTILE_SITE_KEY`, `NEXT_PUBLIC_ASSETS_URL` et `NEXT_PUBLIC_API_URL` sont bien figés dedans. C'était le risque principal — sans les `ARG` ajoutés au Dockerfile, la clé Turnstile aurait disparu du bundle et le captcha serait mort avec un déploiement vert.

## Notes

Ce merge ne fait que construire l'image `:latest` et démarrer le service `frontend` dans le compose de production. **Il ne change pas encore le routage** : les 4 domaines pointent toujours vers l'application autonome, qui continue de servir le site.

La bascule du routage suit immédiatement après, dans cet ordre :

1. Vérifier que `stats-frontend-prod` est `healthy`.
2. Déplacer les 4 domaines (`minecraft-stats.com`, `minecraft-stats.fr`, `prod.minecraft-stats.com`, `prod.minecraft-stats.fr`) vers le compose avec `serviceName: frontend`, port 3000.
3. Redéployer la stack — un domaine de compose n'existe pour Traefik qu'après un redéploiement, puisque Dokploy injecte les labels à ce moment-là. Sans cette étape, le site reste en 404.
4. Vérifier, puis supprimer l'application `KA6_jcrlqlWVZKmRbgpq-`.

L'étape 2-3 est la seule avec une coupure réelle : moins d'une minute sur staging.

Les variables d'environnement `NEXT_PUBLIC_*` ont déjà été ajoutées au compose de production.
