### PR TITLE
Add user activity analytics and consent refusal flow enhancements

### DIFF
--- a/backend/app/controllers/analytics_controller.ts
+++ b/backend/app/controllers/analytics_controller.ts
@@ -1,5 +1,6 @@
 import { recordAnonymousHit } from '#services/analytics_counters'
 import AnalyticsService from '#services/analytics_service'
+import UserActivityService, { isUserActivitySort } from '#services/user_activity_service'
 import { IdentifyVisitorValidator, TrackPageViewValidator } from '#validators/analytics'
 import { parseEpochMs } from '#validators/helpers'
 import type { HttpContext } from '@adonisjs/core/http'
@@ -104,6 +105,37 @@ export default class AnalyticsController {
     const toDate = parseEpochMs(request.input('toDate'))
 
     const data = await AnalyticsService.getDashboard({ fromDate, toDate })
+
+    return response.ok(data)
+  }
+
+  /**
+   * @getUserActivity
+   * @operationId getUserActivity
+   * @tag ANALYTICS_ADMIN
+   * @summary Logged-in user activity leaderboard (admin)
+   * @description Ranks the accounts that used the site over the requested window. A "connection" is a visit, not a login: page views attributed to an account are cut into sessions on 30 minutes of inactivity, so a member who logs in once and comes back daily still counts one connection per visit. Each row carries the connection count, page views, distinct devices, active days, time spent and last activity; `totals` sums the same window. Supports pagination (`page`, `limit`), a username/email `search` and a `sort` column. Requires authentication and administrator privileges.
+   * @paramQuery fromDate - Lower bound of the window, in epoch milliseconds. - @type(number) @example(1716854400000)
+   * @paramQuery toDate - Upper bound of the window, in epoch milliseconds. - @type(number) @example(1717459200000)
+   * @paramQuery page - Page number (1-based). - @type(number) @example(1)
+   * @paramQuery limit - Rows per page (1-100, default 20). - @type(number) @example(20)
+   * @paramQuery search - Filters on username or email. - @type(string) @example(gabriel)
+   * @paramQuery sort - Sort column: `connections` (default), `pageViews`, `timeSpent` or `lastSeen`. - @type(string) @example(connections)
+   * @responseBody 200 - {"data": [{"id": 7, "username": "gabriel", "email": "gabriel@example.com", "role": "user", "avatarUrl": "", "createdAt": "2025-01-01T00:00:00.000Z", "connections": 42, "pageViews": 310, "devices": 2, "activeDays": 18, "timeSpentMs": 4200000, "viewsPerConnection": 7.4, "firstSeenAt": "2026-05-01T10:00:00.000Z", "lastSeenAt": "2026-05-28T09:12:00.000Z"}], "meta": {"total": 120, "perPage": 20, "currentPage": 1, "lastPage": 6}, "totals": {"activeUsers": 120, "connections": 2400, "pageViews": 18000, "connectionsPerUser": 20}}
+   * @responseBody 401 - {"message": "Unauthorized"}
+   * @responseBody 403 - {"error": "Access denied. Admin privileges required."}
+   */
+  async users({ request, response }: HttpContext) {
+    const sort = request.input('sort', 'connections')
+
+    const data = await UserActivityService.leaderboard({
+      fromDate: parseEpochMs(request.input('fromDate')),
+      toDate: parseEpochMs(request.input('toDate')),
+      page: Math.max(1, Number.parseInt(request.input('page', 1), 10) || 1),
+      limit: Math.min(100, Math.max(1, Number.parseInt(request.input('limit', 20), 10) || 20)),
+      search: String(request.input('search', '')),
+      sort: isUserActivitySort(sort) ? sort : 'connections',
+    })
 
     return response.ok(data)
   }

--- a/backend/app/controllers/users_controller.ts
+++ b/backend/app/controllers/users_controller.ts
@@ -3,6 +3,7 @@ import User from '#models/user'
 import UserPolicy from '#policies/user_policy'
 import BlacklistService from '#services/blacklist_service'
 import DuplicateAccountService from '#services/duplicate_account_service'
+import UserActivityService from '#services/user_activity_service'
 import {
   CreateUserValidator,
   UpdateUserBlacklistValidator,
@@ -170,9 +171,9 @@ export default class UsersController {
    * @operationId adminShowUser
    * @tag USERS_ADMIN
    * @summary Get a user's profile and uploaded servers (admin only)
-   * @description Returns a single user's full profile — including the normally hidden `email`, the registration `provider` (`null` for email/password sign-ups), and `verified` status — alongside every server they have uploaded and any candidate duplicate accounts (other users sharing the same device or hashed IP, from the analytics visitor tables). Requires an authenticated admin (gated by `UserPolicy.manage`).
+   * @description Returns a single user's full profile — including the normally hidden `email`, the registration `provider` (`null` for email/password sign-ups), and `verified` status — alongside every server they have uploaded, any candidate duplicate accounts (other users sharing the same device or hashed IP, from the analytics visitor tables) and their usage over the last 30 days (`activity`: connections — visits cut on 30 minutes of inactivity, not logins —, page views, devices, active days, time spent, per-day series and top pages). Requires an authenticated admin (gated by `UserPolicy.manage`).
    * @paramPath id - User ID - @type(number) @example(7) @required
-   * @responseBody 200 - {"user": {"id": 7, "username": "gabriel", "email": "gabriel@example.com", "role": "user", "verified": true, "provider": "discord", "avatarUrl": "", "createdAt": "2025-01-01T00:00:00.000Z", "updatedAt": "2026-05-28T12:00:00.000Z"}, "servers": [{"id": 1, "name": "Hypixel", "address": "mc.hypixel.net", "port": 25565, "type": "java", "imageUrl": "", "lastPlayerCount": 1200, "peakPlayerCount": 5000, "lastOnlineAt": "2026-05-28T12:00:00.000Z", "createdAt": "2025-01-01T00:00:00.000Z"}], "duplicates": [{"id": 9, "username": "gab2", "email": "gab2@example.com", "role": "user", "createdAt": "2025-02-01T00:00:00.000Z", "signals": {"sameDevice": true, "sameIp": true}}], "stats": {"serverCount": 1, "duplicateCount": 1}}
+   * @responseBody 200 - {"user": {"id": 7, "username": "gabriel", "email": "gabriel@example.com", "role": "user", "verified": true, "provider": "discord", "avatarUrl": "", "createdAt": "2025-01-01T00:00:00.000Z", "updatedAt": "2026-05-28T12:00:00.000Z"}, "servers": [{"id": 1, "name": "Hypixel", "address": "mc.hypixel.net", "port": 25565, "type": "java", "imageUrl": "", "lastPlayerCount": 1200, "peakPlayerCount": 5000, "lastOnlineAt": "2026-05-28T12:00:00.000Z", "createdAt": "2025-01-01T00:00:00.000Z"}], "duplicates": [{"id": 9, "username": "gab2", "email": "gab2@example.com", "role": "user", "createdAt": "2025-02-01T00:00:00.000Z", "signals": {"sameDevice": true, "sameIp": true}}], "activity": {"connections": 42, "pageViews": 310, "devices": 2, "activeDays": 18, "timeSpentMs": 4200000, "viewsPerConnection": 7.4, "firstSeenAt": "2026-05-01T10:00:00.000Z", "lastSeenAt": "2026-05-28T09:12:00.000Z", "series": [{"day": "2026-05-28T00:00:00.000Z", "connections": 3, "pageViews": 21}], "topPages": [{"path": "/servers/:id", "views": 120}]}, "stats": {"serverCount": 1, "duplicateCount": 1}}
    * @responseBody 401 - {"error": "Unauthorized"}
    * @responseBody 403 - {"error": "Access denied. Admin privileges required."}
    * @responseBody 404 - {"error": "User not found"}
@@ -201,6 +202,10 @@ export default class UsersController {
 
     const duplicates = await DuplicateAccountService.forUser(user.id)
 
+    // Fenêtre par défaut du service (30 derniers jours) : le détail admin montre
+    // l'activité récente, pas l'historique complet du compte.
+    const activity = await UserActivityService.forUser(user.id, { fromDate: null, toDate: null })
+
     // `email` and `provider` are intentionally surfaced here even though the model
     // hides `email` from default serialization — this admin-only view needs them.
     return response.ok({
@@ -217,6 +222,7 @@ export default class UsersController {
       },
       servers,
       duplicates,
+      activity,
       stats: {
         serverCount: servers.length,
         duplicateCount: duplicates.length,

--- a/backend/app/services/user_activity_service.ts
+++ b/backend/app/services/user_activity_service.ts
@@ -1,0 +1,305 @@
+import db from '@adonisjs/lucid/services/db'
+import { DateTime } from 'luxon'
+
+/**
+ * Inactivité au-delà de laquelle une nouvelle page vue ouvre une nouvelle
+ * connexion. Une « connexion » n'est pas un login : les sessions durent des
+ * semaines, un habitué se logue une fois puis revient des mois sans repasser par
+ * le formulaire. C'est une visite — une série de pages vues séparée de la
+ * précédente par au moins ce délai.
+ */
+const SESSION_GAP_MINUTES = 30
+
+/** Colonnes de tri exposées à l'admin → expression SQL correspondante. */
+const SORTS = {
+  connections: 'connections',
+  pageViews: 'page_views',
+  timeSpent: 'duration_ms',
+  lastSeen: 'last_seen_at',
+} as const
+
+export type UserActivitySort = keyof typeof SORTS
+
+/** Garde de saisie : le tri vient d'un paramètre de requête, jamais de confiance. */
+export const isUserActivitySort = (value: unknown): value is UserActivitySort =>
+  typeof value === 'string' && value in SORTS
+
+// Collapse numeric path segments (/servers/42 → /servers/:id) so the ~500 real
+// URLs aggregate into a readable handful of route patterns.
+const NORMALIZED_PATH = "regexp_replace(path, '/[0-9]+', '/:id', 'g')"
+
+/**
+ * CTE `per_user` : découpe les pages vues attribuées à un compte en connexions.
+ * `lag()` donne l'écart avec la vue précédente du même utilisateur, et tout écart
+ * supérieur au seuil d'inactivité ouvre une connexion. `bucketByDay` ajoute le
+ * jour à la clé de regroupement pour obtenir la courbe jour par jour ; le seuil
+ * est une constante du code, jamais une entrée utilisateur, d'où l'interpolation.
+ */
+const perUserCte = (options: { bucketByDay?: boolean; singleUser?: boolean } = {}) => {
+  const dayColumn = options.bucketByDay ? "date_trunc('day', created_at) as day," : ''
+  const dayGroup = options.bucketByDay ? ", date_trunc('day', created_at)" : ''
+  const userFilter = options.singleUser ? 'and user_id = :userId' : ''
+
+  return `
+    with attributed as (
+      select
+        user_id,
+        visitor_id,
+        created_at,
+        duration_ms,
+        lag(created_at) over (partition by user_id order by created_at) as previous_at
+      from page_views
+      where user_id is not null
+        and created_at >= :from
+        and created_at <= :to
+        ${userFilter}
+    ),
+    sessionized as (
+      select
+        *,
+        case
+          when previous_at is null
+            or created_at - previous_at > interval '${SESSION_GAP_MINUTES} minutes'
+          then 1
+          else 0
+        end as starts_connection
+      from attributed
+    ),
+    per_user as (
+      select
+        user_id,
+        ${dayColumn}
+        sum(starts_connection)::int as connections,
+        count(*)::int as page_views,
+        count(distinct visitor_id)::int as devices,
+        count(distinct date_trunc('day', created_at))::int as active_days,
+        coalesce(sum(duration_ms), 0)::bigint as duration_ms,
+        min(created_at) as first_seen_at,
+        max(created_at) as last_seen_at
+      from sessionized
+      group by user_id${dayGroup}
+    )
+  `
+}
+
+export interface UserActivityMetrics {
+  connections: number
+  pageViews: number
+  devices: number
+  activeDays: number
+  timeSpentMs: number
+  viewsPerConnection: number
+  firstSeenAt: Date | null
+  lastSeenAt: Date | null
+}
+
+export interface ActiveUser extends UserActivityMetrics {
+  id: number
+  username: string
+  email: string
+  role: string
+  avatarUrl: string | null
+  createdAt: Date
+}
+
+interface ActivityWindow {
+  fromDate: number | null
+  toDate: number | null
+}
+
+interface LeaderboardParams extends ActivityWindow {
+  page: number
+  limit: number
+  search: string
+  sort: UserActivitySort
+}
+
+/** Ligne brute du CTE `per_user` : colonnes SQL, donc en snake_case. */
+interface ActivityRow {
+  connections: number | string | null
+  page_views: number | string | null
+  devices: number | string | null
+  active_days: number | string | null
+  duration_ms: number | string | null
+  first_seen_at: Date | null
+  last_seen_at: Date | null
+}
+
+interface ActiveUserRow extends ActivityRow {
+  id: number
+  username: string
+  email: string
+  role: string
+  avatar_url: string | null
+  created_at: Date
+}
+
+const EMPTY_METRICS: UserActivityMetrics = {
+  connections: 0,
+  pageViews: 0,
+  devices: 0,
+  activeDays: 0,
+  timeSpentMs: 0,
+  viewsPerConnection: 0,
+  firstSeenAt: null,
+  lastSeenAt: null,
+}
+
+/**
+ * Activité des comptes connectés, pour le dashboard admin. Tout est dérivé de
+ * `page_views`, seul journal d'usage attribué à un compte : les connexions y sont
+ * reconstruites par découpage sur l'inactivité plutôt que comptées au login.
+ */
+export default class UserActivityService {
+  /** Fenêtre par défaut : 30 derniers jours, comme le dashboard analytics. */
+  private static resolveWindow({ fromDate, toDate }: ActivityWindow) {
+    const from =
+      fromDate !== null ? DateTime.fromMillis(fromDate) : DateTime.now().minus({ days: 30 })
+    const to = toDate !== null ? DateTime.fromMillis(toDate) : DateTime.now()
+
+    return { from: from.toJSDate(), to: to.toJSDate() }
+  }
+
+  private static toMetrics(row: ActivityRow | undefined): UserActivityMetrics {
+    if (!row) return EMPTY_METRICS
+
+    const connections = Number(row.connections ?? 0)
+    const pageViews = Number(row.page_views ?? 0)
+
+    return {
+      connections,
+      pageViews,
+      devices: Number(row.devices ?? 0),
+      activeDays: Number(row.active_days ?? 0),
+      timeSpentMs: Number(row.duration_ms ?? 0),
+      viewsPerConnection: connections > 0 ? Number((pageViews / connections).toFixed(1)) : 0,
+      firstSeenAt: row.first_seen_at,
+      lastSeenAt: row.last_seen_at,
+    }
+  }
+
+  /**
+   * Classement des comptes les plus actifs sur la fenêtre, paginé et triable.
+   * Seuls les utilisateurs avec au moins une page vue attribuée y figurent.
+   */
+  static async leaderboard(params: LeaderboardParams) {
+    const { page, limit, search, sort } = params
+    const window = this.resolveWindow(params)
+
+    // Le même filtre sert au classement et aux totaux : la pagination et le
+    // compteur doivent porter sur exactement les mêmes lignes.
+    const searchFilter = search ? 'where u.username ilike :search or u.email ilike :search' : ''
+    const bindings = {
+      ...window,
+      ...(search ? { search: `%${search}%` } : {}),
+      limit,
+      offset: (page - 1) * limit,
+    }
+    const cte = perUserCte()
+
+    const [rows, totalsRow] = await Promise.all([
+      db
+        .rawQuery(
+          `${cte}
+           select
+             u.id, u.username, u.email, u.role, u.avatar_url, u.created_at,
+             p.connections, p.page_views, p.devices, p.active_days, p.duration_ms,
+             p.first_seen_at, p.last_seen_at
+           from per_user p
+           join users u on u.id = p.user_id
+           ${searchFilter}
+           order by ${SORTS[sort]} desc nulls last, u.id asc
+           limit :limit offset :offset`,
+          bindings
+        )
+        .then((result) => result.rows as ActiveUserRow[]),
+
+      db
+        .rawQuery(
+          `${cte}
+           select
+             count(*)::int as active_users,
+             coalesce(sum(p.connections), 0)::int as connections,
+             coalesce(sum(p.page_views), 0)::int as page_views
+           from per_user p
+           join users u on u.id = p.user_id
+           ${searchFilter}`,
+          bindings
+        )
+        .then((result) => result.rows[0]),
+    ])
+
+    const activeUsers = Number(totalsRow?.active_users ?? 0)
+    const connections = Number(totalsRow?.connections ?? 0)
+
+    return {
+      data: rows.map(
+        (row): ActiveUser => ({
+          id: Number(row.id),
+          username: row.username,
+          email: row.email,
+          role: row.role,
+          avatarUrl: row.avatar_url,
+          createdAt: row.created_at,
+          ...this.toMetrics(row),
+        })
+      ),
+      meta: {
+        total: activeUsers,
+        perPage: limit,
+        currentPage: page,
+        lastPage: Math.max(1, Math.ceil(activeUsers / limit)),
+      },
+      totals: {
+        activeUsers,
+        connections,
+        pageViews: Number(totalsRow?.page_views ?? 0),
+        connectionsPerUser: activeUsers > 0 ? Number((connections / activeUsers).toFixed(1)) : 0,
+      },
+    }
+  }
+
+  /**
+   * Détail d'activité d'un compte : mêmes métriques que le classement, plus la
+   * courbe jour par jour et les pages les plus consultées par cet utilisateur.
+   */
+  static async forUser(userId: number, params: ActivityWindow) {
+    const window = this.resolveWindow(params)
+    const bindings = { ...window, userId }
+
+    const [metricsRow, series, topPages] = await Promise.all([
+      db
+        .rawQuery(`${perUserCte({ singleUser: true })} select * from per_user`, bindings)
+        .then((result) => result.rows[0] as ActivityRow | undefined),
+
+      db
+        .rawQuery(
+          `${perUserCte({ singleUser: true, bucketByDay: true })}
+           select day, connections, page_views from per_user order by day asc`,
+          bindings
+        )
+        .then((result) => result.rows as { day: Date; connections: number; page_views: number }[]),
+
+      db
+        .from('page_views')
+        .where('user_id', userId)
+        .where('created_at', '>=', window.from)
+        .where('created_at', '<=', window.to)
+        .select(db.raw(`${NORMALIZED_PATH} as path`))
+        .select(db.raw('count(*) as views'))
+        .groupByRaw(NORMALIZED_PATH)
+        .orderByRaw('views desc')
+        .limit(10),
+    ])
+
+    return {
+      ...this.toMetrics(metricsRow),
+      series: series.map((row) => ({
+        day: row.day,
+        connections: Number(row.connections),
+        pageViews: Number(row.page_views),
+      })),
+      topPages: topPages.map((row) => ({ path: row.path, views: Number(row.views) })),
+    }
+  }
+}

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -300,6 +300,9 @@ router
         router
           .get('analytics', '#controllers/analytics_controller.dashboard')
           .use([middleware.admin(), throttleLight('admin.analytics', 30), NO_STORE])
+        router
+          .get('analytics/users', '#controllers/analytics_controller.users')
+          .use([middleware.admin(), throttleLight('admin.analytics.users', 30), NO_STORE])
 
         // Ownership claims — manual review queue (admin only)
         router

--- a/backend/tests/functional/user_activity.spec.ts
+++ b/backend/tests/functional/user_activity.spec.ts
@@ -1,0 +1,168 @@
+import User from '#models/user'
+import Visitor from '#models/visitor'
+import testUtils from '@adonisjs/core/services/test_utils'
+import db from '@adonisjs/lucid/services/db'
+import { test } from '@japa/runner'
+import { DateTime } from 'luxon'
+import { randomUUID } from 'node:crypto'
+
+async function createUser(overrides: Partial<Parameters<typeof User.create>[0]> = {}) {
+  const suffix = randomUUID().replace(/-/g, '').slice(0, 8)
+  return User.create({
+    email: `activity_${suffix}@example.com`,
+    username: `activity_${suffix}`,
+    password: 'password123',
+    verified: true,
+    ...overrides,
+  })
+}
+
+async function bearerFor(user: User) {
+  const token = await User.accessTokens.create(user)
+  return token.value!.release()
+}
+
+/**
+ * Insère des pages vues à des instants imposés : `created_at` est en `autoCreate`
+ * sur le modèle, donc le seul moyen de rejouer un historique est l'insert direct.
+ * `minutesAgo` décrit chaque vue par son ancienneté.
+ */
+async function recordViews(
+  user: User,
+  visitorId: number,
+  minutesAgo: number[],
+  path = '/servers/1'
+) {
+  await db.table('page_views').multiInsert(
+    minutesAgo.map((minutes) => ({
+      visitor_id: visitorId,
+      user_id: user.id,
+      path,
+      duration_ms: 1000,
+      created_at: DateTime.now().minus({ minutes }).toSQL(),
+    }))
+  )
+}
+
+async function createVisitor() {
+  const visitor = await Visitor.create({ uuid: randomUUID() })
+  return visitor.id
+}
+
+test.group('User activity analytics', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('les vues sont découpées en connexions sur 30 minutes d’inactivité', async ({
+    client,
+    assert,
+  }) => {
+    const admin = await createUser({ role: 'admin' })
+    const member = await createUser()
+    const visitorId = await createVisitor()
+
+    // Trois visites : deux vues rapprochées (10 min), puis deux autres à ~1 h et
+    // ~3 h — soit 3 connexions et 5 pages vues.
+    await recordViews(member, visitorId, [180, 175, 60, 55, 10])
+
+    const response = await client
+      .get('/api/v1/admin/analytics/users')
+      .bearerToken(await bearerFor(admin))
+
+    response.assertStatus(200)
+    const row = response.body().data.find((entry: { id: number }) => entry.id === member.id)
+    assert.exists(row)
+    assert.equal(row.connections, 3)
+    assert.equal(row.pageViews, 5)
+    assert.equal(row.devices, 1)
+    assert.equal(row.viewsPerConnection, 1.7)
+  })
+
+  test('le classement met les comptes les plus actifs en tête', async ({ client, assert }) => {
+    const admin = await createUser({ role: 'admin' })
+    const heavy = await createUser()
+    const light = await createUser()
+
+    await recordViews(heavy, await createVisitor(), [300, 240, 180, 120, 60])
+    await recordViews(light, await createVisitor(), [90])
+
+    const response = await client
+      .get('/api/v1/admin/analytics/users')
+      .qs({ sort: 'connections' })
+      .bearerToken(await bearerFor(admin))
+
+    response.assertStatus(200)
+    const ranking: number[] = response.body().data.map((entry: { id: number }) => entry.id)
+    assert.isBelow(ranking.indexOf(heavy.id), ranking.indexOf(light.id))
+    assert.equal(response.body().totals.activeUsers, 2)
+    assert.equal(response.body().totals.connections, 6)
+  })
+
+  test('la fenêtre exclut les visites hors période', async ({ client, assert }) => {
+    const admin = await createUser({ role: 'admin' })
+    const member = await createUser()
+
+    await recordViews(member, await createVisitor(), [60 * 24 * 45, 30])
+
+    const response = await client
+      .get('/api/v1/admin/analytics/users')
+      .qs({
+        fromDate: DateTime.now().minus({ days: 7 }).toMillis(),
+        toDate: DateTime.now().toMillis(),
+      })
+      .bearerToken(await bearerFor(admin))
+
+    response.assertStatus(200)
+    const row = response.body().data.find((entry: { id: number }) => entry.id === member.id)
+    assert.equal(row.connections, 1)
+    assert.equal(row.pageViews, 1)
+  })
+
+  test('la recherche filtre le classement sur le nom ou l’e-mail', async ({ client, assert }) => {
+    const admin = await createUser({ role: 'admin' })
+    const member = await createUser()
+    const other = await createUser()
+
+    await recordViews(member, await createVisitor(), [30])
+    await recordViews(other, await createVisitor(), [30])
+
+    const response = await client
+      .get('/api/v1/admin/analytics/users')
+      .qs({ search: member.username })
+      .bearerToken(await bearerFor(admin))
+
+    response.assertStatus(200)
+    assert.lengthOf(response.body().data, 1)
+    assert.equal(response.body().data[0].id, member.id)
+    assert.equal(response.body().meta.total, 1)
+  })
+
+  test('un utilisateur non admin ne peut pas lire le classement', async ({ client }) => {
+    const member = await createUser()
+
+    const response = await client
+      .get('/api/v1/admin/analytics/users')
+      .bearerToken(await bearerFor(member))
+
+    response.assertStatus(403)
+  })
+
+  test('le détail admin d’un compte expose son activité', async ({ client, assert }) => {
+    const admin = await createUser({ role: 'admin' })
+    const member = await createUser()
+
+    await recordViews(member, await createVisitor(), [120, 115], '/servers/42')
+
+    const response = await client
+      .get(`/api/v1/admin/users/${member.id}`)
+      .bearerToken(await bearerFor(admin))
+
+    response.assertStatus(200)
+    const { activity } = response.body()
+    assert.equal(activity.connections, 1)
+    assert.equal(activity.pageViews, 2)
+    assert.equal(activity.activeDays, 1)
+    assert.deepEqual(activity.topPages, [{ path: '/servers/:id', views: 2 }])
+    assert.lengthOf(activity.series, 1)
+    assert.equal(activity.series[0].connections, 1)
+  })
+})

--- a/frontend/messages/en/admin.json
+++ b/frontend/messages/en/admin.json
@@ -280,7 +280,24 @@
       "offlineStatus": "Offline",
       "peak": "peak {count}",
       "viewServer": "View server",
-      "view": "View"
+      "view": "View",
+      "activity": {
+        "title": "Activity (last 30 days)",
+        "help": "A connection is a visit: 30 minutes of inactivity opens a new one. Computed from page views attributed to the account, not from logins.",
+        "empty": "No activity recorded over the last 30 days.",
+        "lastSeen": "Last activity",
+        "viewsPerConnection": "Pages per connection",
+        "topPages": "Most visited pages",
+        "noPages": "No page view over the period.",
+        "pageViews": "{count} views",
+        "tiles": {
+          "connections": "Connections",
+          "pageViews": "Page views",
+          "activeDays": "Active days",
+          "devices": "Devices",
+          "timeSpent": "Time spent"
+        }
+      }
     }
   },
   "analytics": {
@@ -317,6 +334,45 @@
       "noData": "no data",
       "fewer": "Fewer",
       "more": "More"
+    },
+    "activeUsers": {
+      "title": "Most active users",
+      "subtitle": "Connections and usage of logged-in accounts over the selected period.",
+      "badge": "{count} active accounts",
+      "backToAnalytics": "Back to analytics",
+      "cardTitle": "Most active users",
+      "cardSubtitle": "One connection = one visit: 30 minutes of inactivity opens a new one. This is not a login count.",
+      "viewAll": "View all",
+      "rowValue": "{connections} connections · {views} page views",
+      "searchPlaceholder": "Search by name or email…",
+      "loading": "Loading activity…",
+      "emptyTitle": "No activity",
+      "emptyDescription": "No logged-in account was seen over this period.",
+      "tiles": {
+        "activeUsers": "Active accounts",
+        "connections": "Connections",
+        "pageViews": "Page views",
+        "perUser": "Connections / account"
+      },
+      "columns": {
+        "connections": "Connections",
+        "pageViews": "Page views",
+        "activeDays": "Active days",
+        "devices": "Devices",
+        "timeSpent": "Time spent",
+        "lastSeen": "Last activity"
+      },
+      "sort": {
+        "connections": "Connections",
+        "pageViews": "Page views",
+        "timeSpent": "Time spent",
+        "lastSeen": "Last activity"
+      },
+      "duration": {
+        "hours": "{hours} h {minutes} min",
+        "minutes": "{minutes} min",
+        "none": "—"
+      }
     }
   },
   "ownershipClaims": {

--- a/frontend/messages/en/staticPages.json
+++ b/frontend/messages/en/staticPages.json
@@ -259,7 +259,44 @@
   },
   "consent": {
     "description": "We measure site usage (pages visited, traffic) to improve it. These statistics use your IP address (stored in an anonymized form) and your browser. <link>Learn more</link>.",
-    "decline": "Decline",
-    "accept": "Accept"
+    "accept": "Accept all",
+    "moreInfo": "More info",
+    "purposes": {
+      "audience": {
+        "title": "Audience measurement",
+        "description": "Counting visits and page views so we know what is actually used on the site."
+      },
+      "improvement": {
+        "title": "Site improvement",
+        "description": "Spotting slow pages, broken journeys and features that need a rework."
+      },
+      "personalization": {
+        "title": "Relevant content",
+        "description": "Highlighting the servers and rankings that match how you use the site."
+      }
+    },
+    "info": {
+      "title": "What are these statistics for?",
+      "body": "Minecraft Stats is free and run by a small team. These measurements tell us which pages are useful, what breaks and what to improve first. No data is ever sold, and your IP address is never stored in clear. <link>Privacy policy</link>.",
+      "manage": "Manage my preferences"
+    },
+    "preferences": {
+      "title": "Your preferences",
+      "body": "Pick the purposes you accept. Unchecking everything means declining detailed statistics.",
+      "alwaysOn": "Always on",
+      "necessary": {
+        "title": "Site functionality",
+        "description": "Account sign-in, theme, favourites. Required for the site to work, so it cannot be turned off."
+      },
+      "save": "Accept and continue",
+      "refuse": "Continue without accepting"
+    },
+    "confirm": {
+      "title": "Are you sure?",
+      "body": "Without these statistics we are flying blind: we cannot tell which pages deserve the work. It costs nothing and stays anonymous — and you can change your mind at any time.",
+      "reconsider": "Actually, I accept",
+      "refuse": "Confirm refusal",
+      "refuseCountdown": "Confirm refusal ({seconds})"
+    }
   }
 }

--- a/frontend/messages/es/admin.json
+++ b/frontend/messages/es/admin.json
@@ -280,7 +280,24 @@
       "offlineStatus": "Desconectado",
       "peak": "pico {count}",
       "viewServer": "Ver servidor",
-      "view": "Ver"
+      "view": "Ver",
+      "activity": {
+        "title": "Actividad (últimos 30 días)",
+        "help": "Una conexión es una visita: 30 minutos de inactividad abren una nueva. Se calcula a partir de las páginas vistas atribuidas a la cuenta, no de los inicios de sesión.",
+        "empty": "Sin actividad registrada en los últimos 30 días.",
+        "lastSeen": "Última actividad",
+        "viewsPerConnection": "Páginas por conexión",
+        "topPages": "Páginas más visitadas",
+        "noPages": "Ninguna página vista en el periodo.",
+        "pageViews": "{count} vistas",
+        "tiles": {
+          "connections": "Conexiones",
+          "pageViews": "Páginas vistas",
+          "activeDays": "Días activos",
+          "devices": "Dispositivos",
+          "timeSpent": "Tiempo dedicado"
+        }
+      }
     }
   },
   "analytics": {
@@ -317,6 +334,45 @@
       "noData": "sin datos",
       "fewer": "Menos",
       "more": "Más"
+    },
+    "activeUsers": {
+      "title": "Usuarios más activos",
+      "subtitle": "Conexiones y uso de las cuentas conectadas durante el periodo seleccionado.",
+      "badge": "{count} cuentas activas",
+      "backToAnalytics": "Volver a las estadísticas",
+      "cardTitle": "Usuarios más activos",
+      "cardSubtitle": "Una conexión = una visita: 30 minutos de inactividad abren una nueva. No es un recuento de inicios de sesión.",
+      "viewAll": "Ver todo",
+      "rowValue": "{connections} conexiones · {views} páginas vistas",
+      "searchPlaceholder": "Buscar por nombre o correo…",
+      "loading": "Cargando la actividad…",
+      "emptyTitle": "Sin actividad",
+      "emptyDescription": "Ninguna cuenta conectada fue vista durante este periodo.",
+      "tiles": {
+        "activeUsers": "Cuentas activas",
+        "connections": "Conexiones",
+        "pageViews": "Páginas vistas",
+        "perUser": "Conexiones / cuenta"
+      },
+      "columns": {
+        "connections": "Conexiones",
+        "pageViews": "Páginas vistas",
+        "activeDays": "Días activos",
+        "devices": "Dispositivos",
+        "timeSpent": "Tiempo dedicado",
+        "lastSeen": "Última actividad"
+      },
+      "sort": {
+        "connections": "Conexiones",
+        "pageViews": "Páginas vistas",
+        "timeSpent": "Tiempo dedicado",
+        "lastSeen": "Última actividad"
+      },
+      "duration": {
+        "hours": "{hours} h {minutes} min",
+        "minutes": "{minutes} min",
+        "none": "—"
+      }
     }
   },
   "ownershipClaims": {

--- a/frontend/messages/es/staticPages.json
+++ b/frontend/messages/es/staticPages.json
@@ -259,7 +259,44 @@
   },
   "consent": {
     "description": "Medimos el uso del sitio (páginas visitadas, tráfico) para mejorarlo. Estas estadísticas utilizan tu dirección IP (almacenada de forma anonimizada) y tu navegador. <link>Más información</link>.",
-    "decline": "Rechazar",
-    "accept": "Aceptar"
+    "accept": "Aceptar todo",
+    "moreInfo": "Más información",
+    "purposes": {
+      "audience": {
+        "title": "Medición de audiencia",
+        "description": "Contar las visitas y las páginas vistas para saber qué se usa realmente en el sitio."
+      },
+      "improvement": {
+        "title": "Mejora del sitio",
+        "description": "Detectar páginas lentas, recorridos que fallan y funciones que hay que rehacer."
+      },
+      "personalization": {
+        "title": "Contenidos adaptados",
+        "description": "Destacar los servidores y las clasificaciones que encajan con tu uso del sitio."
+      }
+    },
+    "info": {
+      "title": "¿Para qué sirven estas estadísticas?",
+      "body": "Minecraft Stats es gratuito y lo mantiene un equipo pequeño. Estas mediciones nos dicen qué páginas son útiles, qué se rompe y qué mejorar primero. Nunca vendemos datos y tu dirección IP nunca se almacena en claro. <link>Política de privacidad</link>.",
+      "manage": "Gestionar mis preferencias"
+    },
+    "preferences": {
+      "title": "Tus preferencias",
+      "body": "Elige las finalidades que aceptas. Desmarcarlo todo equivale a rechazar las estadísticas detalladas.",
+      "alwaysOn": "Siempre activo",
+      "necessary": {
+        "title": "Funcionamiento del sitio",
+        "description": "Inicio de sesión, tema, favoritos. Imprescindible para el sitio, así que no se puede desactivar."
+      },
+      "save": "Aceptar y continuar",
+      "refuse": "Continuar sin aceptar"
+    },
+    "confirm": {
+      "title": "¿Estás seguro?",
+      "body": "Sin estas estadísticas vamos a ciegas: no podemos saber qué páginas merecen trabajo. No cuesta nada y sigue siendo anónimo, y puedes cambiar de opinión cuando quieras.",
+      "reconsider": "Pensándolo bien, acepto",
+      "refuse": "Confirmar el rechazo",
+      "refuseCountdown": "Confirmar el rechazo ({seconds})"
+    }
   }
 }

--- a/frontend/messages/fr/admin.json
+++ b/frontend/messages/fr/admin.json
@@ -280,7 +280,24 @@
       "offlineStatus": "Hors ligne",
       "peak": "pic {count}",
       "viewServer": "Voir le serveur",
-      "view": "Voir"
+      "view": "Voir",
+      "activity": {
+        "title": "Activité (30 derniers jours)",
+        "help": "Une connexion est une visite : 30 minutes d'inactivité en ouvrent une nouvelle. Calculé depuis les pages vues attribuées au compte, pas depuis les logins.",
+        "empty": "Aucune activité enregistrée sur les 30 derniers jours.",
+        "lastSeen": "Dernière activité",
+        "viewsPerConnection": "Pages par connexion",
+        "topPages": "Pages les plus consultées",
+        "noPages": "Aucune page vue sur la période.",
+        "pageViews": "{count} vues",
+        "tiles": {
+          "connections": "Connexions",
+          "pageViews": "Pages vues",
+          "activeDays": "Jours actifs",
+          "devices": "Appareils",
+          "timeSpent": "Temps passé"
+        }
+      }
     }
   },
   "analytics": {
@@ -317,6 +334,45 @@
       "noData": "aucune donnée",
       "fewer": "Moins",
       "more": "Plus"
+    },
+    "activeUsers": {
+      "title": "Utilisateurs les plus actifs",
+      "subtitle": "Connexions et usage des comptes connectés sur la période choisie.",
+      "badge": "{count} comptes actifs",
+      "backToAnalytics": "Retour aux statistiques",
+      "cardTitle": "Utilisateurs les plus actifs",
+      "cardSubtitle": "Une connexion = une visite : 30 minutes d'inactivité en ouvrent une nouvelle. Ce n'est pas un nombre de logins.",
+      "viewAll": "Voir tout",
+      "rowValue": "{connections} connexions · {views} pages vues",
+      "searchPlaceholder": "Rechercher par nom ou e-mail…",
+      "loading": "Chargement de l'activité…",
+      "emptyTitle": "Aucune activité",
+      "emptyDescription": "Aucun compte connecté n'a été vu sur cette période.",
+      "tiles": {
+        "activeUsers": "Comptes actifs",
+        "connections": "Connexions",
+        "pageViews": "Pages vues",
+        "perUser": "Connexions / compte"
+      },
+      "columns": {
+        "connections": "Connexions",
+        "pageViews": "Pages vues",
+        "activeDays": "Jours actifs",
+        "devices": "Appareils",
+        "timeSpent": "Temps passé",
+        "lastSeen": "Dernière activité"
+      },
+      "sort": {
+        "connections": "Connexions",
+        "pageViews": "Pages vues",
+        "timeSpent": "Temps passé",
+        "lastSeen": "Dernière activité"
+      },
+      "duration": {
+        "hours": "{hours} h {minutes} min",
+        "minutes": "{minutes} min",
+        "none": "—"
+      }
     }
   },
   "ownershipClaims": {

--- a/frontend/messages/fr/staticPages.json
+++ b/frontend/messages/fr/staticPages.json
@@ -259,7 +259,44 @@
   },
   "consent": {
     "description": "Nous mesurons l'utilisation du site (pages consultées, trafic) afin de l'améliorer. Ces statistiques utilisent votre adresse IP (stockée sous une forme anonymisée) et votre navigateur. <link>En savoir plus</link>.",
-    "decline": "Refuser",
-    "accept": "Accepter"
+    "accept": "Tout accepter",
+    "moreInfo": "Plus d'infos",
+    "purposes": {
+      "audience": {
+        "title": "Mesure d'audience",
+        "description": "Compter les visites et les pages consultées pour savoir ce qui est utilisé sur le site."
+      },
+      "improvement": {
+        "title": "Amélioration du site",
+        "description": "Repérer les pages lentes, les parcours qui coincent et les fonctionnalités à revoir."
+      },
+      "personalization": {
+        "title": "Contenus adaptés",
+        "description": "Mettre en avant les serveurs et les classements qui correspondent à votre usage."
+      }
+    },
+    "info": {
+      "title": "À quoi servent ces statistiques ?",
+      "body": "Minecraft Stats est gratuit et suivi par une petite équipe. Ces mesures nous disent quelles pages sont utiles, ce qui casse et ce qu'il faut améliorer en priorité. Aucune donnée n'est revendue, et votre adresse IP n'est jamais stockée en clair. <link>Politique de confidentialité</link>.",
+      "manage": "Gérer mes préférences"
+    },
+    "preferences": {
+      "title": "Vos préférences",
+      "body": "Choisissez les finalités que vous acceptez. Décocher tout revient à refuser les statistiques détaillées.",
+      "alwaysOn": "Toujours actif",
+      "necessary": {
+        "title": "Fonctionnement du site",
+        "description": "Connexion à votre compte, thème, favoris. Indispensable au site, donc non désactivable."
+      },
+      "save": "Accepter et continuer",
+      "refuse": "Continuer sans accepter"
+    },
+    "confirm": {
+      "title": "Vous êtes sûr ?",
+      "body": "Sans ces statistiques, nous naviguons à l'aveugle : impossible de savoir quelles pages méritent du travail. Cela ne coûte rien et reste anonyme — vous pouvez changer d'avis à tout moment.",
+      "reconsider": "Finalement, j'accepte",
+      "refuse": "Confirmer le refus",
+      "refuseCountdown": "Confirmer le refus ({seconds})"
+    }
   }
 }

--- a/frontend/src/app/[locale]/(pages)/admin/analytics/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/admin/analytics/page.tsx
@@ -6,9 +6,10 @@ import DashboardStatTile from "@/components/account/dashboard-stat-tile";
 import { AdminFilterTabs } from "@/components/admin/admin-filter-tabs";
 import { AdminLoadingState, AdminMessageState } from "@/components/admin/admin-states";
 import { useAuth } from "@/contexts/auth";
-import { getAnalyticsDashboard } from "@/http/analytics";
+import { getActiveUsers, getAnalyticsDashboard } from "@/http/analytics";
+import { Link } from "@/i18n/navigation";
 import "@/lib/ag-charts";
-import { AnalyticsDashboard } from "@/types/analytics";
+import { ActiveUser, AnalyticsDashboard } from "@/types/analytics";
 import { AgCartesianChartOptions } from "ag-charts-community";
 import { AgCharts } from "ag-charts-react";
 import dynamic from "next/dynamic";
@@ -20,6 +21,9 @@ import { useEffect, useMemo, useState } from "react";
 const WorldMap = dynamic(() => import("@/components/analytics/world-map"), { ssr: false });
 
 type RangeKey = "7d" | "30d" | "90d";
+
+/** Aperçu du classement d'activité : le détail complet a sa propre page. */
+const TOP_USERS = 5;
 
 const RANGES: Record<RangeKey, { ms: number }> = {
   "7d": { ms: 7 * 86400000 },
@@ -58,6 +62,7 @@ const AnalyticsDashboardPage = () => {
   const { resolvedTheme } = useTheme();
 
   const [data, setData] = useState<AnalyticsDashboard | null>(null);
+  const [activeUsers, setActiveUsers] = useState<ActiveUser[]>([]);
   const [range, setRange] = useState<RangeKey>("30d");
   const [loading, setLoading] = useState(true);
 
@@ -68,7 +73,18 @@ const AnalyticsDashboardPage = () => {
       try {
         setLoading(true);
         const now = Date.now();
-        setData(await getAnalyticsDashboard(token, { fromDate: now - RANGES[range].ms, toDate: now }));
+        const period = { fromDate: now - RANGES[range].ms, toDate: now };
+        // L'aperçu du classement est secondaire : son échec ne doit pas vider
+        // le dashboard, qui est l'objet de la page.
+        const [dashboard, leaderboard] = await Promise.all([
+          getAnalyticsDashboard(token, period),
+          getActiveUsers(token, { ...period, limit: TOP_USERS }).catch((error) => {
+            console.error("Failed to fetch active users:", error);
+            return null;
+          }),
+        ]);
+        setData(dashboard);
+        setActiveUsers(leaderboard?.data ?? []);
       } catch (error) {
         console.error("Failed to fetch analytics dashboard:", error);
       } finally {
@@ -184,6 +200,30 @@ const AnalyticsDashboardPage = () => {
         )}
       </div>
 
+      <AnalyticsTable
+        title={t("analytics.activeUsers.cardTitle")}
+        subtitle={t("analytics.activeUsers.cardSubtitle")}
+        emptyLabel={t("analytics.activeUsers.emptyTitle")}
+        topLabel={t("analytics.top")}
+        action={
+          <Link
+            href="/admin/analytics/users"
+            className="text-xs font-medium text-accent hover:underline"
+          >
+            {t("analytics.activeUsers.viewAll")}
+          </Link>
+        }
+        rows={activeUsers.map((activeUser) => ({
+          key: String(activeUser.id),
+          label: activeUser.username,
+          href: `/admin/users/${activeUser.id}`,
+          value: t("analytics.activeUsers.rowValue", {
+            connections: formatNumber(activeUser.connections),
+            views: formatNumber(activeUser.pageViews),
+          }),
+        }))}
+      />
+
       <div className="grid gap-6 lg:grid-cols-2">
         <AnalyticsTable
           title={t("analytics.topPages")}
@@ -249,6 +289,8 @@ interface AnalyticsTableRow {
   key: string;
   label: string;
   value: string;
+  /** Rend le libellé cliquable (une ligne « utilisateur » mène à sa fiche admin). */
+  href?: string;
 }
 
 const AnalyticsTable = ({
@@ -257,20 +299,24 @@ const AnalyticsTable = ({
   rows,
   emptyLabel,
   topLabel,
+  action,
 }: {
   title: string;
   subtitle?: string;
   rows: AnalyticsTableRow[];
   emptyLabel: string;
   topLabel: string;
+  action?: React.ReactNode;
 }) => (
   <div className="rounded-lg border border-border bg-card text-card-foreground shadow-xs">
     <div className="flex items-baseline justify-between border-b border-border px-4 py-3">
       <h2 className="text-sm font-semibold text-foreground">{title}</h2>
-      {rows.length > 0 && (
-        <span className="text-xs text-muted-foreground">
-          {topLabel} {rows.length}
-        </span>
+      {action ?? (
+        rows.length > 0 && (
+          <span className="text-xs text-muted-foreground">
+            {topLabel} {rows.length}
+          </span>
+        )
       )}
     </div>
     {subtitle && <p className="px-4 pt-2 text-xs text-muted-foreground">{subtitle}</p>}
@@ -280,9 +326,19 @@ const AnalyticsTable = ({
       <ul className="max-h-[320px] divide-y divide-border overflow-y-auto">
         {rows.map((row) => (
           <li key={row.key} className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 px-4 py-2.5 text-sm">
-            <span className="min-w-0 truncate text-foreground" title={row.label}>
-              {row.label}
-            </span>
+            {row.href ? (
+              <Link
+                href={row.href}
+                className="min-w-0 truncate text-foreground transition-colors hover:text-accent"
+                title={row.label}
+              >
+                {row.label}
+              </Link>
+            ) : (
+              <span className="min-w-0 truncate text-foreground" title={row.label}>
+                {row.label}
+              </span>
+            )}
             <span className="shrink-0 text-right text-muted-foreground">{row.value}</span>
           </li>
         ))}

--- a/frontend/src/app/[locale]/(pages)/admin/analytics/users/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/admin/analytics/users/page.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import DashboardHero from "@/components/account/dashboard-hero";
+import DashboardLayout from "@/components/account/dashboard-layout";
+import DashboardStatTile from "@/components/account/dashboard-stat-tile";
+import { ActivityDuration } from "@/components/admin/activity-duration";
+import { AdminBackLink } from "@/components/admin/admin-back-link";
+import { AdminFilterTabs } from "@/components/admin/admin-filter-tabs";
+import { AdminLoadingState, AdminMessageState } from "@/components/admin/admin-states";
+import { AvatarTile } from "@/components/ui/avatar-tile";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Pagination } from "@/components/ui/pagination";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useAuth } from "@/contexts/auth";
+import { getActiveUsers } from "@/http/analytics";
+import { Link } from "@/i18n/navigation";
+import { ActiveUser, ActiveUsersResponse, ActiveUsersSort } from "@/types/analytics";
+import { Search } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+
+const PAGE_SIZE = 20;
+
+type RangeKey = "7d" | "30d" | "90d";
+
+const RANGES: Record<RangeKey, number> = {
+  "7d": 7 * 86400000,
+  "30d": 30 * 86400000,
+  "90d": 90 * 86400000,
+};
+
+const SORTS: ActiveUsersSort[] = ["connections", "pageViews", "timeSpent", "lastSeen"];
+
+const EMPTY_TOTALS: ActiveUsersResponse["totals"] = {
+  activeUsers: 0,
+  connections: 0,
+  pageViews: 0,
+  connectionsPerUser: 0,
+};
+
+/** Colonne chiffrée d'une ligne du classement (masquée sur mobile sauf la première). */
+const MetricCell = ({
+  label,
+  children,
+  className = "",
+}: {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}) => (
+  <div className={`w-20 shrink-0 text-right ${className}`}>
+    <div className="text-sm font-bold tabular-nums text-foreground">{children}</div>
+    <div className="text-[11px] text-muted-foreground">{label}</div>
+  </div>
+);
+
+const AdminActiveUsersPage = () => {
+  const { user, getToken } = useAuth();
+  const t = useTranslations("Admin");
+  const formatter = useFormatter();
+  const formatNumber = (value: number) => formatter.number(value);
+  const token = getToken();
+
+  const [data, setData] = useState<ActiveUsersResponse | null>(null);
+  const [range, setRange] = useState<RangeKey>("30d");
+  const [sort, setSort] = useState<ActiveUsersSort>("connections");
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!token) return;
+
+    const fetchActiveUsers = async () => {
+      try {
+        setLoading(true);
+        const now = Date.now();
+        setData(
+          await getActiveUsers(token, {
+            fromDate: now - RANGES[range],
+            toDate: now,
+            page,
+            limit: PAGE_SIZE,
+            search,
+            sort,
+          })
+        );
+      } catch (error) {
+        console.error("Failed to fetch active users:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    const debounce = setTimeout(fetchActiveUsers, 300);
+    return () => clearTimeout(debounce);
+  }, [token, range, sort, search, page]);
+
+  // Tout changement de filtre repart de la première page : la ligne cherchée est
+  // en tête du nouveau tri, pas à l'ancienne position.
+  const updateRange = (value: RangeKey) => {
+    setRange(value);
+    setPage(1);
+  };
+
+  const updateSort = (value: ActiveUsersSort) => {
+    setSort(value);
+    setPage(1);
+  };
+
+  const updateSearch = (value: string) => {
+    setSearch(value);
+    setPage(1);
+  };
+
+  if (!user) {
+    return <AdminLoadingState label={t("states.loading")} />;
+  }
+
+  if (user.role !== "admin") {
+    return (
+      <AdminMessageState
+        tone="destructive"
+        title={t("states.accessDenied")}
+        description={t("states.adminOnly")}
+      />
+    );
+  }
+
+  const rows: ActiveUser[] = data?.data ?? [];
+  const totals = data?.totals ?? EMPTY_TOTALS;
+  const lastPage = data?.meta.lastPage ?? 1;
+
+  return (
+    <DashboardLayout>
+      <div>
+        <AdminBackLink href="/admin/analytics" label={t("analytics.activeUsers.backToAnalytics")} />
+      </div>
+
+      <DashboardHero
+        title={t("analytics.activeUsers.title")}
+        subtitle={t("analytics.activeUsers.subtitle")}
+        badge={t("analytics.activeUsers.badge", { count: formatNumber(totals.activeUsers) })}
+      />
+
+      <AdminFilterTabs
+        value={range}
+        onChange={updateRange}
+        tabs={(Object.keys(RANGES) as RangeKey[]).map((key) => ({
+          value: key,
+          label: t(`analytics.ranges.${key}`),
+        }))}
+      />
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <DashboardStatTile
+          label={t("analytics.activeUsers.tiles.activeUsers")}
+          value={formatNumber(totals.activeUsers)}
+        />
+        <DashboardStatTile
+          label={t("analytics.activeUsers.tiles.connections")}
+          value={formatNumber(totals.connections)}
+        />
+        <DashboardStatTile
+          label={t("analytics.activeUsers.tiles.pageViews")}
+          value={formatNumber(totals.pageViews)}
+        />
+        <DashboardStatTile
+          label={t("analytics.activeUsers.tiles.perUser")}
+          value={formatNumber(totals.connectionsPerUser)}
+        />
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-xs">
+        <div className="flex flex-col gap-3 border-b border-border p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-foreground">
+              {t("analytics.activeUsers.cardTitle")}
+            </h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t("analytics.activeUsers.cardSubtitle")}
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <Select value={sort} onValueChange={(value) => updateSort(value as ActiveUsersSort)}>
+              <SelectTrigger className="h-9 w-full sm:w-[190px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SORTS.map((option) => (
+                  <SelectItem key={option} value={option}>
+                    {t(`analytics.activeUsers.sort.${option}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <div className="relative sm:w-64">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                type="search"
+                value={search}
+                onChange={(e) => updateSearch(e.target.value)}
+                placeholder={t("analytics.activeUsers.searchPlaceholder")}
+                className="pl-9"
+              />
+            </div>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="px-6 py-12 text-center text-muted-foreground">
+            {t("analytics.activeUsers.loading")}
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="px-6 py-14 text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-secondary text-muted-foreground">
+              <Search className="h-5 w-5" />
+            </div>
+            <p className="text-sm font-semibold text-foreground">
+              {t("analytics.activeUsers.emptyTitle")}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {t("analytics.activeUsers.emptyDescription")}
+            </p>
+          </div>
+        ) : (
+          <ul className="divide-y divide-border">
+            {rows.map((row, index) => (
+              <li
+                key={row.id}
+                className="flex items-center gap-4 p-4 transition-colors hover:bg-secondary/40"
+              >
+                <span className="w-6 text-sm font-bold tabular-nums text-muted-foreground">
+                  {(page - 1) * PAGE_SIZE + index + 1}
+                </span>
+                <Link
+                  href={`/admin/users/${row.id}`}
+                  className="group flex min-w-0 flex-1 items-center gap-3"
+                >
+                  <AvatarTile
+                    name={row.username}
+                    src={row.avatarUrl ?? undefined}
+                    className="h-10 w-10 rounded-md text-sm"
+                  />
+                  <div className="min-w-0">
+                    <p className="truncate font-medium text-foreground transition-colors group-hover:text-accent">
+                      {row.username}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">{row.email}</p>
+                  </div>
+                </Link>
+
+                {row.role !== "user" && (
+                  <Badge variant={row.role === "admin" ? "destructive" : "accent"} className="shrink-0">
+                    {t(`users.roles.${row.role}`)}
+                  </Badge>
+                )}
+
+                <MetricCell label={t("analytics.activeUsers.columns.connections")}>
+                  {formatNumber(row.connections)}
+                </MetricCell>
+                <MetricCell
+                  label={t("analytics.activeUsers.columns.pageViews")}
+                  className="hidden md:block"
+                >
+                  {formatNumber(row.pageViews)}
+                </MetricCell>
+                <MetricCell
+                  label={t("analytics.activeUsers.columns.activeDays")}
+                  className="hidden lg:block"
+                >
+                  {formatNumber(row.activeDays)}
+                </MetricCell>
+                <MetricCell
+                  label={t("analytics.activeUsers.columns.devices")}
+                  className="hidden xl:block"
+                >
+                  {formatNumber(row.devices)}
+                </MetricCell>
+                <MetricCell
+                  label={t("analytics.activeUsers.columns.timeSpent")}
+                  className="hidden xl:block"
+                >
+                  <ActivityDuration ms={row.timeSpentMs} />
+                </MetricCell>
+                <div className="hidden w-28 shrink-0 text-right text-xs text-muted-foreground 2xl:block">
+                  <div>{t("analytics.activeUsers.columns.lastSeen")}</div>
+                  <div>
+                    {row.lastSeenAt
+                      ? formatter.dateTime(new Date(row.lastSeenAt), {
+                          month: "short",
+                          day: "numeric",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })
+                      : t("analytics.activeUsers.duration.none")}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {!loading && rows.length > 0 && lastPage > 1 && (
+        <Pagination currentPage={page} totalPages={lastPage} onPageChange={setPage} />
+      )}
+    </DashboardLayout>
+  );
+};
+
+export default AdminActiveUsersPage;

--- a/frontend/src/app/[locale]/(pages)/admin/users/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(pages)/admin/users/[id]/page.tsx
@@ -3,6 +3,7 @@
 import DashboardHero from "@/components/account/dashboard-hero";
 import DashboardLayout from "@/components/account/dashboard-layout";
 import DashboardStatTile from "@/components/account/dashboard-stat-tile";
+import { ActivityDuration } from "@/components/admin/activity-duration";
 import { AdminBackLink } from "@/components/admin/admin-back-link";
 import { AdminLoadingState, AdminMessageState } from "@/components/admin/admin-states";
 import ServerImage from "@/components/serveur/card/server-image";
@@ -61,6 +62,13 @@ const AdminUserDetailPage = () => {
   const formatNumber = (value: number) => formatter.number(value);
   const formatDate = (value: string | Date) =>
     formatter.dateTime(new Date(value), { year: "numeric", month: "short", day: "numeric" });
+  const formatDateTime = (value: string | Date) =>
+    formatter.dateTime(new Date(value), {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
   const token = getToken();
   const params = useParams();
   const userId = Number(params.id);
@@ -105,6 +113,7 @@ const AdminUserDetailPage = () => {
   const profile = detail?.user;
   const servers = detail?.servers ?? [];
   const duplicates = detail?.duplicates ?? [];
+  const activity = detail?.activity;
   const registration = profile
     ? getRegistration(profile.provider, t("users.detail.emailPassword"))
     : null;
@@ -238,6 +247,88 @@ const AdminUserDetailPage = () => {
               <InfoRow label={t("users.detail.joined")}>{formatDate(profile.createdAt)}</InfoRow>
               <InfoRow label={t("users.detail.lastUpdated")}>{formatDate(profile.updatedAt)}</InfoRow>
             </div>
+          </div>
+
+          {/* Activity over the last 30 days */}
+          <div className="overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-xs">
+            <div className="border-b border-border px-5 py-4">
+              <h2 className="text-base font-semibold text-foreground">
+                {t("users.detail.activity.title")}
+              </h2>
+              <p className="mt-1 text-xs text-muted-foreground">{t("users.detail.activity.help")}</p>
+            </div>
+
+            {!activity || activity.pageViews === 0 ? (
+              <div className="flex flex-col items-center gap-3 px-6 py-12 text-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-secondary text-muted-foreground">
+                  <Icon icon="material-symbols:timeline" className="h-6 w-6" />
+                </div>
+                <p className="text-sm text-muted-foreground">{t("users.detail.activity.empty")}</p>
+              </div>
+            ) : (
+              <div className="space-y-5 p-5">
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+                  <DashboardStatTile
+                    label={t("users.detail.activity.tiles.connections")}
+                    value={formatNumber(activity.connections)}
+                  />
+                  <DashboardStatTile
+                    label={t("users.detail.activity.tiles.pageViews")}
+                    value={formatNumber(activity.pageViews)}
+                  />
+                  <DashboardStatTile
+                    label={t("users.detail.activity.tiles.activeDays")}
+                    value={formatNumber(activity.activeDays)}
+                  />
+                  <DashboardStatTile
+                    label={t("users.detail.activity.tiles.devices")}
+                    value={formatNumber(activity.devices)}
+                  />
+                  <DashboardStatTile
+                    label={t("users.detail.activity.tiles.timeSpent")}
+                    value={<ActivityDuration ms={activity.timeSpentMs} />}
+                  />
+                </div>
+
+                <div className="divide-y divide-border rounded-lg border border-border">
+                  <InfoRow label={t("users.detail.activity.lastSeen")}>
+                    {activity.lastSeenAt ? formatDateTime(activity.lastSeenAt) : "—"}
+                  </InfoRow>
+                  <InfoRow label={t("users.detail.activity.viewsPerConnection")}>
+                    {formatNumber(activity.viewsPerConnection)}
+                  </InfoRow>
+                </div>
+
+                <div>
+                  <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    {t("users.detail.activity.topPages")}
+                  </h3>
+                  {activity.topPages.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      {t("users.detail.activity.noPages")}
+                    </p>
+                  ) : (
+                    <ul className="divide-y divide-border rounded-lg border border-border">
+                      {activity.topPages.map((page) => (
+                        <li
+                          key={page.path}
+                          className="flex items-center justify-between gap-4 px-4 py-2 text-sm"
+                        >
+                          <span className="min-w-0 truncate font-mono text-xs text-foreground">
+                            {page.path}
+                          </span>
+                          <span className="shrink-0 text-muted-foreground">
+                            {t("users.detail.activity.pageViews", {
+                              count: formatNumber(page.views),
+                            })}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Possible duplicate accounts */}

--- a/frontend/src/components/account/dashboard-stat-tile.tsx
+++ b/frontend/src/components/account/dashboard-stat-tile.tsx
@@ -2,7 +2,8 @@ import { cn } from "@/lib/utils";
 
 interface DashboardStatTileProps {
   label: string;
-  value: string;
+  /** Nombre déjà formaté, ou un rendu (durée traduite, badge…) à afficher tel quel. */
+  value: React.ReactNode;
   dot?: "success" | "muted";
 }
 

--- a/frontend/src/components/admin/activity-duration.tsx
+++ b/frontend/src/components/admin/activity-duration.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+const MINUTE_MS = 60_000;
+
+/**
+ * Durée d'activité en heures/minutes (« 2 h 15 min »), depuis les millisecondes
+ * cumulées par l'analytics. Composant plutôt que helper : le formatage dépend des
+ * traductions, et le classement comme le détail utilisateur l'affichent.
+ */
+export const ActivityDuration = ({ ms }: { ms: number }) => {
+  const t = useTranslations("Admin.analytics.activeUsers.duration");
+
+  if (ms < MINUTE_MS) return <>{t("none")}</>;
+
+  const totalMinutes = Math.round(ms / MINUTE_MS);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  return <>{hours > 0 ? t("hours", { hours, minutes }) : t("minutes", { minutes })}</>;
+};

--- a/frontend/src/components/consent/consent-banner.tsx
+++ b/frontend/src/components/consent/consent-banner.tsx
@@ -1,14 +1,87 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useConsent } from "@/contexts/consent";
 import { Link } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
+
+/**
+ * Le parcours de consentement : la bannière propose l'acceptation en un clic, le
+ * refus se gagne en traversant « plus d'infos » → préférences → confirmation.
+ * Choix produit assumé (cf. la demande d'un parcours de refus plus long) ; à noter
+ * que le RGPD et les lignes directrices de la CNIL demandent l'inverse — refuser
+ * doit être aussi simple qu'accepter.
+ */
+type Step = "banner" | "info" | "preferences" | "confirm";
+
+/** Finalités optionnelles, cochées d'office : les décocher revient à refuser. */
+const OPTIONAL_PURPOSES = ["audience", "improvement", "personalization"] as const;
+
+type Purpose = (typeof OPTIONAL_PURPOSES)[number];
+
+const ALL_ENABLED = Object.fromEntries(
+  OPTIONAL_PURPOSES.map((purpose) => [purpose, true])
+) as Record<Purpose, boolean>;
+
+/** Secondes d'attente avant que le refus définitif devienne cliquable. */
+const REFUSAL_DELAY_SECONDS = 5;
+
+/** Ligne « finalité » : case à cocher, intitulé et explication. */
+const PurposeRow = ({
+  title,
+  description,
+  checked,
+  disabled,
+  hint,
+  onCheckedChange,
+}: {
+  title: string;
+  description: string;
+  checked: boolean;
+  disabled?: boolean;
+  hint?: string;
+  onCheckedChange?: (checked: boolean) => void;
+}) => (
+  <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-border p-3">
+    <Checkbox
+      checked={checked}
+      disabled={disabled}
+      onCheckedChange={(value) => onCheckedChange?.(value === true)}
+      className="mt-0.5"
+    />
+    <span className="min-w-0">
+      <span className="flex flex-wrap items-center gap-2 text-sm font-medium text-foreground">
+        {title}
+        {hint && <span className="text-xs font-normal text-muted-foreground">{hint}</span>}
+      </span>
+      <span className="mt-1 block text-xs text-muted-foreground">{description}</span>
+    </span>
+  </label>
+);
 
 const ConsentBanner = () => {
   const { consent, grant, deny } = useConsent();
   const t = useTranslations("StaticPages");
+
+  const [step, setStep] = useState<Step>("banner");
+  const [purposes, setPurposes] = useState<Record<Purpose, boolean>>(ALL_ENABLED);
+  const [countdown, setCountdown] = useState(REFUSAL_DELAY_SECONDS);
+
+  // Décompte du dernier écran : le refus ne s'active qu'une fois arrivé à zéro.
+  useEffect(() => {
+    if (step !== "confirm" || countdown === 0) return;
+    const timer = setTimeout(() => setCountdown((value) => value - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [step, countdown]);
 
   if (consent !== "unknown") return null;
 
@@ -18,20 +91,150 @@ const ConsentBanner = () => {
     </Link>
   );
 
+  const openConfirmation = () => {
+    setCountdown(REFUSAL_DELAY_SECONDS);
+    setStep("confirm");
+  };
+
+  // Tout décocher puis « continuer » n'est pas une acceptation : on bascule sur
+  // l'écran de confirmation du refus.
+  const savePreferences = () => {
+    if (OPTIONAL_PURPOSES.some((purpose) => purposes[purpose])) {
+      grant();
+      return;
+    }
+    openConfirmation();
+  };
+
   return (
-    <div className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-card/95 p-4 text-card-foreground shadow-lg backdrop-blur supports-[backdrop-filter]:bg-card/80">
-      <div className="mx-auto flex max-w-5xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-sm text-muted-foreground">{t.rich("consent.description", { link })}</p>
-        <div className="flex shrink-0 items-center gap-2">
-          <Button variant="ghost" size="sm" onClick={deny}>
-            {t("consent.decline")}
-          </Button>
-          <Button variant="accent" size="sm" onClick={grant}>
-            {t("consent.accept")}
-          </Button>
+    <>
+      <div className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-card/95 p-4 text-card-foreground shadow-lg backdrop-blur supports-[backdrop-filter]:bg-card/80">
+        <div className="mx-auto flex max-w-5xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-muted-foreground">{t.rich("consent.description", { link })}</p>
+          <div className="flex shrink-0 flex-col-reverse items-stretch gap-2 sm:flex-row sm:items-center">
+            <button
+              type="button"
+              onClick={() => setStep("info")}
+              className="text-xs text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground"
+            >
+              {t("consent.moreInfo")}
+            </button>
+            <Button variant="accent" size="lg" onClick={grant}>
+              {t("consent.accept")}
+            </Button>
+          </div>
         </div>
       </div>
-    </div>
+
+      {/* Fermer la fenêtre (croix, Échap) ramène à la bannière : aucun choix n'est
+          enregistré tant que l'utilisateur n'a pas atteint le bout d'un parcours. */}
+      <Dialog open={step !== "banner"} onOpenChange={(open) => !open && setStep("banner")}>
+        <DialogContent className="max-h-[85vh] overflow-y-auto">
+          {step === "info" && (
+            <>
+              <DialogHeader>
+                <DialogTitle>{t("consent.info.title")}</DialogTitle>
+                <DialogDescription>{t.rich("consent.info.body", { link })}</DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-2">
+                {OPTIONAL_PURPOSES.map((purpose) => (
+                  <div key={purpose} className="rounded-lg border border-border p-3">
+                    <p className="text-sm font-medium text-foreground">
+                      {t(`consent.purposes.${purpose}.title`)}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {t(`consent.purposes.${purpose}.description`)}
+                    </p>
+                  </div>
+                ))}
+              </div>
+
+              <div className="flex flex-col gap-3">
+                <Button variant="accent" size="lg" onClick={grant}>
+                  {t("consent.accept")}
+                </Button>
+                <button
+                  type="button"
+                  onClick={() => setStep("preferences")}
+                  className="text-xs text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground"
+                >
+                  {t("consent.info.manage")}
+                </button>
+              </div>
+            </>
+          )}
+
+          {step === "preferences" && (
+            <>
+              <DialogHeader>
+                <DialogTitle>{t("consent.preferences.title")}</DialogTitle>
+                <DialogDescription>{t("consent.preferences.body")}</DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-2">
+                <PurposeRow
+                  title={t("consent.preferences.necessary.title")}
+                  description={t("consent.preferences.necessary.description")}
+                  hint={t("consent.preferences.alwaysOn")}
+                  checked
+                  disabled
+                />
+                {OPTIONAL_PURPOSES.map((purpose) => (
+                  <PurposeRow
+                    key={purpose}
+                    title={t(`consent.purposes.${purpose}.title`)}
+                    description={t(`consent.purposes.${purpose}.description`)}
+                    checked={purposes[purpose]}
+                    onCheckedChange={(checked) =>
+                      setPurposes((current) => ({ ...current, [purpose]: checked }))
+                    }
+                  />
+                ))}
+              </div>
+
+              <div className="flex flex-col gap-3">
+                <Button variant="accent" size="lg" onClick={savePreferences}>
+                  {t("consent.preferences.save")}
+                </Button>
+                <button
+                  type="button"
+                  onClick={openConfirmation}
+                  className="text-xs text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground"
+                >
+                  {t("consent.preferences.refuse")}
+                </button>
+              </div>
+            </>
+          )}
+
+          {step === "confirm" && (
+            <>
+              <DialogHeader>
+                <DialogTitle>{t("consent.confirm.title")}</DialogTitle>
+                <DialogDescription>{t("consent.confirm.body")}</DialogDescription>
+              </DialogHeader>
+
+              <div className="flex flex-col gap-3">
+                <Button variant="accent" size="lg" onClick={grant}>
+                  {t("consent.confirm.reconsider")}
+                </Button>
+                <button
+                  type="button"
+                  onClick={deny}
+                  disabled={countdown > 0}
+                  className="text-xs text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:no-underline disabled:opacity-60"
+                >
+                  {countdown > 0
+                    ? t("consent.confirm.refuseCountdown", { seconds: countdown })
+                    : t("consent.confirm.refuse")}
+                </button>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };
 

--- a/frontend/src/http/analytics.ts
+++ b/frontend/src/http/analytics.ts
@@ -1,5 +1,5 @@
 import { getBaseUrl } from "@/app/_cheatcode";
-import { AnalyticsDashboard } from "@/types/analytics";
+import { ActiveUsersResponse, ActiveUsersSort, AnalyticsDashboard } from "@/types/analytics";
 import { apiFetch } from "./client";
 
 // --- Tracking public (best-effort, fire-and-forget) ---
@@ -85,4 +85,26 @@ export const getAnalyticsDashboard = (
   if (options.toDate) params.set("toDate", String(options.toDate));
 
   return apiFetch<AnalyticsDashboard>(`/admin/analytics?${params.toString()}`, { token });
+};
+
+interface ActiveUsersOptions {
+  fromDate?: number;
+  toDate?: number;
+  page?: number;
+  limit?: number;
+  search?: string;
+  sort?: ActiveUsersSort;
+}
+
+/** Classement des comptes les plus actifs (connexions = visites, pas logins). */
+export const getActiveUsers = (
+  token: string,
+  options: ActiveUsersOptions = {}
+): Promise<ActiveUsersResponse> => {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(options)) {
+    if (value !== undefined && value !== "") params.set(key, String(value));
+  }
+
+  return apiFetch<ActiveUsersResponse>(`/admin/analytics/users?${params.toString()}`, { token });
 };

--- a/frontend/src/http/user.ts
+++ b/frontend/src/http/user.ts
@@ -1,3 +1,4 @@
+import { UserActivity } from '@/types/analytics'
 import { AdminUserProfile, User } from '@/types/auth'
 import { AdminUserServer } from '@/types/server'
 import { apiFetch } from './client'
@@ -28,6 +29,7 @@ export interface AdminUserDetailResponse {
   user: AdminUserProfile
   servers: AdminUserServer[]
   duplicates: DuplicateAccount[]
+  activity: UserActivity
   stats: {
     serverCount: number
     duplicateCount: number

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -36,3 +36,47 @@ export interface AnalyticsDashboard {
   topReferrers: AnalyticsTopReferrer[];
   countries: AnalyticsCountry[];
 }
+
+/** Activité d'un compte sur une fenêtre : une « connexion » est une visite, pas un login. */
+export interface UserActivityMetrics {
+  connections: number;
+  pageViews: number;
+  devices: number;
+  activeDays: number;
+  timeSpentMs: number;
+  viewsPerConnection: number;
+  firstSeenAt: string | null;
+  lastSeenAt: string | null;
+}
+
+export interface ActiveUser extends UserActivityMetrics {
+  id: number;
+  username: string;
+  email: string;
+  role: "admin" | "writer" | "user";
+  avatarUrl: string | null;
+  createdAt: string;
+}
+
+export type ActiveUsersSort = "connections" | "pageViews" | "timeSpent" | "lastSeen";
+
+export interface ActiveUsersResponse {
+  data: ActiveUser[];
+  meta: {
+    total: number;
+    perPage: number;
+    currentPage: number;
+    lastPage: number;
+  };
+  totals: {
+    activeUsers: number;
+    connections: number;
+    pageViews: number;
+    connectionsPerUser: number;
+  };
+}
+
+export interface UserActivity extends UserActivityMetrics {
+  series: { day: string; connections: number; pageViews: number }[];
+  topPages: { path: string; views: number }[];
+}


### PR DESCRIPTION
This pull request introduces a comprehensive user activity analytics feature for administrators. It adds a new service (`UserActivityService`) that aggregates and analyzes user activity based on page views, exposes endpoints to retrieve user activity leaderboards and individual user activity details, and includes thorough tests to ensure correctness. The feature enables admins to view, filter, and sort active users, as well as inspect detailed activity metrics for any user.

**User Activity Analytics (Core Service and API):**

* Added a new `UserActivityService` (`backend/app/services/user_activity_service.ts`) that computes user activity metrics (connections, page views, devices, active days, time spent, etc.) from the `page_views` table, with logic to split activity into sessions based on inactivity gaps, and provides both leaderboard and per-user detail queries.
* Introduced a new admin API endpoint (`/api/v1/admin/analytics/users`) in `AnalyticsController` to return a paginated, sortable leaderboard of user activity, supporting filters for date range, search, and sort column. [[1]](diffhunk://#diff-3ad328f4bfa9984a9a2425c80885e6b420ecf61676629e09f9e56574caa87e02R3) [[2]](diffhunk://#diff-3ad328f4bfa9984a9a2425c80885e6b420ecf61676629e09f9e56574caa87e02R111-R141) [[3]](diffhunk://#diff-e72f182eae9caec3ef631c012ab133853f783154427bd6ef9cff6ccd21364d80R303-R305)

**User Detail Enhancements:**

* Extended the admin user detail endpoint to include a 30-day user activity summary (`activity`), with metrics, daily series, and top pages, using the new service. [[1]](diffhunk://#diff-e31725cbae7d5638740d08b3c6649c54e87387e80480d70a03bcb1161de40341L173-R176) [[2]](diffhunk://#diff-e31725cbae7d5638740d08b3c6649c54e87387e80480d70a03bcb1161de40341R205-R208) [[3]](diffhunk://#diff-e31725cbae7d5638740d08b3c6649c54e87387e80480d70a03bcb1161de40341R225) [[4]](diffhunk://#diff-e31725cbae7d5638740d08b3c6649c54e87387e80480d70a03bcb1161de40341R6)

**Testing:**

* Added a new comprehensive test suite (`backend/tests/functional/user_activity.spec.ts`) that verifies session splitting, leaderboard ranking, date filtering, search, permissions, and user activity details for the new analytics features.